### PR TITLE
FEAT: #46 사용자 약관 동의 항목을 저장하기

### DIFF
--- a/src/main/java/com/meetup/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
     private final ResponseContextFilter responseContextFilter;
 
     private final String[] BLACK_LIST = {
-            "/historys/**"
+            "/users/**"
     };
 
     @Bean

--- a/src/main/java/com/meetup/server/user/application/UserService.java
+++ b/src/main/java/com/meetup/server/user/application/UserService.java
@@ -4,6 +4,7 @@ import com.meetup.server.user.domain.User;
 import com.meetup.server.user.dto.response.UserProfileInfoResponse;
 import com.meetup.server.user.exception.UserErrorType;
 import com.meetup.server.user.exception.UserException;
+import com.meetup.server.user.implement.AgreementValidator;
 import com.meetup.server.user.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final AgreementValidator agreementValidator;
 
     public UserProfileInfoResponse getUserProfileInfo(Long userId) {
 
@@ -32,7 +34,9 @@ public class UserService {
     }
 
     @Transactional
-    public void saveUserAgreement(Long userId,boolean personalInfoAgreement, boolean marketingAgreement) {
+    public void saveUserAgreement(Long userId, boolean personalInfoAgreement, boolean marketingAgreement) {
+        agreementValidator.validateAgreements(personalInfoAgreement);
+
         User user = getUserById(userId);
         user.updateAgreement(personalInfoAgreement, marketingAgreement);
     }

--- a/src/main/java/com/meetup/server/user/application/UserService.java
+++ b/src/main/java/com/meetup/server/user/application/UserService.java
@@ -30,4 +30,10 @@ public class UserService {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorType.USER_NOT_FOUND));
     }
+
+    @Transactional
+    public void saveUserAgreement(Long userId,boolean personalInfoAgreement, boolean marketingAgreement) {
+        User user = getUserById(userId);
+        user.updateAgreement(personalInfoAgreement, marketingAgreement);
+    }
 }

