### PR TITLE
FEAT: #32 최적 경로를 계산해서 중간지점 역 계산하기

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Test with Gradle
-        run: ./gradlew test -Dspring.config.additional-location=file:config/application-test.yml
+        run: ./gradlew test

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,9 +1,11 @@
 dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'com.h2database:h2'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation "org.testcontainers:postgresql"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
-    systemProperty "spring.config.additional-location", "file:config/application-test.yml"
 }

--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -2,16 +2,17 @@ package com.meetup.server.event.application;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
+import com.meetup.server.event.exception.EventErrorType;
+import com.meetup.server.event.exception.EventException;
 import com.meetup.server.event.implement.EventProcessor;
 import com.meetup.server.event.implement.EventReader;
+import com.meetup.server.event.implement.EventValidator;
 import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.startpoint.implement.StartPointProcessor;
 import com.meetup.server.startpoint.implement.StartPointReader;
 import com.meetup.server.subway.domain.Subway;
-import com.meetup.server.subway.exception.SubwayErrorType;
-import com.meetup.server.subway.exception.SubwayException;
 import com.meetup.server.subway.implement.processor.SubwayPathResult;
 import com.meetup.server.subway.implement.processor.SubwayProcessor;
 import com.meetup.server.subway.implement.reader.SubwayReader;
@@ -36,6 +37,7 @@ public class EventService {
     private final UserReader userReader;
     private final EventReader eventReader;
     private final EventProcessor eventProcessor;
+    private final EventValidator eventValidator;
     private final StartPointReader startPointReader;
     private final StartPointProcessor startPointProcessor;
     private final SubwayReader subwayReader;
@@ -58,11 +60,14 @@ public class EventService {
     public void getEventMap(UUID eventId) {
         Event event = eventReader.read(eventId);
         List<StartPoint> startPoints = startPointReader.readAllByEvent(event);
+        eventValidator.validateMinimumStartPoints(startPoints);
 
         Map<StartPoint, Subway> startPointToSubwayMap = subwayProcessor.mapStartPointsToClosestSubway(startPoints);
+        eventValidator.validateStartPointsNotAllSameSubway(startPointToSubwayMap);
 
         Point centerPoint = CoordinateUtil.calculateCenterPoint(startPoints.stream().map(StartPoint::getPoint).toList());
         List<Subway> nearbySubways = subwayReader.readNearbySubways(centerPoint);
+        eventValidator.validateNearbySubwaysExist(nearbySubways);
 
         Map<StartPoint, List<SubwayPathResult>> startPointToSubwayPathsMap = subwayProcessor.mapStartPointsToDestinationSubways(startPoints, startPointToSubwayMap, nearbySubways);
 
@@ -70,7 +75,7 @@ public class EventService {
             Subway subway = subwayReader.read(subwayId);
             log.info("중간지점 Subway: {} ({})", subway.getName(), subway.getSubwayId());
         }, () -> {
-            throw new SubwayException(SubwayErrorType.SUBWAY_NOT_FOUND);
+            throw new EventException(EventErrorType.PATH_CALCULATION_FAILED);
         });
     }
 }

--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -3,24 +3,43 @@ package com.meetup.server.event.application;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.implement.EventProcessor;
+import com.meetup.server.event.implement.EventReader;
+import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.startpoint.implement.StartPointProcessor;
+import com.meetup.server.startpoint.implement.StartPointReader;
+import com.meetup.server.subway.domain.Subway;
+import com.meetup.server.subway.exception.SubwayErrorType;
+import com.meetup.server.subway.exception.SubwayException;
+import com.meetup.server.subway.implement.processor.SubwayPathResult;
+import com.meetup.server.subway.implement.processor.SubwayProcessor;
+import com.meetup.server.subway.implement.reader.SubwayReader;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.implement.UserReader;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EventService {
 
     private final UserReader userReader;
+    private final EventReader eventReader;
     private final EventProcessor eventProcessor;
+    private final StartPointReader startPointReader;
     private final StartPointProcessor startPointProcessor;
+    private final SubwayReader subwayReader;
+    private final SubwayProcessor subwayProcessor;
 
     @Transactional
     public EventStartPointResponse createEvent(Long userId, StartPointRequest startPointRequest) {
@@ -33,5 +52,25 @@ public class EventService {
                 startPointRequest
         );
         return EventStartPointResponse.of(event, startPoint, startPointRequest.username());
+    }
+
+    @Transactional
+    public void getEventMap(UUID eventId) {
+        Event event = eventReader.read(eventId);
+        List<StartPoint> startPoints = startPointReader.readAllByEvent(event);
+
+        Map<StartPoint, Subway> startPointToSubwayMap = subwayProcessor.mapStartPointsToClosestSubway(startPoints);
+
+        Point centerPoint = CoordinateUtil.calculateCenterPoint(startPoints.stream().map(StartPoint::getPoint).toList());
+        List<Subway> nearbySubways = subwayReader.readNearbySubways(centerPoint);
+
+        Map<StartPoint, List<SubwayPathResult>> startPointToSubwayPathsMap = subwayProcessor.mapStartPointsToDestinationSubways(startPoints, startPointToSubwayMap, nearbySubways);
+
+        subwayProcessor.findMostFairSubway(startPointToSubwayPathsMap).ifPresentOrElse(subwayId -> {
+            Subway subway = subwayReader.read(subwayId);
+            log.info("중간지점 Subway: {} ({})", subway.getName(), subway.getSubwayId());
+        }, () -> {
+            throw new SubwayException(SubwayErrorType.SUBWAY_NOT_FOUND);
+        });
     }
 }

