### PR TITLE
FEAT: #4 공통 에러 응답 구조 및 전역 예외 처리 기능을 추가한다

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+language: ko-KR
+
+enable_free_tier: true
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_placeholder: '@coderabbitai 요약'
+  auto_title_placeholder: '@coderabbitai'
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  abort_on_close: true
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+chat:
+  auto_reply: true
+knowledge_base:
+  learnings:
+    scope: auto
+  issues:
+    scope: auto

--- a/gradle/util.gradle
+++ b/gradle/util.gradle
@@ -1,3 +1,4 @@
 dependencies {
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }

--- a/src/main/java/com/meetup/server/global/presentation/ApiControllerAdvice.java
+++ b/src/main/java/com/meetup/server/global/presentation/ApiControllerAdvice.java
@@ -1,0 +1,40 @@
+package com.meetup.server.global.presentation;
+
+import com.meetup.server.global.support.error.GlobalErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+import com.meetup.server.global.support.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ApiControllerAdvice {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        log.error("Exception : {}", e.getMessage(), e);
+        return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.INTERNAL_ERROR), GlobalErrorType.INTERNAL_ERROR.getStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException : {}", e.getMessage(), e);
+        return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.FAILED_REQUEST_VALIDATION), GlobalErrorType.FAILED_REQUEST_VALIDATION.getStatus());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("IllegalArgumentException : {}", e.getMessage(), e);
+        return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.INVALID_REQUEST_ARGUMENT), GlobalErrorType.INVALID_REQUEST_ARGUMENT.getStatus());
+    }
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ApiResponse<?>> handleGlobalException(GlobalException e) {
+        log.error("GlobalException : {}", e.getMessage(), e);
+        return new ResponseEntity<>(ApiResponse.error(e.getErrorType()), e.getErrorType().getStatus());
+    }
+
+}

--- a/src/main/java/com/meetup/server/global/support/error/ErrorMessage.java
+++ b/src/main/java/com/meetup/server/global/support/error/ErrorMessage.java
@@ -1,0 +1,17 @@
+package com.meetup.server.global.support.error;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorMessage {
+
+    private final String code;
+
+    private final String message;
+
+    public ErrorMessage(ErrorType errorType) {
+        this.code = errorType.name();
+        this.message = errorType.getMessage();
+    }
+
+}

