### PR TITLE
FEAT: #21 사용자 출발지 등록 API

### DIFF
--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -3,7 +3,6 @@ package com.meetup.server.event.domain;
 
 import com.github.f4b6a3.uuid.UuidCreator;
 import com.meetup.server.global.domain.BaseEntity;
-import com.meetup.server.user.domain.User;
 import com.meetup.server.recommend.domain.RecommendPlace;
 import com.meetup.server.subway.domain.Subway;
 import jakarta.persistence.*;
@@ -28,10 +27,6 @@ public class Event extends BaseEntity {
     private Subway subway;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = true)
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recommend_id", nullable = true)
     private RecommendPlace recommendPlace;
 
@@ -41,9 +36,8 @@ public class Event extends BaseEntity {
     }
 
     @Builder
-    public Event(Subway subway, User user, RecommendPlace recommendPlace) {
+    public Event(Subway subway, RecommendPlace recommendPlace) {
         this.subway = subway;
-        this.user = user;
         this.recommendPlace = recommendPlace;
     }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
@@ -1,0 +1,28 @@
+package com.meetup.server.event.dto.response;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.startpoint.domain.StartPoint;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record EventStartPointResponse(
+        @Schema(description = "이벤트 ID", example = "01968fe2-5277-712a-ad3c-98f29c2782e0")
+        UUID eventId,
+
+        @Schema(description = "출발지 ID", example = "01968fe2-5277-712a-ad3c-98f29c2782e1")
+        UUID startPointId,
+
+        @Schema(description = "지번주소", example = "땡수팟")
+        String username
+) {
+    public static EventStartPointResponse of(Event event, StartPoint startPoint, String username) {
+        return EventStartPointResponse.builder()
+                .eventId(event.getEventId())
+                .startPointId(startPoint.getStartPointId())
+                .username(username)
+                .build();
+    }
+}

--- a/src/main/java/com/meetup/server/event/exception/EventErrorType.java
+++ b/src/main/java/com/meetup/server/event/exception/EventErrorType.java
@@ -1,0 +1,18 @@
+package com.meetup.server.event.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventErrorType implements ErrorType {
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "모임을 찾을 수 없습니다."),
+    START_POINT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "출발지는 최대 8개까지 등록할 수 있습니다.")
+    ;
+
+    private final HttpStatus status;
+
+    private final String message;
+}

