### PR TITLE
FEAT: #50 JWTFilter 로직을 수정한다

### DIFF
--- a/src/main/java/com/meetup/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SecurityConfig.java
@@ -32,7 +32,9 @@ public class SecurityConfig {
     private final ResponseContextFilter responseContextFilter;
 
     private final String[] BLACK_LIST = {
-            "/users/**"
+            "/historys/**",
+            "/users/**",
+            "/auth/**",
     };
 
     @Bean


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #50 

## 💡 작업 내용
- 기존 분리하여 역할을 나누어 진행했던 Filter 처리 과정에서
 jwtAuthenticationFilter 와 responseContextFilter 의 로직을 일부 통합하여 수정하였습니다

## 📸 스크린샷 
1. refreshToken 만 존재하는 경우
![image](https://github.com/user-attachments/assets/79e26156-e4cf-4783-b15e-e950aebae38e)
![image](https://github.com/user-attachments/assets/c9e9bc93-e83c-49dd-9326-5347f77745a9)

2. accessToken 과 refreshToken 모두 존재하는 경우
![image](https://github.com/user-attachments/assets/8d2b84d0-b1c7-49a8-8ec3-12dd39677726)
![image](https://github.com/user-attachments/assets/677ffbca-f35b-4e99-bc82-d0f0fad34a8b)

3, accessToken 과 refreshToken 모두 존재하지 않는 경우
![image](https://github.com/user-attachments/assets/032f5cc6-b3ae-4f64-b6f9-08a4e37addb5)
![image](https://github.com/user-attachments/assets/302e63f0-a30f-4966-b264-3e87b791f137)

4. 로그아웃 한 경우
![image](https://github.com/user-attachments/assets/c943b939-2da8-4695-86d5-8c478a7513c4)
 로그아웃 이후 상태
![image](https://github.com/user-attachments/assets/0cc1860b-ec55-44ab-be37-676ff3ea6109)

5. Token 만료 된 경우
- 지정 해 놓은 시간에 따라 삭제 됨을 확인했습니다

## 💬리뷰 요구사항
- user table 추가로 인해 공지 후 dev yml create 로 바꾸어야 할 것 같습니다 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 액세스 토큰이 없거나 유효하지 않은 경우, 리프레시 토큰을 통해 자동으로 재인증이 시도되어 사용자 인증 상태가 유지됩니다.
  - 이벤트 경로 응답에 가장 가까운 주차장 정보가 포함되어 편의성이 향상되었습니다.
  - 서울시 공영주차장 데이터를 CSV 파일에서 자동으로 로드하여 주차장 정보가 시스템에 추가되었습니다.

- **버그 수정**
  - 리프레시 토큰이 유효하지 않거나 사용자 인증에 실패할 경우, 관련 쿠키가 삭제되어 보안이 강화되었습니다.

- **보안**
  - "/users/**" 및 "/auth/**" 경로에 대한 인증 요구가 추가되어 접근이 제한됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->