--- a/src/main/java/com/meetup/server/global/support/error/ErrorType.java
+++ b/src/main/java/com/meetup/server/global/support/error/ErrorType.java
@@ -1,0 +1,12 @@
+package com.meetup.server.global.support.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorType {
+
+    String name();
+
+    HttpStatus getStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
+++ b/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
@@ -1,0 +1,19 @@
+package com.meetup.server.global.support.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorType implements ErrorType {
+
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
+    FAILED_REQUEST_VALIDATION(HttpStatus.BAD_REQUEST, "요청 데이터 검증에 실패하였습니다."),
+    INVALID_REQUEST_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 요청 인자입니다."),
+    ;
+
+    private final HttpStatus status;
+
+    private final String message;
+}

--- a/src/main/java/com/meetup/server/global/support/error/GlobalException.java
+++ b/src/main/java/com/meetup/server/global/support/error/GlobalException.java
@@ -3,7 +3,7 @@ package com.meetup.server.global.support.error;
 import lombok.Getter;
 
 @Getter
-public class GlobalException extends RuntimeException{
+public class GlobalException extends RuntimeException {
 
     private final ErrorType errorType;
 

--- a/src/main/java/com/meetup/server/global/support/error/GlobalException.java
+++ b/src/main/java/com/meetup/server/global/support/error/GlobalException.java
@@ -1,0 +1,14 @@
+package com.meetup.server.global.support.error;
+
+import lombok.Getter;
+
+@Getter
+public class GlobalException extends RuntimeException{
+
+    private final ErrorType errorType;
+
+    public GlobalException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+}

--- a/src/main/java/com/meetup/server/global/support/response/ApiResponse.java
+++ b/src/main/java/com/meetup/server/global/support/response/ApiResponse.java
@@ -1,0 +1,20 @@
+package com.meetup.server.global.support.response;
+
+import com.meetup.server.global.support.error.ErrorMessage;
+import com.meetup.server.global.support.error.ErrorType;
+
+public record ApiResponse<T>(ResultType result, T data, ErrorMessage error) {
+
+    public static ApiResponse<?> success() {
+        return new ApiResponse<>(ResultType.SUCCESS, null, null);
+    }
+
+    public static <S> ApiResponse<S> success(S data) {
+        return new ApiResponse<>(ResultType.SUCCESS, data, null);
+    }
+
+    public static ApiResponse<?> error(ErrorType error) {
+        return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error));
+    }
+
+}

--- a/src/main/java/com/meetup/server/global/support/response/ResultType.java
+++ b/src/main/java/com/meetup/server/global/support/response/ResultType.java
@@ -1,0 +1,5 @@
+package com.meetup.server.global.support.response;
+
+public enum ResultType {
+    SUCCESS, ERROR
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #4 

## 💡 작업 내용
- **CodeRabbit** 설정을 위한 **yaml**을 추가하였습니다.
  - CodeRabbit이 제공하는 기능이 워낙 많더라고요. 그래서 필요할 것 같은 기능들을 선택해서 넣었는데, 컨벤션 같은 부분도 추가하면 리뷰를 받을 수 있어서 추후에 추가해보는 것도 고려해보면 좋을 거 같아요! ([CodeRabbit 적용기 _ 인프런](https://tech.inflab.com/20250303-introduce-coderabbit/))
- API 응답을 처리할 때 `ApiResponse.success()`, `ApiResponse.success(T data)`, `ApiResponse.error(ErrorType error)` 정적 메서드를 사용하면 됩니다. 
- 에러 처리 시, 도메인 별로 `ErrorType`과 `GlobalException`을 상속/구현해서 사용하면 됩니다.

위 부분에 대해서 조만간 디스코드에서 알려드릴게요!

## 📸 스크린샷
**ApiResponse.success()**
![스크린샷 2025-04-08 오전 5 11 30](https://github.com/user-attachments/assets/2f25e03a-d7ac-47be-aa55-f6565cef6be2)

**ApiResponse.success(T data)**
![스크린샷 2025-04-08 오전 5 12 43](https://github.com/user-attachments/assets/495176b1-9b7f-44db-bc2e-759cfc4985d3)

**ApiResponse.error(ErrorType error)**
![스크린샷 2025-04-08 오전 5 11 20](https://github.com/user-attachments/assets/e4e72be1-a018-419c-b68f-f081f3ea9c8f)

**MethodArgumentNotValidException**
<img width="475" alt="스크린샷 2025-04-08 오후 2 43 29" src="https://github.com/user-attachments/assets/36391870-3bc6-4205-9240-fd15fa645c97" />

**IllegalArgumentException**
<img width="432" alt="스크린샷 2025-04-08 오후 2 43 42" src="https://github.com/user-attachments/assets/5689845b-ab5d-406b-a03e-e077ea63ed79" />

## 💬리뷰 요구사항
궁금한 점 있음 편하게 물어보세요~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 시스템 구성 옵션 강화: 신규 설정 파일 추가로 한국어 지원, 프리 티어, 리뷰, 채팅 자동응답, 및 지식 기반 기능 구성이 가능해졌습니다.
	- API 응답 및 예외 처리 개선: 통합된 예외 처리와 표준화된 API 응답 메시지 제공으로, 에러 발생 시 보다 일관되고 명확한 피드백을 받을 수 있습니다.
	- 결과 상태 표준화: 성공 및 오류 상태를 명확하게 구분할 수 있는 새로운 결과 타입 추가.
- **버그 수정**
	- 예외 처리 로직 개선으로 다양한 예외 상황에 대한 응답 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->