--- a/src/main/java/com/meetup/server/event/exception/EventException.java
+++ b/src/main/java/com/meetup/server/event/exception/EventException.java
@@ -1,0 +1,11 @@
+package com.meetup.server.event.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+
+public class EventException extends GlobalException {
+
+    public EventException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/meetup/server/event/implement/EventProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/EventProcessor.java
@@ -2,7 +2,6 @@ package com.meetup.server.event.implement;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.persistence.EventRepository;
-import com.meetup.server.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,14 +11,7 @@ public class EventProcessor {
 
     private final EventRepository eventRepository;
 
-    public Event saveForLoggedInUser(User user) {
-        Event event = Event.builder()
-                .user(user)
-                .build();
-        return eventRepository.save(event);
-    }
-
-    public Event saveForGuestUser() {
+    public Event save() {
         Event event = Event.builder().build();
         return eventRepository.save(event);
     }

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -1,0 +1,22 @@
+package com.meetup.server.event.implement;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.exception.EventErrorType;
+import com.meetup.server.event.exception.EventException;
+import com.meetup.server.event.persistence.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class EventReader {
+
+    private final EventRepository eventRepository;
+
+    public Event read(UUID eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventException(EventErrorType.EVENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/meetup/server/event/implement/EventValidator.java
+++ b/src/main/java/com/meetup/server/event/implement/EventValidator.java
@@ -1,0 +1,23 @@
+package com.meetup.server.event.implement;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.exception.EventErrorType;
+import com.meetup.server.event.exception.EventException;
+import com.meetup.server.startpoint.persistence.StartPointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EventValidator {
+
+    private static final int MAX_START_POINTS = 8;
+
+    private final StartPointRepository startPointRepository;
+
+    public void validateEventIsNotFull(Event event) {
+        if (startPointRepository.countByEvent(event) >= MAX_START_POINTS) {
+            throw new EventException(EventErrorType.START_POINT_LIMIT_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -1,6 +1,7 @@
 package com.meetup.server.event.presentation;
 
 import com.meetup.server.event.application.EventService;
+import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.global.support.response.ApiResponse;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,8 +14,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.UUID;
-
 @Tag(name = "Event API", description = "모임 API")
 @RestController
 @RequestMapping("/events")
@@ -25,8 +24,7 @@ public class EventController {
 
     @Operation(summary = "모임 생성 API", description = "모임 생성자의 출발지를 입력받아 모임을 생성합니다")
     @PostMapping
-    public ApiResponse<UUID> createEvent(@Valid @RequestBody StartPointRequest startPointRequest, @AuthenticationPrincipal Long userId) {
-        UUID eventId = eventService.createEvent(userId, startPointRequest);
-        return ApiResponse.success(eventId);
+    public ApiResponse<EventStartPointResponse> createEvent(@Valid @RequestBody StartPointRequest startPointRequest, @AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(eventService.createEvent(userId, startPointRequest));
     }
 }

--- a/src/main/java/com/meetup/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
             "/swagger-resources/**",
             "/webjars/**",
             "/auth/**",
-            "/events"
+            "/events",
+            "/events/*/start-points"
     };
 
     @Bean

--- a/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
+++ b/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
@@ -1,0 +1,38 @@
+package com.meetup.server.startpoint.application;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.response.EventStartPointResponse;
+import com.meetup.server.event.implement.EventReader;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import com.meetup.server.startpoint.implement.StartPointProcessor;
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.implement.UserReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StartPointService {
+
+    private final StartPointProcessor startPointProcessor;
+    private final EventReader eventReader;
+    private final UserReader userReader;
+
+    @Transactional
+    public EventStartPointResponse createStartPoint(UUID eventId, Long userId, StartPointRequest startPointRequest) {
+        Event event = eventReader.read(eventId);
+
+        Optional<User> optionalUser = userReader.readUserIfExists(userId);
+        StartPoint startPoint = startPointProcessor.save(
+                event,
+                optionalUser.orElse(null),
+                startPointRequest
+        );
+        return EventStartPointResponse.of(event, startPoint, startPointRequest.username());
+    }
+}

--- a/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
@@ -1,28 +1,35 @@
 package com.meetup.server.startpoint.domain;
 
+import com.github.f4b6a3.uuid.UuidCreator;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.global.domain.BaseEntity;
 import com.meetup.server.startpoint.domain.type.Address;
 import com.meetup.server.startpoint.domain.type.Location;
+import com.meetup.server.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Entity
-@Table(name = "start_point")
+@Table(name = "start_point", uniqueConstraints = {@UniqueConstraint(columnNames = {"event_id", "user_id"})})
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Getter
 public class StartPoint extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "start_point_id")
-    private Long startPointId;
+    private UUID startPointId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id", nullable = false)
     private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = true)
+    private User user;
 
     @Column(name = "start_point_name", nullable = false)
     private String name;
@@ -33,9 +40,15 @@ public class StartPoint extends BaseEntity {
     @Embedded
     private Location location;
 
+    @PrePersist
+    public void prePersist() {
+        this.startPointId = UuidCreator.getTimeOrderedEpoch();
+    }
+
     @Builder
-    public StartPoint(Event event, String name, Address address, Location location) {
+    public StartPoint(Event event, User user, String name, Address address, Location location) {
         this.event = event;
+        this.user = user;
         this.name = name;
         this.address = address;
         this.location = location;

--- a/src/main/java/com/meetup/server/startpoint/domain/type/Address.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/type/Address.java
@@ -2,11 +2,14 @@ package com.meetup.server.startpoint.domain.type;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Address {
 
@@ -15,4 +18,8 @@ public class Address {
 
     @Column(name = "road_address", length = 255, nullable = false)
     private String roadAddress; //도로명주소
+
+    public static Address of(String address, String roadAddress) {
+        return new Address(address, roadAddress);
+    }
 }

--- a/src/main/java/com/meetup/server/startpoint/domain/type/Location.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/type/Location.java
@@ -2,6 +2,8 @@ package com.meetup.server.startpoint.domain.type;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,12 +11,17 @@ import java.math.BigDecimal;
 
 @Embeddable
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Location {
 
-    @Column(name = "road_longitude", length = 255, nullable = false)
+    @Column(name = "road_longitude", nullable = false, columnDefinition = "NUMERIC(9,6)")
     private BigDecimal roadLongitude;   //경도
 
-    @Column(name = "road_latitude", length = 255, nullable = false)
+    @Column(name = "road_latitude", nullable = false, columnDefinition = "NUMERIC(9,6)")
     private BigDecimal roadLatitude;    //위도
+
+    public static Location of(BigDecimal longitude, BigDecimal latitude) {
+        return new Location(longitude, latitude);
+    }
 }

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
@@ -1,0 +1,33 @@
+package com.meetup.server.startpoint.implement;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.implement.EventValidator;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.domain.type.Address;
+import com.meetup.server.startpoint.domain.type.Location;
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import com.meetup.server.startpoint.persistence.StartPointRepository;
+import com.meetup.server.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StartPointProcessor {
+
+    private final StartPointRepository startPointRepository;
+    private final EventValidator eventValidator;
+
+    public StartPoint save(Event event, User user, StartPointRequest startPointRequest) {
+        eventValidator.validateEventIsNotFull(event);
+        StartPoint startPoint = StartPoint.builder()
+                .event(event)
+                .user(user)
+                .name(startPointRequest.startPoint())
+                .address(Address.of(startPointRequest.address(), startPointRequest.roadAddress()))
+                .location(Location.of(startPointRequest.longitude(), startPointRequest.latitude()))
+                .build();
+
+        return startPointRepository.save(startPoint);
+    }
+}

--- a/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
+++ b/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
@@ -1,0 +1,12 @@
+package com.meetup.server.startpoint.persistence;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.startpoint.domain.StartPoint;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface StartPointRepository extends JpaRepository<StartPoint, UUID> {
+
+    int countByEvent(Event event);
+}

--- a/src/main/java/com/meetup/server/startpoint/presentation/StartPointController.java
+++ b/src/main/java/com/meetup/server/startpoint/presentation/StartPointController.java
@@ -1,0 +1,32 @@
+package com.meetup.server.startpoint.presentation;
+
+import com.meetup.server.event.dto.response.EventStartPointResponse;
+import com.meetup.server.global.support.response.ApiResponse;
+import com.meetup.server.startpoint.application.StartPointService;
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Tag(name = "StartPoint API", description = "출발지 API")
+@RestController
+@RequiredArgsConstructor
+public class StartPointController {
+
+    private final StartPointService startPointService;
+
+    @Operation(summary = "출발지 생성 API", description = "모임 참여자의 출발지를 생성합니다")
+    @PostMapping("/events/{eventId}/start-points")
+    public ApiResponse<EventStartPointResponse> createStartPoint(
+            @PathVariable UUID eventId,
+            @Valid @RequestBody StartPointRequest startPointRequest,
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.success(startPointService.createStartPoint(eventId, userId, startPointRequest));
+    }
+}

--- a/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
@@ -2,10 +2,6 @@ package com.meetup.server.event.implement;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.persistence.EventRepository;
-import com.meetup.server.fixture.UserFixture;
-import com.meetup.server.user.domain.User;
-import com.meetup.server.user.persistence.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,26 +17,10 @@ class EventProcessorTest {
     @Autowired
     private EventRepository eventRepository;
 
-    @Autowired
-    private UserRepository userRepository;
-
-    private User user;
-
-    @BeforeEach
-    void setUp() {
-        user = userRepository.save(UserFixture.getUser());
-    }
-
     @Test
-    void 비로그인_사용자가_이벤트를_저장한다() {
-        Event event = eventProcessor.saveForGuestUser();
+    void 사용자가_이벤트를_저장한다() {
+        Event event = eventProcessor.save();
         assertThat(eventRepository.findById(event.getEventId())).isPresent();
-    }
-
-    @Test
-    void 로그인_사용자가_이벤트를_저장한다() {
-        Event event = eventProcessor.saveForLoggedInUser(user);
-        assertThat(event.getUser().getUserId()).isEqualTo(user.getUserId());
     }
 
 }

--- a/src/test/java/com/meetup/server/event/implement/EventValidatorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventValidatorTest.java
@@ -1,0 +1,46 @@
+package com.meetup.server.event.implement;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.exception.EventException;
+import com.meetup.server.event.persistence.EventRepository;
+import com.meetup.server.fixture.EventFixture;
+import com.meetup.server.fixture.StartPointFixture;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.persistence.StartPointRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class EventValidatorTest {
+
+    private static final int MAX_START_POINTS = 8;
+
+    @Autowired
+    private EventValidator eventValidator;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private StartPointRepository startPointRepository;
+
+    @Test
+    void 최대_출발지_개수를_초과하면_출발지_등록에_실패한다() {
+        Event event = eventRepository.save(EventFixture.getEvent());
+
+        List<StartPoint> startPoints = new ArrayList<>();
+        for (int i = 0; i < MAX_START_POINTS; i++) {
+            startPoints.add(StartPointFixture.getStartPoint(event, null));
+        }
+        startPointRepository.saveAll(startPoints);
+
+        assertThatThrownBy(() -> eventValidator.validateEventIsNotFull(event))
+                .isInstanceOf(EventException.class);
+    }
+}

--- a/src/test/java/com/meetup/server/fixture/EventFixture.java
+++ b/src/test/java/com/meetup/server/fixture/EventFixture.java
@@ -1,0 +1,12 @@
+package com.meetup.server.fixture;
+
+import com.meetup.server.event.domain.Event;
+
+public class EventFixture {
+
+    public static Event getEvent() {
+        return Event.builder()
+                .build();
+    }
+
+}

--- a/src/test/java/com/meetup/server/fixture/StartPointFixture.java
+++ b/src/test/java/com/meetup/server/fixture/StartPointFixture.java
@@ -1,0 +1,31 @@
+package com.meetup.server.fixture;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.domain.type.Address;
+import com.meetup.server.startpoint.domain.type.Location;
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import com.meetup.server.user.domain.User;
+
+import java.math.BigDecimal;
+
+public class StartPointFixture {
+
+    public static StartPointRequest getStartPointRequest() {
+        return new StartPointRequest(
+                "땡수팟", "선정릉역 수인분당선", "서울특별시 강남구 삼성동 111-114", "서울특별시 강남구 선릉로 지하580",
+                BigDecimal.valueOf(127.043999), BigDecimal.valueOf(37.510297)
+        );
+    }
+
+    public static StartPoint getStartPoint(Event event, User user) {
+        return StartPoint.builder()
+                .event(event)
+                .user(user)
+                .name("선정릉역 수인분당선")
+                .address(Address.of("서울특별시 강남구 삼성동 111-114", "서울특별시 강남구 선릉로 지하580"))
+                .location(Location.of(BigDecimal.valueOf(127.043999), BigDecimal.valueOf(37.510297)))
+                .build();
+    }
+
+}

--- a/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
+++ b/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
@@ -1,0 +1,82 @@
+package com.meetup.server.startpoint.application;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.response.EventStartPointResponse;
+import com.meetup.server.event.persistence.EventRepository;
+import com.meetup.server.fixture.EventFixture;
+import com.meetup.server.fixture.StartPointFixture;
+import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import com.meetup.server.startpoint.persistence.StartPointRepository;
+import com.meetup.server.user.domain.User;
+import com.meetup.server.user.persistence.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class StartPointServiceTest {
+
+    @Autowired
+    private StartPointService startPointService;
+
+    @Autowired
+    private StartPointRepository startPointRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Event event;
+    private StartPointRequest startPointRequest;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        event = eventRepository.save(EventFixture.getEvent());
+        startPointRequest = StartPointFixture.getStartPointRequest();
+        user = userRepository.save(UserFixture.getUser());
+    }
+
+    @Test
+    void 비로그인_사용자가_출발지를_저장한다() {
+        EventStartPointResponse eventStartPointResponse = startPointService.createStartPoint(
+                event.getEventId(),
+                null,
+                startPointRequest
+        );
+
+        assertThat(event.getEventId()).isEqualTo(eventStartPointResponse.eventId());
+
+        Optional<StartPoint> optionalStartPoint = startPointRepository.findById(eventStartPointResponse.startPointId());
+        assertThat(optionalStartPoint).isPresent();
+        assertThat(optionalStartPoint.get().getStartPointId()).isEqualTo(eventStartPointResponse.startPointId());
+        assertThat(optionalStartPoint.get().getUser()).isEqualTo(null);
+    }
+
+    @Transactional
+    @Test
+    void 로그인_사용자가_출발지를_저장한다() {
+        EventStartPointResponse eventStartPointResponse = startPointService.createStartPoint(
+                event.getEventId(),
+                user.getUserId(),
+                startPointRequest
+        );
+
+        assertThat(event.getEventId()).isEqualTo(eventStartPointResponse.eventId());
+
+        Optional<StartPoint> optionalStartPoint = startPointRepository.findById(eventStartPointResponse.startPointId());
+        assertThat(optionalStartPoint).isPresent();
+        assertThat(optionalStartPoint.get().getStartPointId()).isEqualTo(eventStartPointResponse.startPointId());
+        assertThat(optionalStartPoint.get().getUser()).isEqualTo(user);
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #21 

## 💡 작업 내용
- #18 의 모임 생성 기능에서 `EventPublisher`를 사용하려 했으나 **모임 생성 -> 출발지 등록** 이후 출발지 ID도 프론트에 같이 반환해야 해서 하나의 메소드에서 처리하였습니다.
- 유진님께서 수정하신 ERD를 참고하여, StartPoint가 User와 Event의 중간 테이블로 동작하도록 필드 수정하였습니다.
- 최대 출발지 개수인 8개가 넘어가면 예외를 발생하도록 validator를 추가하였습니다.

## 📸 스크린샷
### 모임, 출발지 등록 테스트
<img width="552" alt="스크린샷 2025-05-03 오후 4 24 15" src="https://github.com/user-attachments/assets/5a22394f-9f26-4ef8-9d5e-1d7560f7a389" />

### 출발지 등록 테스트
<img width="557" alt="스크린샷 2025-05-03 오후 4 24 40" src="https://github.com/user-attachments/assets/356f1cc9-b862-4053-8f01-3ba5f64adbff" />

## 💬리뷰 요구사항
- 로그인, 비로그인 유저를 분리하여 API를 개발하지 않았습니다. 대신 Optional을 사용했는데 좋은 방법일지 궁금해요.
- 출발지 등록 엔드포인트 확인 부탁드려요! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이벤트 생성 시 출발지 정보를 함께 반환하도록 개선되었습니다.
    - 이벤트별 출발지 등록 개수 제한(최대 8개)이 도입되었습니다.
    - 출발지 생성 전용 API 및 서비스가 추가되었습니다.
    - 출발지 엔티티에 사용자 정보 및 고유 제약 조건이 추가되었습니다.
    - 이벤트 조회 및 검증 기능이 별도 컴포넌트로 분리되어 안정성이 강화되었습니다.
    - 출발지 및 위치 정보 생성 시 정밀한 좌표 저장과 팩토리 메서드 방식이 도입되었습니다.
    - 보안 설정에 출발지 관련 경로가 허용 목록에 추가되었습니다.

- **버그 수정**
    - 이벤트 및 출발지 생성 시 사용자 정보가 없는 경우도 올바르게 처리됩니다.

- **테스트**
    - 이벤트 및 출발지 생성, 최대 출발지 수 제한 등 다양한 시나리오에 대한 테스트가 추가 및 개선되었습니다.
    - 사용자 연관 없이 이벤트 저장 테스트가 단순화되었습니다.

- **문서화**
    - API 응답 및 엔드포인트에 대한 Swagger 문서가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->