### PR TITLE
FEAT: #23 로그아웃 구현하기

### DIFF
--- a/src/main/java/com/meetup/server/auth/application/AuthService.java
+++ b/src/main/java/com/meetup/server/auth/application/AuthService.java
@@ -3,9 +3,11 @@ package com.meetup.server.auth.application;
 import com.meetup.server.auth.dto.response.ReissueTokenResponse;
 import com.meetup.server.auth.exception.AuthErrorType;
 import com.meetup.server.auth.exception.AuthException;
+import com.meetup.server.auth.support.CookieUtil;
 import com.meetup.server.global.support.jwt.JwtTokenProvider;
 import com.meetup.server.user.application.UserService;
 import com.meetup.server.user.domain.User;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,9 +18,20 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtil cookieUtil;
     private final UserService userService;
 
-    public ReissueTokenResponse reIssueToken(String refreshToken) {
+    public void logout(HttpServletResponse response) {
+        cookieUtil.deleteAccessTokenCookie(response);
+        cookieUtil.deleteRefreshTokenCookie(response);
+    }
+
+    public String createAccessTokenForUser(Long userId) {
+        User user = userService.getUserById(userId);
+        return jwtTokenProvider.createAccessToken(user);
+    }
+
+    public ReissueTokenResponse reIssueToken(HttpServletResponse response, String refreshToken) {
 
         refreshToken = resolveToken(refreshToken);
 
@@ -32,10 +45,14 @@ public class AuthService {
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
 
+        cookieUtil.setRefreshTokenCookie(response, newRefreshToken);
+        cookieUtil.setAccessTokenCookie(response, accessToken);
+
         return ReissueTokenResponse.from(accessToken, newRefreshToken);
     }
 
     private String resolveToken(String token) {
+        log.info("accessToken check: {}", token);
         log.info("resolveToken check: {}", token);
 
         if (token == null) {

--- a/src/main/java/com/meetup/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/meetup/server/auth/presentation/AuthController.java
@@ -1,10 +1,13 @@
 package com.meetup.server.auth.presentation;
 
+import com.meetup.server.auth.application.AuthService;
+import com.meetup.server.global.support.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Auth", description = "인증 API")
 @Slf4j
@@ -12,4 +15,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "Access Token 발급", description = "Swagger Test 를 위한 Access Token을 발급합니다.")
+    @GetMapping("/test/{userId}")
+    public String getAccessToken(@PathVariable Long userId) {
+        return authService.createAccessTokenForUser(userId);
+    }
+
+    @Operation(summary = "로그아웃", description = "사용자 로그아웃을 진행합니다.")
+    @PostMapping("/logout")
+    public ApiResponse<?> logout(HttpServletResponse response) {
+        authService.logout(response);
+        return ApiResponse.success();
+    }
 }

--- a/src/main/java/com/meetup/server/auth/support/CookieProperties.java
+++ b/src/main/java/com/meetup/server/auth/support/CookieProperties.java
@@ -1,0 +1,11 @@
+package com.meetup.server.auth.support;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cookie")
+public record CookieProperties(
+        String accessToken,
+        String refreshToken,
+        String setCookie
+) {
+}

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -24,6 +24,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     private String successRedirectUri;
 
     private final JwtTokenProvider tokenProvider;
+    private final CookieUtil cookieUtil;
 
     @Override
     public void onAuthenticationSuccess(
@@ -35,15 +36,15 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String accessToken = tokenProvider.createAccessToken(oAuth2User);
         String refreshToken = tokenProvider.createRefreshToken(oAuth2User);
 
-        CookieUtil.setRefreshTokenCookie(response, refreshToken);
+        cookieUtil.setAccessTokenCookie(response, accessToken);
+        cookieUtil.setRefreshTokenCookie(response, refreshToken);
 
-        String targetUrl = createRedirectUrlWithTokens(accessToken);
+        String targetUrl = createRedirectUrlWithTokens();
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 
-    private String createRedirectUrlWithTokens(String accessToken) {
+    private String createRedirectUrlWithTokens() {
         return UriComponentsBuilder.fromUriString(successRedirectUri)
-                .queryParam("Access_Token", accessToken)
                 .build()
                 .toUriString();
     }

--- a/src/main/java/com/meetup/server/global/config/ConfigurationPropertiesConfig.java
+++ b/src/main/java/com/meetup/server/global/config/ConfigurationPropertiesConfig.java
@@ -1,5 +1,6 @@
 package com.meetup.server.global.config;
 
+import com.meetup.server.auth.support.CookieProperties;
 import com.meetup.server.global.clients.google.place.GooglePlaceProperties;
 import com.meetup.server.global.clients.kakao.local.KakaoLocalProperties;
 import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityProperties;
@@ -9,6 +10,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(value = {JwtProperties.class, KakaoLocalProperties.class, OdsayProperties.class, KakaoMobilityProperties.class, GooglePlaceProperties.class})
+@EnableConfigurationProperties(value = {JwtProperties.class, KakaoLocalProperties.class, OdsayProperties.class, KakaoMobilityProperties.class, GooglePlaceProperties.class, CookieProperties.class})
 public class ConfigurationPropertiesConfig {
 }

--- a/src/main/java/com/meetup/server/user/domain/User.java
+++ b/src/main/java/com/meetup/server/user/domain/User.java
@@ -30,17 +30,21 @@ public class User extends BaseEntity {
     @Column(name = "email", length = 255, nullable = false, unique = true)
     private String email;
 
+    @Column(name = "agreement", nullable = false)
+    private boolean agreement;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role", length = 10, nullable = false)
     private Role role;
 
 
     @Builder
-    public User(String nickname, String profileImage, String email, String socialId, Role role) {
+    public User(String nickname, String profileImage, String email, String socialId, Role role, boolean agreement) {
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.email = email;
         this.socialId = socialId;
+        this.agreement = agreement;
         this.role = role;
     }
 }

--- a/src/main/java/com/meetup/server/user/dto/response/UserProfileInfoResponse.java
+++ b/src/main/java/com/meetup/server/user/dto/response/UserProfileInfoResponse.java
@@ -7,7 +7,8 @@ import lombok.Builder;
 public record UserProfileInfoResponse(
         Long userId,
         String nickname,
-        String profileImageUrl
+        String profileImageUrl,
+        boolean agreement
 ) {
     public static UserProfileInfoResponse from(User user) {
 
@@ -15,6 +16,7 @@ public record UserProfileInfoResponse(
                 .userId(user.getUserId())
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImage())
+                .agreement(user.isAgreement())
                 .build();
     }
 }

--- a/src/main/java/com/meetup/server/user/persistence/init/UserDummy.java
+++ b/src/main/java/com/meetup/server/user/persistence/init/UserDummy.java
@@ -35,6 +35,7 @@ public class UserDummy implements ApplicationRunner {
                     .role(Role.USER)
                     .socialId("test1")
                     .profileImage("https://example.com/test1.jpg")
+                    .agreement(false)
                     .build();
 
             User DUMMY_USER2 = User.builder()
@@ -43,10 +44,21 @@ public class UserDummy implements ApplicationRunner {
                     .role(Role.USER)
                     .socialId("test2")
                     .profileImage("https://example.com/test2.jpg")
+                    .agreement(true)
+                    .build();
+
+            User DUMMY_USER3 = User.builder()
+                    .email("test3@naver.com")
+                    .nickname("테스트3")
+                    .role(Role.USER)
+                    .socialId("test3")
+                    .profileImage("https://example.com/test3.jpg")
+                    .agreement(true)
                     .build();
 
             userList.add(DUMMY_USER1);
             userList.add(DUMMY_USER2);
+            userList.add(DUMMY_USER3);
 
             userRepository.saveAll(userList);
         }

--- a/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
@@ -42,5 +42,4 @@ class EventProcessorTest {
         Event event = eventProcessor.saveForLoggedInUser(user);
         assertThat(event.getUser().getUserId()).isEqualTo(user.getUserId());
     }
-
 }

--- a/src/test/java/com/meetup/server/user/application/UserServiceTest.java
+++ b/src/test/java/com/meetup/server/user/application/UserServiceTest.java
@@ -1,0 +1,42 @@
+package com.meetup.server.user.application;
+
+
+import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.dto.response.UserProfileInfoResponse;
+import com.meetup.server.user.persistence.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(UserFixture.getUser());
+    }
+
+    @Test
+    void 사용자_정보를_조회한다() {
+        Long userId = user.getUserId();
+
+        UserProfileInfoResponse userProfileInfoResponse = userRepository.findById(userId)
+                .map(UserProfileInfoResponse::from)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        assertThat(userProfileInfoResponse).isNotNull();
+        assertThat(userProfileInfoResponse.userId()).isEqualTo(user.getUserId());
+        assertThat(userProfileInfoResponse.nickname()).isEqualTo(user.getNickname());
+    }
+}
+


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #23 

## 💡 작업 내용
- 기존 access token 관리 방식을 수정하고 쿠키 설정을 수정했어요 
- token 관리 변경으로 인해 로그아웃을 수정 구현 진행했어요
- 약관 동의 칼럼을 추가했어요


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/07c18bf3-4f58-463e-9caa-33c20fd6340a)

![image](https://github.com/user-attachments/assets/79b15cd7-1db4-4be0-ae69-66954e047cbf)


## 💬리뷰 요구사항
- DB URL 환경 변수 처리 했습니다 확인 부탁드려요 😂
- 협업 시간에 프론트 failedRedirectUri 논의 할 예정입니다
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 로그아웃 엔드포인트가 추가되어, 로그아웃 시 토큰 쿠키가 삭제됩니다.
    - 사용자 ID로 액세스 토큰을 발급받는 엔드포인트가 추가되었습니다.
    - 사용자 프로필 정보에 'agreement(동의 여부)' 항목이 추가되었습니다.

- **버그 수정**
    - 토큰 재발급 및 쿠키 관리 시 예외 처리 및 쿠키 삭제 로직이 개선되었습니다.

- **리팩터링**
    - 쿠키 관련 유틸리티가 인스턴스 기반으로 변경되어, 설정값을 외부에서 관리할 수 있게 되었습니다.
    - OAuth2 로그인 성공 처리 시 쿠키 설정 방식이 개선되었습니다.

- **테스트**
    - 사용자 정보 조회에 대한 통합 테스트가 추가되었습니다.

- **기타**
    - 더미 사용자 데이터에 'agreement' 필드가 반영되고, 테스트용 사용자가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->