### PR TITLE
Feat: #53 startPointId로 본인 여부 플래그 추가 및 본인 데이터를 0번째 인덱스로 반환하기

### DIFF
--- a/src/main/java/com/meetup/server/event/dto/response/RouteResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/RouteResponse.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 @Builder
 public record RouteResponse(
         boolean isTransit,  // true: 대중교통, false: 자동차
+        boolean isMe,
         UUID id,
         String nickname,
         String profileImage,
@@ -29,9 +30,10 @@ public record RouteResponse(
                                    User user,
                                    OdsayTransitRouteSearchResponse transitResponse,
                                    KakaoMobilityResponse drivingResponse,
-                                   boolean isTransit) {
+                                   boolean isMe) {
         return RouteResponse.builder()
-                .isTransit(isTransit)
+                .isTransit(startPoint.isTransit())
+                .isMe(isMe)
                 .id(startPoint.getStartPointId())
                 .nickname(startPoint.getIsUser() ? user.getNickname() : startPoint.getNonUserName())
                 .profileImage(startPoint.getIsUser() ? user.getProfileImage() : null)
@@ -40,7 +42,7 @@ public record RouteResponse(
                 .startLatitude(startPoint.getLocation().getRoadLatitude())
                 .transitRoute(TransitRouteResponse.from(transitResponse))
                 .drivingRoute(DrivingRouteResponse.from(drivingResponse))
-                .totalTime(isTransit ?
+                .totalTime(startPoint.isTransit() ?
                         transitResponse.data().path().getFirst().info().totalTime()
                         : drivingResponse.routes().getFirst().summary().duration())
                 .build();

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -29,11 +29,8 @@ public class EventController {
     }
 
     @Operation(summary = "지도 조회 API", description = "모임의 중간 지점 계산 및 모임 참여자의 경로 조회를 진행합니다")
-    @GetMapping
-    public ApiResponse<RouteResponseList> getEventMap(
-            @RequestHeader UUID startPointId,
-            @RequestParam UUID eventId
-    ) {
+    @GetMapping("/{eventId}")
+    public ApiResponse<RouteResponseList> getEventMap(@PathVariable UUID eventId, @RequestParam(required = false) UUID startPointId) {
         return ApiResponse.success(eventService.getEventMap(eventId, startPointId));
     }
 }

--- a/src/main/java/com/meetup/server/user/dto/response/UserProfileInfoResponse.java
+++ b/src/main/java/com/meetup/server/user/dto/response/UserProfileInfoResponse.java
@@ -8,6 +8,7 @@ public record UserProfileInfoResponse(
         Long userId,
         String nickname,
         String profileImageUrl,
+        String email,
         boolean personalInfoAgreement,
         boolean marketingAgreement
 ) {
@@ -17,6 +18,7 @@ public record UserProfileInfoResponse(
                 .userId(user.getUserId())
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImage())
+                .email(user.getEmail())
                 .personalInfoAgreement(user.isPersonalInfoAgreement())
                 .marketingAgreement(user.isMarketingAgreement())
                 .build();


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #53 

## 💡 작업 내용
- StartPoint의 id로 본인 여부를 필터링 및 플래그를 추가했습니다
- id가 있을 경우, 본인 데이터를 0번째 인덱스로 반환하였습니다
- 유저 프로필 조회에서 이메일도 반환하도록 하였습니다

## 📸 스크린샷
```json
{
  "result": "SUCCESS",
  "data": {
    "peopleCount": 3,
    "averageTime": 22,
    "meetingPoint": {
      "endStationName": "을지로4가",
      "endLongitude": 126.998122,
      "endLatitude": 37.566611
    },
    "routeResponse": [
      {
        "isTransit": true,
        "isMe": false, // 신규 필드 추가
```

### 이메일 반환 성공 응답
<img width="733" alt="스크린샷 2025-05-11 오전 5 31 03" src="https://github.com/user-attachments/assets/7621a4b3-b34c-44b3-8d69-9720c7d25052" />



## 💬리뷰 요구사항
- `getIsTransit()`에서 로직 상 오류를 발견해서 수정해두었습니다! 확인 바랍니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 사용자 프로필 정보에 이메일 항목이 추가되었습니다.
    - 경로 응답에 내 경로 여부를 나타내는 isMe 표시가 추가되었습니다.

- **개선 사항**
    - 이벤트 지도 조회 시 요청 경로와 파라미터 방식이 변경되어, eventId를 경로 변수로 받고 startPointId는 선택적 쿼리 파라미터로 받을 수 있습니다.
    - 내 경로가 있을 경우 경로 목록에서 가장 앞에 우선적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->