--- a/src/main/java/com/meetup/server/event/exception/EventErrorType.java
+++ b/src/main/java/com/meetup/server/event/exception/EventErrorType.java
@@ -9,7 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum EventErrorType implements ErrorType {
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "모임을 찾을 수 없습니다."),
-    START_POINT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "출발지는 최대 8개까지 등록할 수 있습니다.")
+    START_POINT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "출발지는 최대 8개까지 등록할 수 있습니다."),
+    INSUFFICIENT_START_POINTS(HttpStatus.BAD_REQUEST, "출발지는 최소 2개 이상이어야 합니다."),
+    SAME_SUBWAY_FOR_ALL_START_POINTS(HttpStatus.BAD_REQUEST, "모든 출발지의 지하철역이 동일합니다."),
+    NO_INTERMEDIATE_SUBWAYS_FOUND(HttpStatus.NOT_FOUND, "중간 지점 근처에 지하철역을 찾을 수 없습니다."),
+    PATH_CALCULATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "중간 지점 경로 계산에 실패했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/event/implement/EventValidator.java
+++ b/src/main/java/com/meetup/server/event/implement/EventValidator.java
@@ -3,14 +3,22 @@ package com.meetup.server.event.implement;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.exception.EventErrorType;
 import com.meetup.server.event.exception.EventException;
