### PR TITLE
CI/CD: #7 NCP 서버 및 Container Registry 기반 파이프라인 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,5 +76,5 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           script: |
             sudo docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}
-            sudo docker rm -f spot-backend || true
+            sudo docker ps -q -f "name=spot-backend" | xargs sudo docker stop | xargs sudo docker rm
             sudo docker run -d -p 8080:8080 --name spot-backend ${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,80 @@
+name: Deploy
+
+on:
+  push:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.gradle/caches
+          key: gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: gradle-
+
+      - name: Grant execute permission to gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+      - name: move jar file to deploy
+        run: mv ./build/libs/*.jar ./deploy
+
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v3.10.0
+
+      - name: Login to NCP Container Registry
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+          username: ${{ secrets.NCP_ACCESS_KEY }}
+          password: ${{ secrets.NCP_SECRET_KEY }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v6.15.0
+        with:
+          context: ./deploy
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}
+          build-args: |
+            "DB_URL=${{ secrets.DB_URL }}"
+            "DB_USERNAME=${{ secrets.DB_USERNAME }}"
+            "DB_PASSWORD=${{ secrets.DB_PASSWORD }}"
+
+  deploy:
+    needs: build
+    name: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to NCP Server and Run
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          password: ${{ secrets.NCP_PASSWORD }}
+          port: ${{ secrets.NCP_PORT }}
+          script: |
+            sudo docker pull ${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}
+            sudo docker rm -f spot-backend || true
+            sudo docker run -d -p 8080:8080 --name spot-backend ${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Gradle Test on PR
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.gradle/caches
+          key: gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: gradle-
+
+      - name: Grant execute permission to gradlew
+        run: chmod +x ./gradlew
+
+      - name: Test with Gradle
+        run: ./gradlew test -Dspring.config.additional-location=file:config/application-test.yml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "config"]
     path = config
-    url = https://github.com/Team-MEAT-UP/meetup-config.git
+    url = https://github.com/Team-MEAT-UP/config.git

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:21-alpine
+
+ARG DB_URL
+ARG DB_USERNAME
+ARG DB_PASSWORD
+
+ARG JAR_FILE=./*.jar
+COPY ${JAR_FILE} spot.jar
+
+ENV DB_URL=${DB_URL} \
+    DB_USERNAME=${DB_USERNAME} \
+    DB_PASSWORD=${DB_PASSWORD}
+
+ENTRYPOINT ["java", "-jar", "spot.jar", "--spring.profiles.active=dev"]

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,9 +1,9 @@
 dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    runtimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+    systemProperty "spring.config.additional-location", "file:config/application-test.yml"
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #7 

## 💡 작업 내용
- NCP 서버와 Container Registry, VPC, 서브넷 생성완료하였습니다.
- PR 생성 시, **테스트 과정이 동작하도록 워크플로우를 작성**하였습니다.
  - 테스트코드와 실제 로직이 매칭되지 않을 경우, 본 배포에서 에러가 발생하고 이로 인해 추가적인 수정 커밋과 불필요한 공수가 발생합니다. 이를 막기 위해 PR 시 테스트코드가 동작하도록 추가하였습니다.
- develop 브랜치로 merge될 때, **배포 파이프라인 구축**하였습니다.
- **Dockerfile을 생성**하여 Spring 애플리케이션 이미지를 만들 수 있게 하였습니다.

**NCP 서비스 생성 과정과 워크플로우 작성 근거는 ([관련 노션](https://www.notion.so/NCP-CICD-1d3f319986698004b59cd36cec35aef7?pvs=4))을 통해 확인하실 수 있습니다.**

## 📸 스크린샷
### Docker Container logs
![스크린샷 2025-04-13 오후 6 27 10](https://github.com/user-attachments/assets/4f71b0a9-abe7-4be3-ba35-e71cc79063fc)

### 서버 IP를 통해 스웨거에 접속
![스크린샷 2025-04-13 오후 6 36 01](https://github.com/user-attachments/assets/9bc12837-96aa-4d05-a4e0-b3b6c92335e5)

## 💬리뷰 요구사항
- **서브모듈인 config에 application-dev.yml(개발서버 배포용)와 application-test.yml(테스트 코드용) 추가**되었습니다.
  - application-test.yml는 gradle에 적용해두어 테스트코드 작성시 해당 yml이 자동으로 적용됩니다.

- 저번에 말씀드렸지만, 다시 한번 말씀드리면 **NCP Server와 AWS RDS 사이 VPC가 달라 접속할 수 없는 문제**가 있었습니다.
  - NCP Server와 (AWS EC2 + RDS)를 사용하여 EC2로 RDS를 중계하도록 우선 연결해두었습니다. **논의 후 변경예정**입니다. ([관련 노션](https://www.notion.so/Server-RDS-1d3f3199866980f79b87c04f791d9b0e?pvs=4))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **테스트**
  - PR 생성 시 자동 실행되는 테스트 파이프라인이 도입되어 코드 검증이 강화되었습니다.
  - 최신 자바 환경 및 최적화된 종속성 관리로 테스트 효율성과 안정성이 개선되었습니다.
  - 테스트 환경에서 특정 구성 파일을 활용할 수 있도록 설정이 추가되었습니다.

- **작업**
  - 외부 구성 요소와 참조 버전이 업데이트되어 시스템 관리와 유지보수가 향상되었습니다.
  - H2 데이터베이스 종속성이 테스트 전용으로 조정되어 테스트 환경이 개선되었습니다.
  - 새로운 배포 자동화 파이프라인이 도입되어 개발 브랜치에 대한 배포 프로세스가 간소화되었습니다.
  - Docker 이미지를 위한 새로운 Dockerfile이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->