--- a/src/main/java/com/meetup/server/user/domain/User.java
+++ b/src/main/java/com/meetup/server/user/domain/User.java
@@ -30,21 +30,29 @@ public class User extends BaseEntity {
     @Column(name = "email", length = 255, nullable = false, unique = true)
     private String email;
 
-    @Column(name = "agreement", nullable = false)
-    private boolean agreement;
+    @Column(name = "personal_info_agreement", nullable = false)
+    private boolean personalInfoAgreement;
+
+    @Column(name = "marketing_agreement", nullable = true)
+    private boolean marketingAgreement;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", length = 10, nullable = false)
     private Role role;
 
-
     @Builder
-    public User(String nickname, String profileImage, String email, String socialId, Role role, boolean agreement) {
+    public User(String nickname, String profileImage, String email, String socialId, Role role, boolean personalInfoAgreement, boolean marketingAgreement) {
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.email = email;
         this.socialId = socialId;
-        this.agreement = agreement;
         this.role = role;
+        this.personalInfoAgreement = personalInfoAgreement;
+        this.marketingAgreement = marketingAgreement;
+    }
+
+    public void updateAgreement(boolean personalInfoAgreement, boolean marketingAgreement) {
+        this.personalInfoAgreement = personalInfoAgreement;
+        this.marketingAgreement = marketingAgreement;
     }
 }

--- a/src/main/java/com/meetup/server/user/dto/request/UserAgreementRequest.java
+++ b/src/main/java/com/meetup/server/user/dto/request/UserAgreementRequest.java
@@ -1,0 +1,7 @@
+package com.meetup.server.user.dto.request;
+
+public record UserAgreementRequest(
+        boolean isPersonalInfoAgreement ,
+        boolean isMarketingAgreement
+) {
+}

--- a/src/main/java/com/meetup/server/user/dto/response/UserProfileInfoResponse.java
+++ b/src/main/java/com/meetup/server/user/dto/response/UserProfileInfoResponse.java
@@ -8,7 +8,8 @@ public record UserProfileInfoResponse(
         Long userId,
         String nickname,
         String profileImageUrl,
-        boolean agreement
+        boolean personalInfoAgreement,
+        boolean marketingAgreement
 ) {
     public static UserProfileInfoResponse from(User user) {
 
@@ -16,7 +17,8 @@ public record UserProfileInfoResponse(
                 .userId(user.getUserId())
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImage())
-                .agreement(user.isAgreement())
+                .personalInfoAgreement(user.isPersonalInfoAgreement())
+                .marketingAgreement(user.isMarketingAgreement())
                 .build();
     }
 }

--- a/src/main/java/com/meetup/server/user/exception/UserErrorType.java
+++ b/src/main/java/com/meetup/server/user/exception/UserErrorType.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorType implements ErrorType {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    AGREEMENT_REQUIRED(HttpStatus.BAD_REQUEST, "개인정보 수집 및 이용 동의가 필요합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/user/implement/AgreementValidator.java
+++ b/src/main/java/com/meetup/server/user/implement/AgreementValidator.java
@@ -1,0 +1,17 @@
+package com.meetup.server.user.implement;
+
+import com.meetup.server.user.exception.UserErrorType;
+import com.meetup.server.user.exception.UserException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AgreementValidator {
+
+    public void validateAgreements(boolean personalInfoAgreement) {
+        if (!personalInfoAgreement) {
+            throw new UserException(UserErrorType.AGREEMENT_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/user/persistence/init/UserDummy.java
+++ b/src/main/java/com/meetup/server/user/persistence/init/UserDummy.java
@@ -35,7 +35,8 @@ public class UserDummy implements ApplicationRunner {
                     .role(Role.USER)
                     .socialId("test1")
                     .profileImage("https://example.com/test1.jpg")
-                    .agreement(false)
+                    .personalInfoAgreement(true)
+                    .marketingAgreement(true)
                     .build();
 
             User DUMMY_USER2 = User.builder()
@@ -44,7 +45,8 @@ public class UserDummy implements ApplicationRunner {
                     .role(Role.USER)
                     .socialId("test2")
                     .profileImage("https://example.com/test2.jpg")
-                    .agreement(true)
+                    .personalInfoAgreement(true)
+                    .marketingAgreement(true)
                     .build();
 
             User DUMMY_USER3 = User.builder()
@@ -53,7 +55,8 @@ public class UserDummy implements ApplicationRunner {
                     .role(Role.USER)
                     .socialId("test3")
                     .profileImage("https://example.com/test3.jpg")
-                    .agreement(true)
+                    .personalInfoAgreement(true)
+                    .marketingAgreement(false)
                     .build();
 
             userList.add(DUMMY_USER1);

--- a/src/main/java/com/meetup/server/user/presentation/UserController.java
+++ b/src/main/java/com/meetup/server/user/presentation/UserController.java
@@ -2,15 +2,14 @@ package com.meetup.server.user.presentation;
 
 import com.meetup.server.global.support.response.ApiResponse;
 import com.meetup.server.user.application.UserService;
+import com.meetup.server.user.dto.request.UserAgreementRequest;
 import com.meetup.server.user.dto.response.UserProfileInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @Tag(name = "User API", description = "사용자 API")
@@ -28,5 +27,15 @@ public class UserController {
     ) {
         UserProfileInfoResponse response = userService.getUserProfileInfo(userId);
         return ApiResponse.success(response);
+    }
+
+    @Operation(summary = "유저 약관 동의 저장", description = "유저의 개인정보 이용 동의와 마케팅 이용 동의를 저장합니다")
+    @PostMapping("/agreement")
+    public ApiResponse<?> saveUserAgreement(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UserAgreementRequest request
+    ) {
+        userService.saveUserAgreement(userId, request.isPersonalInfoAgreement(), request.isMarketingAgreement());
+        return ApiResponse.success();
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #46 

## 💡 작업 내용
- 사용자 약관 동의를 진행합니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/127b6857-da4f-4cc1-ae82-6adb0cdb1b8c)


## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 개인정보 수집 및 마케팅 동의 상태를 별도로 저장하고 관리할 수 있는 기능이 추가되었습니다.
    - 사용자는 새로운 동의 저장 엔드포인트를 통해 개인정보 및 마케팅 동의 여부를 개별적으로 제출할 수 있습니다.

- **버그 수정**
    - 기존에 하나로 관리되던 동의 항목이 두 개로 분리되어, 동의 상태가 보다 명확하게 반영됩니다.

- **보안**
    - 사용자 관련 엔드포인트에 대한 인증 보호가 강화되었습니다.

- **기타**
    - 개인정보 수집 동의가 필수임을 안내하는 에러 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->