+import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.persistence.StartPointRepository;
+import com.meetup.server.subway.domain.Subway;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
 public class EventValidator {
 
+    private static final int MIN_START_POINTS = 2;
     private static final int MAX_START_POINTS = 8;
 
     private final StartPointRepository startPointRepository;
@@ -18,6 +26,25 @@ public class EventValidator {
     public void validateEventIsNotFull(Event event) {
         if (startPointRepository.countByEvent(event) >= MAX_START_POINTS) {
             throw new EventException(EventErrorType.START_POINT_LIMIT_EXCEEDED);
+        }
+    }
+
+    public void validateMinimumStartPoints(List<StartPoint> startPoints) {
+        if (startPoints.size() < MIN_START_POINTS) {
+            throw new EventException(EventErrorType.INSUFFICIENT_START_POINTS);
+        }
+    }
+
+    public void validateStartPointsNotAllSameSubway(Map<StartPoint, Subway> startPointToSubwayMap) {
+        Set<Subway> uniqueSubways = new HashSet<>(startPointToSubwayMap.values());
+        if (uniqueSubways.size() == 1) {
+            throw new EventException(EventErrorType.SAME_SUBWAY_FOR_ALL_START_POINTS);
+        }
+    }
+
+    public void validateNearbySubwaysExist(List<Subway> nearBySubways) {
+        if (nearBySubways.isEmpty()) {
+            throw new EventException(EventErrorType.NO_INTERMEDIATE_SUBWAYS_FOUND);
         }
     }
 }

--- a/src/main/java/com/meetup/server/global/util/CoordinateUtil.java
+++ b/src/main/java/com/meetup/server/global/util/CoordinateUtil.java
@@ -1,0 +1,40 @@
+package com.meetup.server.global.util;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
+import java.util.List;
+
+public class CoordinateUtil {
+
+    public static Point createPoint(double longitude, double latitude) {
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        Coordinate coordinate = new Coordinate(longitude, latitude);
+        return geometryFactory.createPoint(coordinate);
+    }
+
+    public static Point calculateCenterPoint(List<Point> points) {
+        if (points == null || points.isEmpty()) {
+            throw new IllegalArgumentException("중간 좌표를 계산할 좌표 리스트가 존재하지 않습니다.");
+        }
+
+        if (points.size() == 1) {
+            return points.getFirst();
+        }
+
+        double sumLongitude = 0.0;
+        double sumLatitude = 0.0;
+
+        for (Point point : points) {
+            sumLongitude += point.getX();
+            sumLatitude += point.getY();
+        }
+
+        double avgLongitude = sumLongitude / points.size();
+        double avgLatitude = sumLatitude / points.size();
+
+        return createPoint(avgLongitude, avgLatitude);
+    }
+}

--- a/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
@@ -10,6 +10,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 
 import java.util.UUID;
 
@@ -40,17 +41,21 @@ public class StartPoint extends BaseEntity {
     @Embedded
     private Location location;
 
+    @Column(columnDefinition = "geography(Point, 4326)")
+    private Point point;
+
     @PrePersist
     public void prePersist() {
         this.startPointId = UuidCreator.getTimeOrderedEpoch();
     }
 
     @Builder
-    public StartPoint(Event event, User user, String name, Address address, Location location) {
+    public StartPoint(Event event, User user, String name, Address address, Location location, Point point) {
         this.event = event;
         this.user = user;
         this.name = name;
         this.address = address;
         this.location = location;
+        this.point = point;
     }
 }

--- a/src/main/java/com/meetup/server/startpoint/domain/type/Location.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/type/Location.java
@@ -7,21 +7,19 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
-
 @Embeddable
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Location {
 
-    @Column(name = "road_longitude", nullable = false, columnDefinition = "NUMERIC(9,6)")
-    private BigDecimal roadLongitude;   //경도
+    @Column(name = "road_longitude", nullable = false)
+    private double roadLongitude;   //경도
 
-    @Column(name = "road_latitude", nullable = false, columnDefinition = "NUMERIC(9,6)")
-    private BigDecimal roadLatitude;    //위도
+    @Column(name = "road_latitude", nullable = false)
+    private double roadLatitude;    //위도
 
-    public static Location of(BigDecimal longitude, BigDecimal latitude) {
+    public static Location of(double longitude, double latitude) {
         return new Location(longitude, latitude);
     }
 }

--- a/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
+++ b/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
@@ -5,8 +5,6 @@ import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
-import java.math.BigDecimal;
-
 public record StartPointRequest(
         @Schema(description = "사용자명", example = "안연아바보")
         String username,
@@ -26,11 +24,11 @@ public record StartPointRequest(
         @DecimalMin(value = "-180.0", message = "경도는 -180.0보다 크거나 같아야 합니다.")
         @DecimalMax(value = "180.0", message = "경도는 180.0보다 작거나 같아야 합니다.")
         @Schema(description = "경도", example = "127.043999")
-        BigDecimal longitude,
+        double longitude,
 
         @DecimalMin(value = "-90.0", message = "위도는 -90.0보다 크거나 같아야 합니다.")
         @DecimalMax(value = "90.0", message = "위도는 90.0보다 작거나 같아야 합니다.")
         @Schema(description = "위도", example = "37.510297")
-        BigDecimal latitude
+        double latitude
 ) {
 }

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
@@ -2,6 +2,7 @@ package com.meetup.server.startpoint.implement;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.implement.EventValidator;
+import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.domain.type.Address;
 import com.meetup.server.startpoint.domain.type.Location;
@@ -26,6 +27,7 @@ public class StartPointProcessor {
                 .name(startPointRequest.startPoint())
                 .address(Address.of(startPointRequest.address(), startPointRequest.roadAddress()))
                 .location(Location.of(startPointRequest.longitude(), startPointRequest.latitude()))
+                .point(CoordinateUtil.createPoint(startPointRequest.longitude(), startPointRequest.latitude()))
                 .build();
 
         return startPointRepository.save(startPoint);

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
@@ -1,0 +1,20 @@
+package com.meetup.server.startpoint.implement;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.persistence.StartPointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class StartPointReader {
+
+    private final StartPointRepository startPointRepository;
+
+    public List<StartPoint> readAllByEvent(Event event) {
+        return startPointRepository.findAllByEvent(event);
+    }
+}

--- a/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
+++ b/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
@@ -3,10 +3,16 @@ package com.meetup.server.startpoint.persistence;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.startpoint.domain.StartPoint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface StartPointRepository extends JpaRepository<StartPoint, UUID> {
 
     int countByEvent(Event event);
+
+    @Query("SELECT DISTINCT s FROM StartPoint s JOIN FETCH s.event WHERE s.event = :event")
+    List<StartPoint> findAllByEvent(@Param("event") Event event);
 }

--- a/src/main/java/com/meetup/server/subway/domain/Subway.java
+++ b/src/main/java/com/meetup/server/subway/domain/Subway.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 
 @Entity
 @Table(name = "subway")
@@ -30,11 +31,15 @@ public class Subway extends BaseEntity {
     @Embedded
     private Location location;
 
+    @Column(columnDefinition = "geography(Point, 4326)")
+    private Point point;
+
     @Builder
-    public Subway(String name, Integer code, Integer line, Location location) {
+    public Subway(String name, Integer code, Integer line, Location location, Point point) {
         this.name = name;
         this.code = code;
         this.line = line;
         this.location = location;
+        this.point = point;
     }
 }

--- a/src/main/java/com/meetup/server/subway/exception/SubwayErrorType.java
+++ b/src/main/java/com/meetup/server/subway/exception/SubwayErrorType.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum SubwayErrorType implements ErrorType {
-    SUBWAY_NOT_FOUND(HttpStatus.NOT_FOUND, "지하철역을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/subway/exception/SubwayErrorType.java
+++ b/src/main/java/com/meetup/server/subway/exception/SubwayErrorType.java
@@ -1,0 +1,17 @@
+package com.meetup.server.subway.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SubwayErrorType implements ErrorType {
+    SUBWAY_NOT_FOUND(HttpStatus.NOT_FOUND, "지하철역을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+
+    private final String message;
+}

--- a/src/main/java/com/meetup/server/subway/exception/SubwayException.java
+++ b/src/main/java/com/meetup/server/subway/exception/SubwayException.java
@@ -1,0 +1,11 @@
+package com.meetup.server.subway.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+
+public class SubwayException extends GlobalException {
+
+    public SubwayException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathNode.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathNode.java
@@ -1,0 +1,10 @@
+package com.meetup.server.subway.implement.processor;
+
+import java.util.List;
+
+public record SubwayPathNode(
+        int subwayId,
+        int totalTime,
+        List<Integer> subwayIds
+) {
+}

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathProcessor.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathProcessor.java
@@ -1,0 +1,102 @@
+package com.meetup.server.subway.implement.processor;
+
+import com.meetup.server.subway.domain.Subway;
+import com.meetup.server.subway.domain.SubwayConnection;
+import com.meetup.server.subway.domain.TransferInfo;
+import com.meetup.server.subway.persistence.SubwayConnectionRepository;
+import com.meetup.server.subway.persistence.SubwayRepository;
+import com.meetup.server.subway.persistence.TransferInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class SubwayPathProcessor {
+
+    private static final int TRANSFER_TIME_SEC = 180;
+
+    private final SubwayRepository subwayRepository;
+    private final SubwayConnectionRepository subwayConnectionRepository;
+    private final TransferInfoRepository transferInfoRepository;
+
+    public SubwayPathResult findShortestPath(int startSubwayId, int endSubwayId) {
+
+        Map<Integer, Subway> subwayMap = mapSubwaysById();
+        Map<Integer, List<SubwayConnection>> connectionsMap = groupConnectionsByFromId();
+        Map<Integer, List<TransferInfo>> transferMap = groupTransfersByFromId();
+
+        PriorityQueue<SubwayPathNode> pathQueue = new PriorityQueue<>(
+                Comparator.comparingInt((SubwayPathNode node) -> node.subwayIds().size())
+                        .thenComparingInt(SubwayPathNode::totalTime)
+        );
+        pathQueue.offer(new SubwayPathNode(startSubwayId, 0, new ArrayList<>(List.of(startSubwayId))));
+
+        Map<String, Integer> visitedTimeMap = new HashMap<>();
+
+        while (!pathQueue.isEmpty()) {
+            SubwayPathNode currentNode = pathQueue.poll();
+
+            String pathKey = currentNode.subwayId() + "-" + currentNode.subwayIds().size();
+            if (visitedTimeMap.containsKey(pathKey) && visitedTimeMap.get(pathKey) <= currentNode.totalTime()) {
+                continue;
+            }
+            visitedTimeMap.put(pathKey, currentNode.totalTime());
+
+            if (currentNode.subwayId() == endSubwayId) {
+                List<String> pathNames = currentNode.subwayIds().stream()
+                        .map(id -> subwayMap.get(id).getName())
+                        .collect(Collectors.toList());
+
+                return new SubwayPathResult(currentNode.totalTime(), currentNode.subwayIds(), pathNames);
+            }
+
+            List<SubwayConnection> connections = connectionsMap.getOrDefault(currentNode.subwayId(), List.of());
+            for (SubwayConnection connection : connections) {
+                pathQueue.offer(new SubwayPathNode(
+                        connection.getToSubway().getSubwayId(),
+                        currentNode.totalTime() + connection.getSectionTimeSec(),
+                        addSubwayToPath(currentNode.subwayIds(), connection.getToSubway().getSubwayId())
+                ));
+            }
+
+            List<TransferInfo> transfers = transferMap.getOrDefault(currentNode.subwayId(), List.of());
+            for (TransferInfo transfer : transfers) {
+                pathQueue.offer(new SubwayPathNode(
+                        transfer.getToSubway().getSubwayId(),
+                        currentNode.totalTime() + TRANSFER_TIME_SEC,
+                        addSubwayToPath(currentNode.subwayIds(), transfer.getToSubway().getSubwayId())
+                ));
+            }
+        }
+
+        return null;
+    }
+
+    private List<Integer> addSubwayToPath(List<Integer> path, int subwayId) {
+        List<Integer> newPath = new ArrayList<>(path);
+        newPath.add(subwayId);
+        return newPath;
+    }
+
+    private Map<Integer, Subway> mapSubwaysById() {
+        return subwayRepository.findAll()
+                .stream()
+                .collect(Collectors.toMap(Subway::getSubwayId, Function.identity()));
+    }
+
+    private Map<Integer, List<SubwayConnection>> groupConnectionsByFromId() {
+        return subwayConnectionRepository.findAllWithSubways()
+                .stream()
+                .collect(Collectors.groupingBy(subwayConnection -> subwayConnection.getFromSubway().getSubwayId()));
+    }
+
+    private Map<Integer, List<TransferInfo>> groupTransfersByFromId() {
+        return transferInfoRepository.findAllWithSubways()
+                .stream()
+                .collect(Collectors.groupingBy(transferInfo -> transferInfo.getFromSubway().getSubwayId()));
+    }
+}

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathResult.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathResult.java
@@ -1,0 +1,10 @@
+package com.meetup.server.subway.implement.processor;
+
+import java.util.List;
+
+public record SubwayPathResult(
+        int totalTime,
+        List<Integer> path,
+        List<String> pathNames
+) {
+}

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayProcessor.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayProcessor.java
@@ -1,0 +1,74 @@
+package com.meetup.server.subway.implement.processor;
+
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.subway.domain.Subway;
+import com.meetup.server.subway.implement.reader.SubwayReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class SubwayProcessor {
+
+    private static final int MINIMUM_PEOPLE_REQUIRED = 2;
+
+    private final SubwayReader subwayReader;
+    private final SubwayPathProcessor subwayPathProcessor;
+
+    public Optional<Integer> findMostFairSubway(Map<StartPoint, List<SubwayPathResult>> startPointToSubwayPaths) {
+        Map<Integer, List<Integer>> destinationSubwayTimeMap = new HashMap<>();
+
+        startPointToSubwayPaths.forEach((startPoint, subwayPaths) ->
+                subwayPaths.forEach(subwayPath -> {
+                    int destinationId = subwayPath.path().getLast();
+                    destinationSubwayTimeMap
+                            .computeIfAbsent(destinationId, k -> new ArrayList<>())
+                            .add(subwayPath.totalTime());
+                })
+        );
+
+        return destinationSubwayTimeMap.entrySet().stream()
+                .filter(entry -> entry.getValue().size() >= MINIMUM_PEOPLE_REQUIRED)
+                .min(Comparator.comparingDouble(entry -> calculateStandardDeviation(entry.getValue())))
+                .map(Map.Entry::getKey);
+    }
+
+    private double calculateStandardDeviation(List<Integer> times) {
+        double avg = times.stream().mapToInt(i -> i).average().orElse(0);
+        return Math.sqrt(times.stream()
+                .mapToDouble(t -> Math.pow(t - avg, 2))
+                .average()
+                .orElse(0));
+    }
+
+    public Map<StartPoint, Subway> mapStartPointsToClosestSubway(List<StartPoint> startPoints) {
+        return startPoints.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        startPoint -> subwayReader.readClosestSubway(startPoint.getPoint())
+                ));
+    }
+
+    public Map<StartPoint, List<SubwayPathResult>> mapStartPointsToDestinationSubways(
+            List<StartPoint> startPoints,
+            Map<StartPoint, Subway> startPointsToClosestSubway,
+            List<Subway> destinationSubways
+    ) {
+        return startPoints.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        startPoint -> destinationSubways.stream()
+                                .map(destinationSubway ->
+                                        subwayPathProcessor.findShortestPath(
+                                                startPointsToClosestSubway.get(startPoint).getSubwayId(),
+                                                destinationSubway.getSubwayId())
+                                )
+                                .filter(Objects::nonNull)
+                                .toList()
+                ));
+    }
+}

--- a/src/main/java/com/meetup/server/subway/implement/reader/SubwayReader.java
+++ b/src/main/java/com/meetup/server/subway/implement/reader/SubwayReader.java
@@ -1,0 +1,34 @@
+package com.meetup.server.subway.implement.reader;
+
+import com.meetup.server.subway.domain.Subway;
+import com.meetup.server.subway.persistence.SubwayRepository;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class SubwayReader {
+
+    private static final double NEAREST_SUBWAY_RADIUS_M = 1500;
+
+    private final SubwayRepository subwayRepository;
+
+    public Subway read(int subwayId) {
+        return subwayRepository.findById(subwayId).orElseThrow();
+    }
+
+    public Subway readClosestSubway(Point startPoint) {
+        return subwayRepository.findClosestSubway(startPoint);
+    }
+
+    public List<Subway> readAllWithinRadius(Point centerPoint, double radius) {
+        return subwayRepository.findAllWithinRadius(centerPoint, radius);
+    }
+
+    public List<Subway> readNearbySubways(Point centerPoint) {
+        return readAllWithinRadius(centerPoint, NEAREST_SUBWAY_RADIUS_M);
+    }
+}

--- a/src/main/java/com/meetup/server/subway/infrastructure/csv/SubwayCsvLoader.java
+++ b/src/main/java/com/meetup/server/subway/infrastructure/csv/SubwayCsvLoader.java
@@ -1,6 +1,7 @@
 package com.meetup.server.subway.infrastructure.csv;
 
 import com.meetup.server.global.support.DummyDataInit;
+import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.startpoint.domain.type.Location;
 import com.meetup.server.subway.domain.Subway;
 import com.meetup.server.subway.domain.SubwayConnection;
@@ -73,6 +74,7 @@ public class SubwayCsvLoader implements ApplicationRunner {
                             .code(csvLine.getCode())
                             .line(csvLine.getLine())
                             .location(Location.of(csvLine.getLongitude(), csvLine.getLatitude()))
+                            .point(CoordinateUtil.createPoint(csvLine.getLongitude(), csvLine.getLatitude()))
                             .build()
                     ).toList();
         }

--- a/src/main/java/com/meetup/server/subway/infrastructure/csv/mapping/SubwayCsvMapping.java
+++ b/src/main/java/com/meetup/server/subway/infrastructure/csv/mapping/SubwayCsvMapping.java
@@ -1,9 +1,7 @@
 package com.meetup.server.subway.infrastructure.csv.mapping;
 
 import com.opencsv.bean.CsvBindByName;
-import lombok.*;
-
-import java.math.BigDecimal;
+import lombok.Getter;
 
 @Getter
 public class SubwayCsvMapping {
@@ -18,8 +16,8 @@ public class SubwayCsvMapping {
     private String name;
 
     @CsvBindByName(column = "경도")
-    private BigDecimal longitude;
+    private double longitude;
 
     @CsvBindByName(column = "위도")
-    private BigDecimal latitude;
+    private double latitude;
 }

--- a/src/main/java/com/meetup/server/subway/persistence/SubwayConnectionRepository.java
+++ b/src/main/java/com/meetup/server/subway/persistence/SubwayConnectionRepository.java
@@ -2,6 +2,12 @@ package com.meetup.server.subway.persistence;
 
 import com.meetup.server.subway.domain.SubwayConnection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface SubwayConnectionRepository extends JpaRepository<SubwayConnection, Long> {
+import java.util.List;
+
+public interface SubwayConnectionRepository extends JpaRepository<SubwayConnection, Integer> {
+
+    @Query("SELECT sc FROM SubwayConnection sc JOIN FETCH sc.fromSubway JOIN FETCH sc.toSubway")
+    List<SubwayConnection> findAllWithSubways();
 }

--- a/src/main/java/com/meetup/server/subway/persistence/SubwayRepository.java
+++ b/src/main/java/com/meetup/server/subway/persistence/SubwayRepository.java
@@ -1,13 +1,35 @@
 package com.meetup.server.subway.persistence;
 
 import com.meetup.server.subway.domain.Subway;
+import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
-public interface SubwayRepository extends JpaRepository<Subway, Long> {
+@Repository
+public interface SubwayRepository extends JpaRepository<Subway, Integer> {
 
     Optional<Subway> findByNameAndLine(String name, Integer line);
 
     Optional<Subway> findByCode(Integer code);
+
+    @Query("""
+                SELECT s
+                FROM Subway s
+                WHERE st_distance(s.point, :startPoint) = (
+                    SELECT MIN(st_distance(s2.point, :startPoint))
+                    FROM Subway s2)
+            """)
+    Subway findClosestSubway(@Param("startPoint") Point startPoint);
+
+    @Query("""
+                SELECT s
+                FROM Subway s
+                WHERE CAST(st_dwithin(s.point, :centerPoint, :radius, true) AS boolean) = true
+            """)
+    List<Subway> findAllWithinRadius(@Param("centerPoint") Point centerPoint, @Param("radius") double radius);
 }

--- a/src/main/java/com/meetup/server/subway/persistence/TransferInfoRepository.java
+++ b/src/main/java/com/meetup/server/subway/persistence/TransferInfoRepository.java
@@ -2,6 +2,12 @@ package com.meetup.server.subway.persistence;
 
 import com.meetup.server.subway.domain.TransferInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface TransferInfoRepository extends JpaRepository<TransferInfo, Long> {
+import java.util.List;
+
+public interface TransferInfoRepository extends JpaRepository<TransferInfo, Integer> {
+
+    @Query("SELECT t FROM TransferInfo t JOIN FETCH t.fromSubway JOIN FETCH t.toSubway")
+    List<TransferInfo> findAllWithSubways();
 }

--- a/src/test/java/com/meetup/server/ServerApplicationTests.java
+++ b/src/test/java/com/meetup/server/ServerApplicationTests.java
@@ -2,7 +2,9 @@ package com.meetup.server;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("h2")
 @SpringBootTest
 class ServerApplicationTests {
 

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -8,20 +8,19 @@ import com.meetup.server.fixture.UserFixture;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.startpoint.persistence.StartPointRepository;
+import com.meetup.server.support.PostgisContainer;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.persistence.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-class EventServiceTest {
+class EventServiceTest extends PostgisContainer {
 
     @Autowired
     private EventService eventService;

--- a/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
@@ -5,9 +5,11 @@ import com.meetup.server.event.persistence.EventRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("h2")
 @SpringBootTest
 class EventProcessorTest {
 

--- a/src/test/java/com/meetup/server/event/implement/EventValidatorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventValidatorTest.java
@@ -7,17 +7,16 @@ import com.meetup.server.fixture.EventFixture;
 import com.meetup.server.fixture.StartPointFixture;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.persistence.StartPointRepository;
+import com.meetup.server.support.PostgisContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
-class EventValidatorTest {
+class EventValidatorTest extends PostgisContainer {
 
     private static final int MAX_START_POINTS = 8;
 

--- a/src/test/java/com/meetup/server/fixture/StartPointFixture.java
+++ b/src/test/java/com/meetup/server/fixture/StartPointFixture.java
@@ -1,20 +1,19 @@
 package com.meetup.server.fixture;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.domain.type.Address;
 import com.meetup.server.startpoint.domain.type.Location;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.user.domain.User;
 
-import java.math.BigDecimal;
-
 public class StartPointFixture {
 
     public static StartPointRequest getStartPointRequest() {
         return new StartPointRequest(
                 "땡수팟", "선정릉역 수인분당선", "서울특별시 강남구 삼성동 111-114", "서울특별시 강남구 선릉로 지하580",
-                BigDecimal.valueOf(127.043999), BigDecimal.valueOf(37.510297)
+                127.043999, 37.510297
         );
     }
 
@@ -24,7 +23,8 @@ public class StartPointFixture {
                 .user(user)
                 .name("선정릉역 수인분당선")
                 .address(Address.of("서울특별시 강남구 삼성동 111-114", "서울특별시 강남구 선릉로 지하580"))
-                .location(Location.of(BigDecimal.valueOf(127.043999), BigDecimal.valueOf(37.510297)))
+                .location(Location.of(127.043999, 37.510297))
+                .point(CoordinateUtil.createPoint(127.043999, 37.510297))
                 .build();
     }
 

--- a/src/test/java/com/meetup/server/global/clients/google/place/GooglePlaceClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/google/place/GooglePlaceClientTest.java
@@ -9,9 +9,11 @@ import com.meetup.server.global.clients.google.place.search.GoogleSearchTextResp
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@ActiveProfiles("h2")
 @SpringBootTest
 class GooglePlaceClientTest {
 

--- a/src/test/java/com/meetup/server/global/clients/kakao/local/KakaoLocalClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/kakao/local/KakaoLocalClientTest.java
@@ -3,10 +3,12 @@ package com.meetup.server.global.clients.kakao.local;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ActiveProfiles("h2")
 @SpringBootTest
 class KakaoLocalClientTest {
 

--- a/src/test/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClientTest.java
@@ -3,9 +3,11 @@ package com.meetup.server.global.clients.kakao.mobility;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@ActiveProfiles("h2")
 @SpringBootTest
 class KakaoMobilityClientTest {
 

--- a/src/test/java/com/meetup/server/global/clients/odsay/OdsayClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/odsay/OdsayClientTest.java
@@ -4,9 +4,11 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@ActiveProfiles("h2")
 @SpringBootTest
 class OdsayClientTest {
 

--- a/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
+++ b/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
@@ -9,20 +9,19 @@ import com.meetup.server.fixture.UserFixture;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.startpoint.persistence.StartPointRepository;
+import com.meetup.server.support.PostgisContainer;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.persistence.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-class StartPointServiceTest {
+class StartPointServiceTest extends PostgisContainer {
 
     @Autowired
     private StartPointService startPointService;

--- a/src/test/java/com/meetup/server/support/PostgisContainer.java
+++ b/src/test/java/com/meetup/server/support/PostgisContainer.java
@@ -1,0 +1,19 @@
+package com.meetup.server.support;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@ActiveProfiles("postgres")
+@Testcontainers
+@SpringBootTest
+public abstract class PostgisContainer {
+
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgis = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgis/postgis:17-3.5-alpine").asCompatibleSubstituteFor("postgres")
+    );
+}

--- a/src/test/java/com/meetup/server/user/application/UserServiceTest.java
+++ b/src/test/java/com/meetup/server/user/application/UserServiceTest.java
@@ -9,10 +9,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
+@ActiveProfiles("h2")
 @SpringBootTest
 class UserServiceTest {
 

--- a/src/test/java/com/meetup/server/user/implement/UserReaderTest.java
+++ b/src/test/java/com/meetup/server/user/implement/UserReaderTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("h2")
 @SpringBootTest
 class UserReaderTest {
 


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #32 

## 💡 작업 내용
- 최적 경로를 계산하고 이를 통해 중간 지점 지하철역을 계산하는 알고리즘을 만들었습니다
- 지하철 역, 노선도, 환승 정보를 토대로 다익스트라를 이용하여 최적 경로를 계산합니다
- 여러 출발지와 도착지 사이에서 소요 시간과 이동 역 개수를 가지고 계산하며, 이때 표준편차를 이용해 최적의 중간지점을 반환합니다
- PostGIS에서 제공하는 메소드(`st_distance`, `st_dwithin`)를 이용하기 위해, Point 타입의 필드를 추가하였습니다

## 📸 스크린샷
![KakaoTalk_Photo_2025-05-06-18-47-53](https://github.com/user-attachments/assets/4e55462b-77f4-45ba-84e3-dd62f1342e76)

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 지하철 경로 탐색 및 최적 도착역 추천 기능이 추가되었습니다.
    - 출발지와 지하철역 간의 거리 기반 매핑 및 최단 경로 탐색이 가능합니다.
    - 출발지들의 중심 좌표 계산 및 반경 내 지하철역 탐색 기능이 제공됩니다.
    - 출발지 최소 개수, 동일 지하철역 여부, 중간 지점 지하철역 존재 여부 등에 대한 검증 기능이 강화되었습니다.

- **버그 수정**
    - 없음

- **리팩터**
    - 좌표 관련 필드(BigDecimal → double) 및 생성자/레코드/DTO 타입 일관성 개선.
    - 엔티티에 지리정보(Point) 필드 추가 및 활용.

- **테스트**
    - 테스트 픽스처에서 좌표 타입 변경 및 Point 필드 반영.
    - 테스트 환경을 PostGIS 컨테이너 기반으로 전환하고, H2 프로파일 활성화.

- **기타**
    - 도메인별 예외 및 에러 타입 추가.
    - 리포지토리 쿼리 및 반환 타입 개선.
    - Gradle 테스트 의존성 및 GitHub Actions 테스트 워크플로우 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->