### PR TITLE
FEAT: #18 모임 생성 API

### DIFF
--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -1,0 +1,33 @@
+package com.meetup.server.event.application;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.implement.EventProcessor;
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import com.meetup.server.user.implement.UserReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+    private final UserReader userReader;
+    private final EventProcessor eventProcessor;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Transactional
+    public UUID createEvent(Long userId, StartPointRequest startPointRequest) {
+        Event event = userReader.readUserIfExists(userId)
+                .map(eventProcessor::saveForLoggedInUser)
+                .orElseGet(eventProcessor::saveForGuestUser);
+
+        // todo. 출발지(startpoint) 생성 기능을 구현하여 처리하기
+        applicationEventPublisher.publishEvent(startPointRequest);
+
+        return event.getEventId();
+    }
+}

--- a/src/main/java/com/meetup/server/event/implement/EventProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/EventProcessor.java
@@ -1,0 +1,26 @@
+package com.meetup.server.event.implement;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.persistence.EventRepository;
+import com.meetup.server.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EventProcessor {
+
+    private final EventRepository eventRepository;
+
+    public Event saveForLoggedInUser(User user) {
+        Event event = Event.builder()
+                .user(user)
+                .build();
+        return eventRepository.save(event);
+    }
+
+    public Event saveForGuestUser() {
+        Event event = Event.builder().build();
+        return eventRepository.save(event);
+    }
+}

--- a/src/main/java/com/meetup/server/event/persistence/EventRepository.java
+++ b/src/main/java/com/meetup/server/event/persistence/EventRepository.java
@@ -1,0 +1,9 @@
+package com.meetup.server.event.persistence;
+
+import com.meetup.server.event.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface EventRepository extends JpaRepository<Event, UUID> {
+}

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -1,0 +1,32 @@
+package com.meetup.server.event.presentation;
+
+import com.meetup.server.event.application.EventService;
+import com.meetup.server.global.support.response.ApiResponse;
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Tag(name = "Event API", description = "모임 API")
+@RestController
+@RequestMapping("/events")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventService eventService;
+
+    @Operation(summary = "모임 생성 API", description = "모임 생성자의 출발지를 입력받아 모임을 생성합니다")
+    @PostMapping
+    public ApiResponse<UUID> createEvent(@Valid @RequestBody StartPointRequest startPointRequest, @AuthenticationPrincipal Long userId) {
+        UUID eventId = eventService.createEvent(userId, startPointRequest);
+        return ApiResponse.success(eventId);
+    }
+}

--- a/src/main/java/com/meetup/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
             "/swagger-resources/**",
             "/webjars/**",
             "/auth/**",
+            "/events"
     };
 
     @Bean

