### PR TITLE
Feat: #15 accessToken 을 재발급합니다

### DIFF
--- a/src/main/java/com/meetup/server/auth/application/AuthService.java
+++ b/src/main/java/com/meetup/server/auth/application/AuthService.java
@@ -24,7 +24,7 @@ public class AuthService {
             throw new AuthException(AuthErrorType.INVALID_REFRESH_TOKEN);
         }
 
-        User user = jwtTokenProvider.getUser(refreshToken);
+        User user = jwtTokenProvider.extractUserIdFromToken(refreshToken);
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
 

--- a/src/main/java/com/meetup/server/auth/application/AuthService.java
+++ b/src/main/java/com/meetup/server/auth/application/AuthService.java
@@ -1,5 +1,10 @@
 package com.meetup.server.auth.application;
 
+import com.meetup.server.auth.dto.response.ReissueTokenResponse;
+import com.meetup.server.auth.exception.AuthErrorType;
+import com.meetup.server.auth.exception.AuthException;
+import com.meetup.server.global.support.jwt.JwtTokenProvider;
+import com.meetup.server.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -8,4 +13,35 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public ReissueTokenResponse reIssueToken(String refreshToken) {
+
+        refreshToken = resolveToken(refreshToken);
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new AuthException(AuthErrorType.INVALID_REFRESH_TOKEN);
+        }
+
+        User user = jwtTokenProvider.getUser(refreshToken);
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        return ReissueTokenResponse.from(accessToken, newRefreshToken);
+    }
+
+    private String resolveToken(String token) {
+        log.info("resolveToken check: {}", token);
+
+        if (token == null) {
+            throw new AuthException(AuthErrorType.INVALID_REFRESH_TOKEN);
+        }
+
+        if (token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+
+        return token;
+    }
 }

--- a/src/main/java/com/meetup/server/auth/application/AuthService.java
+++ b/src/main/java/com/meetup/server/auth/application/AuthService.java
@@ -4,6 +4,7 @@ import com.meetup.server.auth.dto.response.ReissueTokenResponse;
 import com.meetup.server.auth.exception.AuthErrorType;
 import com.meetup.server.auth.exception.AuthException;
 import com.meetup.server.global.support.jwt.JwtTokenProvider;
