### PR TITLE
FEAT: #44 출발지 저장 시 isUser, nonUserName 신규 필드도 함께 저장한다

### DIFF
--- a/src/main/java/com/meetup/server/event/application/RouteService.java
+++ b/src/main/java/com/meetup/server/event/application/RouteService.java
@@ -31,9 +31,9 @@ public class RouteService {
 ) {
         List<StartPoint> startPointList = middlePointResultResponse.startPoints();
 
+        String endStationName = getEndStationName(middlePointResultResponse.event());
         double endX = getEndX(middlePointResultResponse.event());
         double endY = getEndY(middlePointResultResponse.event());
-
 
         List<RouteResponse> routeList = startPointList.stream()
                 .map(startPoint -> fetchPerRouteDetails(
@@ -46,7 +46,7 @@ public class RouteService {
                 ))
                 .toList();
 
-        return RouteResponseList.of(routeList, MeetingPoint.of(getStartPointName(startPointList, startPointId), endX, endY));
+        return RouteResponseList.of(routeList, MeetingPoint.of(endStationName, endX, endY));
     }
 
     private RouteResponse fetchPerRouteDetails(
@@ -67,6 +67,10 @@ public class RouteService {
         return RouteResponse.of(startPoint, startPoint.getUser(), transitRoute, drivingRoute, getIsTransit(startPoint, startPointId));
     }
 
+    private String getEndStationName(Event event) {
+        return event.getSubway().getName();
+    }
+
     private double getEndX(Event event) {
         return event.getSubway().getLocation().getRoadLongitude();
     }
@@ -81,15 +85,6 @@ public class RouteService {
 
     private String getStartY(StartPoint startPoint) {
         return String.valueOf(startPoint.getLocation().getRoadLatitude());
-    }
-
-    private String getStartPointName(List<StartPoint> startPointList, UUID startPointId) {
-        for (StartPoint startPoint : startPointList) {
-            if (startPoint.getStartPointId().equals(startPointId)) {
-                return startPoint.getName();
-            }
-        }
-        return null;
     }
 
     private boolean getIsTransit(StartPoint startPoint, UUID startPointId) {

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
@@ -28,6 +28,8 @@ public class StartPointProcessor {
                 .address(Address.of(startPointRequest.address(), startPointRequest.roadAddress()))
                 .location(Location.of(startPointRequest.longitude(), startPointRequest.latitude()))
                 .point(CoordinateUtil.createPoint(startPointRequest.longitude(), startPointRequest.latitude()))
+                .isUser(user != null)
+                .nonUserName(startPointRequest.username())
                 .build();
 
         return startPointRepository.save(startPoint);


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #44 

## 💡 작업 내용
- StartPoint의 isUser, nonUserName 신규 필드를 같이 저장합니다
- 중간지점 역명이 반환되지 않는 문제가 있어 수정했습니다

## 📸 스크린샷
### 회원
![스크린샷 2025-05-09 오전 3 32 39](https://github.com/user-attachments/assets/9da55772-1ca2-4a40-8f75-384c4e649df4)

### 비회원
![스크린샷 2025-05-09 오전 3 50 07](https://github.com/user-attachments/assets/dc208b23-2600-49d9-b02d-43358c744406)

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 모임 경로 상세 정보에서 모임 장소명이 출발지가 아닌 도착지(지하철역) 이름으로 표시됩니다.

- **기능 개선**
  - 출발지 저장 시, 사용자 여부와 비회원 이름 정보가 함께 저장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->