--- a/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
@@ -24,6 +24,9 @@ public class StartPoint extends BaseEntity {
     @JoinColumn(name = "event_id", nullable = false)
     private Event event;
 
+    @Column(name = "start_point_name", nullable = false)
+    private String name;
+
     @Embedded
     private Address address;
 
@@ -31,8 +34,9 @@ public class StartPoint extends BaseEntity {
     private Location location;
 
     @Builder
-    public StartPoint(Event event, Address address, Location location) {
+    public StartPoint(Event event, String name, Address address, Location location) {
         this.event = event;
+        this.name = name;
         this.address = address;
         this.location = location;
     }

--- a/src/main/java/com/meetup/server/startpoint/domain/type/Address.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/type/Address.java
@@ -10,8 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Address {
 
-    @Column(name = "road_name", length = 255, nullable = false)
-    private String roadName;    //출발지명
+    @Column(name = "address", length = 255, nullable = false)
+    private String address;    //지번주소
 
     @Column(name = "road_address", length = 255, nullable = false)
     private String roadAddress; //도로명주소

--- a/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
+++ b/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
@@ -1,0 +1,28 @@
+package com.meetup.server.startpoint.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record StartPointRequest(
+        @Schema(description = "사용자명", example = "안연아바보")
+        String username,
+
+        @NotNull(message = "출발지명은 필수 값입니다.")
+        @Schema(description = "출발지명", example = "선정릉역 수인분당선")
+        String startPoint,
+
+        @NotNull(message = "지번주소는 필수 값입니다.")
+        @Schema(description = "지번주소", example = "서울특별시 강남구 삼성동 111-114")
+        String address,
+
+        @NotNull(message = "도로명주소는 필수 값입니다.")
+        @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580")
+        String roadAddress,
+
+        @Schema(description = "경도", example = "127.043999")
+        double longitude,
+
+        @Schema(description = "위도", example = "37.510297")
+        double latitude
+) {
+}

--- a/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
+++ b/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
@@ -1,6 +1,8 @@
 package com.meetup.server.startpoint.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
 public record StartPointRequest(
@@ -19,9 +21,13 @@ public record StartPointRequest(
         @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580")
         String roadAddress,
 
+        @DecimalMin(value = "-180.0", message = "경도는 -180.0보다 크거나 같아야 합니다.")
+        @DecimalMax(value = "180.0", message = "경도는 180.0보다 작거나 같아야 합니다.")
         @Schema(description = "경도", example = "127.043999")
         double longitude,
 
+        @DecimalMin(value = "-90.0", message = "위도는 -90.0보다 크거나 같아야 합니다.")
+        @DecimalMax(value = "90.0", message = "위도는 90.0보다 작거나 같아야 합니다.")
         @Schema(description = "위도", example = "37.510297")
         double latitude
 ) {

--- a/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
+++ b/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
+import java.math.BigDecimal;
+
 public record StartPointRequest(
         @Schema(description = "사용자명", example = "안연아바보")
         String username,
@@ -24,11 +26,11 @@ public record StartPointRequest(
         @DecimalMin(value = "-180.0", message = "경도는 -180.0보다 크거나 같아야 합니다.")
         @DecimalMax(value = "180.0", message = "경도는 180.0보다 작거나 같아야 합니다.")
         @Schema(description = "경도", example = "127.043999")
-        double longitude,
+        BigDecimal longitude,
 
         @DecimalMin(value = "-90.0", message = "위도는 -90.0보다 크거나 같아야 합니다.")
         @DecimalMax(value = "90.0", message = "위도는 90.0보다 작거나 같아야 합니다.")
         @Schema(description = "위도", example = "37.510297")
-        double latitude
+        BigDecimal latitude
 ) {
 }

--- a/src/main/java/com/meetup/server/user/implement/UserReader.java
+++ b/src/main/java/com/meetup/server/user/implement/UserReader.java
@@ -1,0 +1,20 @@
+package com.meetup.server.user.implement;
+
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class UserReader {
+
+    private final UserRepository userRepository;
+
+    public Optional<User> readUserIfExists(Long userId) {
+        if (userId == null) return Optional.empty();
+        return userRepository.findById(userId);
+    }
+}

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -39,7 +40,7 @@ class EventServiceTest {
     void 비로그인_사용자가_이벤트를_생성한다() {
         StartPointRequest startPointRequest = new StartPointRequest(
                 null, "선정릉역 수인분당선", "서울특별시 강남구 삼성동 111-114", "서울특별시 강남구 선릉로 지하580",
-                127.043999, 37.510297
+                BigDecimal.valueOf(127.043999), BigDecimal.valueOf(37.510297)
         );
         UUID eventId = eventService.createEvent(null, startPointRequest);
 
@@ -50,7 +51,7 @@ class EventServiceTest {
     void 로그인_사용자가_이벤트를_생성한다() {
         StartPointRequest startPointRequest = new StartPointRequest(
                 "땡수팟", "선정릉역 수인분당선", "서울특별시 강남구 삼성동 111-114", "서울특별시 강남구 선릉로 지하580",
-                127.043999, 37.510297
+                BigDecimal.valueOf(127.043999), BigDecimal.valueOf(37.510297)
         );
         UUID eventId = eventService.createEvent(user.getUserId(), startPointRequest);
 

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -1,0 +1,64 @@
+package com.meetup.server.event.application;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.persistence.EventRepository;
+import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.persistence.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class EventServiceTest {
+
+    @Autowired
+    private EventService eventService;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(UserFixture.getUser());
+    }
+
+    @Test
+    void 비로그인_사용자가_이벤트를_생성한다() {
+        StartPointRequest startPointRequest = new StartPointRequest(
+                null, "선정릉역 수인분당선", "서울특별시 강남구 삼성동 111-114", "서울특별시 강남구 선릉로 지하580",
+                127.043999, 37.510297
+        );
+        UUID eventId = eventService.createEvent(null, startPointRequest);
+
+        assertThat(eventRepository.findById(eventId)).isPresent();
+    }
+
+    @Test
+    void 로그인_사용자가_이벤트를_생성한다() {
+        StartPointRequest startPointRequest = new StartPointRequest(
+                "땡수팟", "선정릉역 수인분당선", "서울특별시 강남구 삼성동 111-114", "서울특별시 강남구 선릉로 지하580",
+                127.043999, 37.510297
+        );
+        UUID eventId = eventService.createEvent(user.getUserId(), startPointRequest);
+
+        Optional<Event> optionalEvent = eventRepository.findById(eventId);
+        assertThat(optionalEvent).isPresent();
+
+        Event event = optionalEvent.get();
+        assertThat(event.getUser().getUserId()).isEqualTo(user.getUserId());
+    }
+
+}

--- a/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
@@ -1,0 +1,46 @@
+package com.meetup.server.event.implement;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.persistence.EventRepository;
+import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.persistence.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class EventProcessorTest {
+
+    @Autowired
+    private EventProcessor eventProcessor;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(UserFixture.getUser());
+    }
+
+    @Test
+    void 비로그인_사용자가_이벤트를_저장한다() {
+        Event event = eventProcessor.saveForGuestUser();
+        assertThat(eventRepository.findById(event.getEventId())).isPresent();
+    }
+
+    @Test
+    void 로그인_사용자가_이벤트를_저장한다() {
+        Event event = eventProcessor.saveForLoggedInUser(user);
+        assertThat(event.getUser().getUserId()).isEqualTo(user.getUserId());
+    }
+
+}

--- a/src/test/java/com/meetup/server/fixture/UserFixture.java
+++ b/src/test/java/com/meetup/server/fixture/UserFixture.java
@@ -1,0 +1,20 @@
+package com.meetup.server.fixture;
+
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.domain.type.Role;
+
+import java.util.UUID;
+
+public class UserFixture {
+
+    public static User getUser() {
+        String uuid = UUID.randomUUID().toString();
+        return User.builder()
+                .nickname("땡수팟")
+                .socialId("kakao" + uuid)
+                .email(uuid + "@spot.com")
+                .role(Role.USER)
+                .build();
+    }
+
+}

--- a/src/test/java/com/meetup/server/user/implement/UserReaderTest.java
+++ b/src/test/java/com/meetup/server/user/implement/UserReaderTest.java
@@ -1,0 +1,43 @@
+package com.meetup.server.user.implement;
+
+import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.persistence.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class UserReaderTest {
+
+    @Autowired
+    private UserReader userReader;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(UserFixture.getUser());
+    }
+
+    @Test
+    void 비로그인_사용자를_조회한다() {
+        Optional<User> nonLoginUser = userReader.readUserIfExists(null);
+        assertThat(nonLoginUser).isEmpty();
+    }
+
+    @Test
+    void 로그인_사용자를_조회한다() {
+        Optional<User> loginUser = userReader.readUserIfExists(user.getUserId());
+        assertThat(loginUser).isPresent();
+        assertThat(loginUser.get().getUserId()).isEqualTo(user.getUserId());
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #18 

## 💡 작업 내용
- 모임 생성하는 API를 구현하였습니다
- 모임 생성 플로우와 모임 참여 플로우가 중복되어 모임 생성 플로우는 제가 맡고, 모임 생성에서의 출발지 등록과 모임 참여의 출발지 등록은 유진님이 이 작업 이어받아 작업하기로 저번 논의 때 결정하였습니다! (`EventService`의 주석 확인 바랍니다)
- StartPoint 엔티티에서 지번 주소로 수정 및 출발지명 필드가 추가되었습니다. ERD Cloud에 추가해두었습니다

## 📸 스크린샷
![스크린샷 2025-05-01 오전 2 41 45](https://github.com/user-attachments/assets/1e2ef6a1-4c69-4b19-b37f-e1d28dab3274)
![스크린샷 2025-05-01 오전 2 42 04](https://github.com/user-attachments/assets/3e8d5101-fa6c-4ca5-be9c-9534932fe1c9)

## 💬리뷰 요구사항
implement에 processor와 reader 클래스를 추가했는데요!
레이어 간의 경계에 대해 고민이 많았는데 좋은 글이 있어 사용해보았습니다.! 
한번 읽어보셔도 좋을 거 같아요~ ([관련 글](https://geminikims.medium.com/%EC%A7%80%EC%86%8D-%EC%84%B1%EC%9E%A5-%EA%B0%80%EB%8A%A5%ED%95%9C-%EC%86%8C%ED%94%84%ED%8A%B8%EC%9B%A8%EC%96%B4%EB%A5%BC-%EB%A7%8C%EB%93%A4%EC%96%B4%EA%B0%80%EB%8A%94-%EB%B0%A9%EB%B2%95-97844c5dab63))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 생성 API가 추가되어 로그인 사용자와 비로그인 사용자 모두 이벤트를 생성할 수 있습니다.
  - 이벤트 생성 시 출발지 정보(이름, 주소, 도로명 주소, 좌표 등)를 입력할 수 있습니다.
- **문서화**
  - 이벤트 생성 API에 대한 Swagger 문서가 추가되었습니다.
- **테스트**
  - 이벤트 생성 및 사용자 조회 관련 통합 테스트가 추가되었습니다.
- **스타일/리팩터링**
  - 출발지(Address) 엔티티의 필드명이 변경되고, 출발지 이름 필드가 추가되었습니다.
- **기타**
  - 이벤트 관련 URL이 인증 없이 접근 가능하도록 보안 설정이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->