+import com.meetup.server.user.application.UserService;
 import com.meetup.server.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
 
     public ReissueTokenResponse reIssueToken(String refreshToken) {
 
@@ -24,7 +26,9 @@ public class AuthService {
             throw new AuthException(AuthErrorType.INVALID_REFRESH_TOKEN);
         }
 
-        User user = jwtTokenProvider.extractUserIdFromToken(refreshToken);
+        Long userId = jwtTokenProvider.extractUserIdFromToken(refreshToken);
+        User user = userService.getUserById(userId);
+
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
 
@@ -37,7 +41,6 @@ public class AuthService {
         if (token == null) {
             throw new AuthException(AuthErrorType.INVALID_REFRESH_TOKEN);
         }
-
         if (token.startsWith("Bearer ")) {
             return token.substring(7);
         }

--- a/src/main/java/com/meetup/server/auth/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/com/meetup/server/auth/dto/response/ReissueTokenResponse.java
@@ -4,7 +4,6 @@ public record ReissueTokenResponse(
         String accessToken,
         String refreshToken
 ) {
-
     public static ReissueTokenResponse from(String accessToken, String refreshToken) {
         return new ReissueTokenResponse(accessToken, refreshToken);
     }

--- a/src/main/java/com/meetup/server/auth/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/com/meetup/server/auth/dto/response/ReissueTokenResponse.java
@@ -1,0 +1,11 @@
+package com.meetup.server.auth.dto.response;
+
+public record ReissueTokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+
+    public static ReissueTokenResponse from(String accessToken, String refreshToken) {
+        return new ReissueTokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/meetup/server/auth/exception/AuthErrorType.java
+++ b/src/main/java/com/meetup/server/auth/exception/AuthErrorType.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorType implements ErrorType {
     INVALID_KAKAO_ACCOUNT(HttpStatus.UNAUTHORIZED, "카카오 계정이 유효하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
     INVALID_TOKEN_ROLE(HttpStatus.FORBIDDEN, "ROLE이 유효하지 않습니다."),
     ;
 

--- a/src/main/java/com/meetup/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/meetup/server/auth/presentation/AuthController.java
@@ -1,14 +1,8 @@
 package com.meetup.server.auth.presentation;
 
-import com.meetup.server.auth.application.AuthService;
-import com.meetup.server.auth.dto.response.ReissueTokenResponse;
-import com.meetup.server.global.support.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,15 +12,4 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
-
-    private final AuthService authService;
-
-    @Operation(summary = "access token 재발급", description = "access token 재발급을 진행합니다.")
-    @GetMapping("/reissue")
-    public ApiResponse<?> reIssueToken(
-            @CookieValue(name = "refreshToken") String refreshToken
-    ) {
-        ReissueTokenResponse reissueTokenResponse = authService.reIssueToken(refreshToken);
-        return ApiResponse.success(reissueTokenResponse);
-    }
 }

--- a/src/main/java/com/meetup/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/meetup/server/auth/presentation/AuthController.java
@@ -1,8 +1,14 @@
 package com.meetup.server.auth.presentation;
 
+import com.meetup.server.auth.application.AuthService;
+import com.meetup.server.auth.dto.response.ReissueTokenResponse;
+import com.meetup.server.global.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,4 +19,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthController {
 
+    private final AuthService authService;
+
+    @Operation(summary = "access token 재발급", description = "access token 재발급을 진행합니다.")
+    @GetMapping("/reissue")
+    public ApiResponse<?> reIssueToken(
+            @CookieValue(name = "refreshToken") String refreshToken
+    ) {
+        ReissueTokenResponse reissueTokenResponse = authService.reIssueToken(refreshToken);
+        return ApiResponse.success(reissueTokenResponse);
+    }
 }

--- a/src/main/java/com/meetup/server/auth/presentation/filter/ResponseContextFilter.java
+++ b/src/main/java/com/meetup/server/auth/presentation/filter/ResponseContextFilter.java
@@ -1,0 +1,45 @@
+package com.meetup.server.auth.presentation.filter;
+
+import com.meetup.server.auth.application.AuthService;
+import com.meetup.server.auth.dto.response.ReissueTokenResponse;
+import com.meetup.server.auth.support.CookieUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ResponseContextFilter extends OncePerRequestFilter {
+
+    private final AuthService authService;
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String refreshToken = CookieUtil.getRefreshTokenFromCookie(request);
+
+        if (refreshToken != null) {
+            ReissueTokenResponse reissueTokenResponse = authService.reIssueToken(refreshToken);
+            setResponseCookies(response, reissueTokenResponse);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void setResponseCookies(HttpServletResponse response, ReissueTokenResponse reissueTokenResponse) {
+
+        CookieUtil.setRefreshTokenCookie(response, reissueTokenResponse.refreshToken());
+    }
+}

--- a/src/main/java/com/meetup/server/auth/support/CookieUtil.java
+++ b/src/main/java/com/meetup/server/auth/support/CookieUtil.java
@@ -1,0 +1,38 @@
+package com.meetup.server.auth.support;
+
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+
+
+public class CookieUtil {
+
+    public static void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("Refresh-Token", refreshToken)
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(24 * 60 * 60)
+                .sameSite("Lax")    //GET 요청
+                .build();
+
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+    }
+
+    public static String getRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("Refresh-Token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/meetup/server/auth/support/CookieUtil.java
+++ b/src/main/java/com/meetup/server/auth/support/CookieUtil.java
@@ -13,10 +13,10 @@ public class CookieUtil {
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from("Refresh-Token", refreshToken)
                 .httpOnly(true)
-                .secure(false)
+                .secure(true)
                 .path("/")
                 .maxAge(24 * 60 * 60)
-                .sameSite("Lax")    //GET 요청
+                .sameSite("Strict")   //GET 요청
                 .build();
 
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -29,6 +29,9 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     public void onAuthenticationSuccess(
             HttpServletRequest request, HttpServletResponse response, Authentication authentication
     ) throws IOException {
+        log.info("Authentication: {}", authentication);
+        log.info("Principal: {}", authentication.getPrincipal());
+
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
         String accessToken = tokenProvider.createAccessToken(oAuth2User);

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -29,8 +29,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     public void onAuthenticationSuccess(
             HttpServletRequest request, HttpServletResponse response, Authentication authentication
     ) throws IOException {
-        log.info("Authentication: {}", authentication);
-        log.info("Principal: {}", authentication.getPrincipal());
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -1,13 +1,13 @@
 package com.meetup.server.auth.support.handler;
 
 import com.meetup.server.auth.dto.CustomOAuth2User;
+import com.meetup.server.auth.support.CookieUtil;
 import com.meetup.server.global.support.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -35,7 +35,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String accessToken = tokenProvider.createAccessToken(oAuth2User);
         String refreshToken = tokenProvider.createRefreshToken(oAuth2User);
 
-        setRefreshTokenCookie(response, refreshToken);
+        CookieUtil.setRefreshTokenCookie(response, refreshToken);
 
         String targetUrl = createRedirectUrlWithTokens(accessToken);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
@@ -43,22 +43,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     private String createRedirectUrlWithTokens(String accessToken) {
         return UriComponentsBuilder.fromUriString(successRedirectUri)
-                .queryParam("access_token", accessToken)
+                .queryParam("Access_Token", accessToken)
                 .build()
                 .toUriString();
-    }
-
-    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
-                .httpOnly(true)
-                .secure(false)
-                .path("/")
-                .maxAge(24 * 60 * 60)
-                .sameSite("Lax")    //GET 요청
-                .build();
-
-        log.info("Refresh token cookie: {}", refreshTokenCookie);
-
-        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
     }
 }

--- a/src/main/java/com/meetup/server/global/config/CorsConfig.java
+++ b/src/main/java/com/meetup/server/global/config/CorsConfig.java
@@ -29,7 +29,7 @@ public class CorsConfig {
                 HttpMethod.PATCH.name(),
                 HttpMethod.OPTIONS.name()));
         config.setAllowedHeaders(List.of("*"));
-        config.setExposedHeaders(List.of("Authorization", "Access-Token", "Set-Cookie"));
+        config.setExposedHeaders(List.of("Authorization", "Access-Token"));
         config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/meetup/server/global/config/CorsConfig.java
+++ b/src/main/java/com/meetup/server/global/config/CorsConfig.java
@@ -29,7 +29,7 @@ public class CorsConfig {
                 HttpMethod.PATCH.name(),
                 HttpMethod.OPTIONS.name()));
         config.setAllowedHeaders(List.of("*"));
-        config.setExposedHeaders(List.of("Authorization", "Access-Token"));
+        config.setExposedHeaders(List.of("Authorization", "Access-Token", "Set-Cookie"));
         config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/meetup/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.meetup.server.auth.application.CustomOAuth2UserService;
 import com.meetup.server.auth.presentation.filter.JwtAccessDeniedHandler;
 import com.meetup.server.auth.presentation.filter.JwtAuthenticationEntryPoint;
 import com.meetup.server.auth.presentation.filter.JwtAuthenticationFilter;
+import com.meetup.server.auth.presentation.filter.ResponseContextFilter;
 import com.meetup.server.auth.support.handler.OAuth2LoginFailureHandler;
 import com.meetup.server.auth.support.handler.OAuth2LoginSuccessHandler;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final ResponseContextFilter responseContextFilter;
 
     private final String[] WHITE_LIST = {
             "/v3/api-docs/**",
@@ -60,7 +62,8 @@ public class SecurityConfig {
                                 .successHandler(oAuth2LoginSuccessHandler)
                                 .failureHandler(oAuth2LoginFailureHandler)
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(responseContextFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/meetup/server/global/support/DummyDataInit.java
+++ b/src/main/java/com/meetup/server/global/support/DummyDataInit.java
@@ -1,0 +1,14 @@
+package com.meetup.server.global.support;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Transactional
+@Component
+public @interface DummyDataInit {
+}

--- a/src/main/java/com/meetup/server/global/support/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/meetup/server/global/support/jwt/JwtTokenProvider.java
@@ -2,10 +2,8 @@ package com.meetup.server.global.support.jwt;
 
 import com.meetup.server.auth.dto.CustomOAuth2User;
 import com.meetup.server.auth.dto.response.JwtUserDetails;
+import com.meetup.server.user.application.UserService;
 import com.meetup.server.user.domain.User;
-import com.meetup.server.user.exception.UserErrorType;
-import com.meetup.server.user.exception.UserException;
-import com.meetup.server.user.persistence.UserRepository;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -20,7 +18,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 @Component
 public class JwtTokenProvider {
-    private final UserRepository userRepository;
+    private final UserService userService;
     private final JwtProperties jwtProperties;
     private Key key;
 
@@ -84,15 +82,12 @@ public class JwtTokenProvider {
         return JwtUserDetails.fromClaim(claims);
     }
 
-    public User getUser(String token) {
+    public User extractUserIdFromToken(String token) {
         Long id = Long.parseLong(Jwts.parserBuilder().setSigningKey(key).build()
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject());
 
-        log.info("in getUser() id: {}", id);
-
-        return userRepository.findById(id)
-                .orElseThrow(() -> new UserException(UserErrorType.USER_NOT_FOUND));
+        return userService.getUserById(id);
     }
 }

--- a/src/main/java/com/meetup/server/global/support/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/meetup/server/global/support/jwt/JwtTokenProvider.java
@@ -48,23 +48,16 @@ public class JwtTokenProvider {
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .signWith(key, SignatureAlgorithm.HS512);
 
-        if (user instanceof CustomOAuth2User oAuth2User) {
-            builder.setSubject(oAuth2User.getUserId().toString());
-        } else {
-            builder.setSubject("defaultUser");
-        }
+            if (user instanceof CustomOAuth2User oAuth2User) {
+                builder.setSubject(oAuth2User.getUserId().toString());
+            } else if (user instanceof User normalUser) {
+                builder.setSubject(normalUser.getUserId().toString());
+            } else {
+                throw new IllegalArgumentException("Unsupported user type: " + user.getClass().getName());
+            }
 
-        return builder.compact();
+            return builder.compact();
     }
-
-//        if (user instanceof CustomOAuth2User oAuth2User) {
-//            builder.setSubject(oAuth2User.getUserId().toString());
-//        } else {
-//            throw new IllegalArgumentException("Unsupported user type: " + user.getClass().getName());
-//        }
-
-//        return builder.compact();
-//    }
 
     public boolean validateToken(String token) {
         try {

--- a/src/main/java/com/meetup/server/global/support/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/meetup/server/global/support/jwt/JwtTokenProvider.java
@@ -2,6 +2,8 @@ package com.meetup.server.global.support.jwt;
 
 import com.meetup.server.auth.dto.CustomOAuth2User;
 import com.meetup.server.auth.dto.response.JwtUserDetails;
+import com.meetup.server.auth.exception.AuthErrorType;
+import com.meetup.server.auth.exception.AuthException;
 import com.meetup.server.user.application.UserService;
 import com.meetup.server.user.domain.User;
 import io.jsonwebtoken.*;
@@ -82,12 +84,14 @@ public class JwtTokenProvider {
         return JwtUserDetails.fromClaim(claims);
     }
 
-    public User extractUserIdFromToken(String token) {
-        Long id = Long.parseLong(Jwts.parserBuilder().setSigningKey(key).build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getSubject());
-
-        return userService.getUserById(id);
+    public Long extractUserIdFromToken(String token) {
+        try {
+            return Long.parseLong(Jwts.parserBuilder().setSigningKey(key).build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject());
+        } catch (JwtException | NumberFormatException e) {
+            throw new AuthException(AuthErrorType.INVALID_TOKEN);
+        }
     }
 }

--- a/src/main/java/com/meetup/server/user/application/UserService.java
+++ b/src/main/java/com/meetup/server/user/application/UserService.java
@@ -1,0 +1,26 @@
+package com.meetup.server.user.application;
+
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.dto.response.UserProfileInfoResponse;
+import com.meetup.server.user.exception.UserErrorType;
+import com.meetup.server.user.exception.UserException;
+import com.meetup.server.user.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserProfileInfoResponse getUserProfileInfo(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorType.USER_NOT_FOUND));
+
+        return UserProfileInfoResponse.from(user);
+    }
+}

--- a/src/main/java/com/meetup/server/user/application/UserService.java
+++ b/src/main/java/com/meetup/server/user/application/UserService.java
@@ -8,10 +8,12 @@ import com.meetup.server.user.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 
     private final UserRepository userRepository;

--- a/src/main/java/com/meetup/server/user/application/UserService.java
+++ b/src/main/java/com/meetup/server/user/application/UserService.java
@@ -25,4 +25,9 @@ public class UserService {
 
         return UserProfileInfoResponse.from(user);
     }
+
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorType.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/meetup/server/user/dto/response/UserProfileInfoResponse.java
+++ b/src/main/java/com/meetup/server/user/dto/response/UserProfileInfoResponse.java
@@ -1,0 +1,20 @@
+package com.meetup.server.user.dto.response;
+
+import com.meetup.server.user.domain.User;
+import lombok.Builder;
+
+@Builder
+public record UserProfileInfoResponse(
+        Long userId,
+        String nickname,
+        String profileImageUrl
+) {
+    public static UserProfileInfoResponse from(User user) {
+
+        return UserProfileInfoResponse.builder()
+                .userId(user.getUserId())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImage())
+                .build();
+    }
+}

--- a/src/main/java/com/meetup/server/user/exception/UserErrorType.java
+++ b/src/main/java/com/meetup/server/user/exception/UserErrorType.java
@@ -1,0 +1,17 @@
+package com.meetup.server.user.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorType implements ErrorType {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+
+    private final String message;
+}

--- a/src/main/java/com/meetup/server/user/exception/UserException.java
+++ b/src/main/java/com/meetup/server/user/exception/UserException.java
@@ -1,0 +1,11 @@
+package com.meetup.server.user.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+
+public class UserException extends GlobalException {
+
+    public UserException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/meetup/server/user/persistence/init/UserDummy.java
+++ b/src/main/java/com/meetup/server/user/persistence/init/UserDummy.java
@@ -1,0 +1,54 @@
+package com.meetup.server.user.persistence.init;
+
+import com.meetup.server.global.support.DummyDataInit;
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.domain.type.Role;
+import com.meetup.server.user.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+
+import java.util.ArrayList;
+
+@Slf4j
+@RequiredArgsConstructor
+@Profile("local")
+@Order(1)
+@DummyDataInit
+public class UserDummy implements ApplicationRunner {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (userRepository.count() > 0) {
+            log.info("[USER]더미 데이터 존재");
+        } else {
+            ArrayList<User> userList = new ArrayList<>();
+
+            User DUMMY_USER1 = User.builder()
+                    .email("test1@naver.com")
+                    .nickname("테스트1")
+                    .role(Role.USER)
+                    .socialId("test1")
+                    .profileImage("https://example.com/test1.jpg")
+                    .build();
+
+            User DUMMY_USER2 = User.builder()
+                    .email("test2@naver.com")
+                    .nickname("테스트2")
+                    .role(Role.USER)
+                    .socialId("test2")
+                    .profileImage("https://example.com/test2.jpg")
+                    .build();
+
+            userList.add(DUMMY_USER1);
+            userList.add(DUMMY_USER2);
+
+            userRepository.saveAll(userList);
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/user/presentation/UserController.java
+++ b/src/main/java/com/meetup/server/user/presentation/UserController.java
@@ -1,6 +1,10 @@
 package com.meetup.server.user.presentation;
 
 import com.meetup.server.global.support.response.ApiResponse;
+import com.meetup.server.user.application.UserService;
+import com.meetup.server.user.dto.response.UserProfileInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -9,15 +13,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@RequestMapping("/users")
+@Tag(name = "User API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/users")
 public class UserController {
 
-    @GetMapping("/test")
-    public ApiResponse<?> test(
-            @AuthenticationPrincipal Long memberId
+    private final UserService userService;
+
+    @Operation(summary = "유저 프로필 정보", description = "유저의 프로필 정보를 조회합니다")
+    @GetMapping("")
+    public ApiResponse<?> getUserProfileInfo(
+            @AuthenticationPrincipal Long userId
     ) {
-        return ApiResponse.success(memberId);
+        UserProfileInfoResponse response = userService.getUserProfileInfo(userId);
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/meetup/server/user/presentation/UserController.java
+++ b/src/main/java/com/meetup/server/user/presentation/UserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@Tag(name = "User API")
+@Tag(name = "User API", description = "사용자 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #15 

## 💡 작업 내용
- access token 을 재발급 하고 refresh token 을 갱신하도록 진행했습니다☺️
- 사용자 정보를 조회하는 api 를 통해 확인 가능하도록 진행했습니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/3da5e430-2bb0-4cca-ae99-160c7ac153d7)
삭제한 accessToken 발급 api 를 통해 test 진행했습니다☺️ 

![image](https://github.com/user-attachments/assets/186c78cd-cdb4-47b0-92af-8801c6fdf392)


## 💬리뷰 요구사항
- 로그를 통해 토큰 검증 확인 가능합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 리프레시 토큰을 통한 액세스 토큰 재발급 기능이 추가되었습니다.
    - 사용자 프로필 정보 조회 API가 추가되었습니다.
    - 인증 및 사용자 관련 오류 처리가 세분화되었습니다.
    - 개발 환경에서 더미 사용자 데이터 자동 생성 기능이 도입되었습니다.
    - 리프레시 토큰 쿠키 관리 및 자동 재발급 처리가 지원됩니다.

- **버그 수정**
    - 리프레시 토큰 검증 및 오류 메시지가 개선되었습니다.

- **리팩터링**
    - 사용자 조회 로직이 서비스 계층으로 분리되어 구조가 개선되었습니다.
    - 쿠키 처리 로직이 유틸리티 클래스로 이동하여 재사용성이 향상되었습니다.

- **문서화**
    - 사용자 API에 Swagger 문서 태그 및 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->