### PR TITLE
FEAT: #56 출발지 등록 시 비회원 방식으로 처리 하고 캐시 무효화를 진행한다 

### DIFF
--- a/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
+++ b/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
@@ -16,6 +16,7 @@ import com.meetup.server.user.domain.User;
 import com.meetup.server.user.implement.UserReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,6 +50,7 @@ public class StartPointService {
     }
 
     @Transactional
+    @CacheEvict(value = "routeDetails", key = "#eventId")
     public EventStartPointResponse createStartPoint(UUID eventId, Long userId, StartPointRequest startPointRequest) {
         Event event = eventReader.read(eventId);
 

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -8,7 +8,7 @@ import com.meetup.server.fixture.UserFixture;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.startpoint.persistence.StartPointRepository;
-import com.meetup.server.support.PostgisContainer;
+import com.meetup.server.support.IntegrationTestContainer;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.persistence.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class EventServiceTest extends PostgisContainer {
+class EventServiceTest extends IntegrationTestContainer {
 
     @Autowired
     private EventService eventService;

--- a/src/test/java/com/meetup/server/event/implement/EventValidatorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventValidatorTest.java
@@ -7,7 +7,7 @@ import com.meetup.server.fixture.EventFixture;
 import com.meetup.server.fixture.StartPointFixture;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.persistence.StartPointRepository;
-import com.meetup.server.support.PostgisContainer;
+import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class EventValidatorTest extends PostgisContainer {
+class EventValidatorTest extends IntegrationTestContainer {
 
     private static final int MAX_START_POINTS = 8;
 

--- a/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
+++ b/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
@@ -9,7 +9,7 @@ import com.meetup.server.fixture.UserFixture;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.startpoint.persistence.StartPointRepository;
-import com.meetup.server.support.PostgisContainer;
+import com.meetup.server.support.IntegrationTestContainer;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.persistence.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class StartPointServiceTest extends PostgisContainer {
+class StartPointServiceTest extends IntegrationTestContainer {
 
     @Autowired
     private StartPointService startPointService;

--- a/src/test/java/com/meetup/server/support/IntegrationTestContainer.java
+++ b/src/test/java/com/meetup/server/support/IntegrationTestContainer.java
@@ -3,6 +3,7 @@ package com.meetup.server.support;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
@@ -10,10 +11,15 @@ import org.testcontainers.utility.DockerImageName;
 @ActiveProfiles("postgres")
 @Testcontainers
 @SpringBootTest
-public abstract class PostgisContainer {
+public abstract class IntegrationTestContainer {
 
     @ServiceConnection
     static PostgreSQLContainer<?> postgis = new PostgreSQLContainer<>(
             DockerImageName.parse("postgis/postgis:17-3.5-alpine").asCompatibleSubstituteFor("postgres")
     );
+
+    @ServiceConnection
+    static GenericContainer<?> redis = new GenericContainer<>(
+            DockerImageName.parse("redis:7.4-alpine").asCompatibleSubstituteFor("redis")
+    ).withExposedPorts(6379);
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #56 

## 💡 작업 내용
- 캐시 무효화를 진행합니다 
- 로그인 된 사용자가 이미 자신의 출발지를 등록한 경우 출발지 등록 시 비회원 방식으로 처리합니다

## 📸 스크린샷
- 로그인 [O] && 자신의 출발지 등록 [X] 
![image](https://github.com/user-attachments/assets/2200f177-57a9-4cc7-aad7-9061d0141ddf)
![image](https://github.com/user-attachments/assets/ba7b0c9b-e52e-4ebe-9a61-cd587716dcd8)

- 로그인 [O] && 자신의 출발지 등록 [O] 
![image](https://github.com/user-attachments/assets/78e47d86-d224-4b6e-b93c-6bc92f810223)
![image](https://github.com/user-attachments/assets/19f38e3b-d8b1-4ea8-a36c-ac3bd990d7a1)

- 모임 참여자 명수 초과 한 경우
![image](https://github.com/user-attachments/assets/f0319085-86f1-47fa-a34e-64dbe9d8f860)
- 로그를 통해 redis 삭제 진행 안됨을 확인했습니다


## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이벤트에 대한 출발지 생성 시, 로그인된 사용자의 상태에 따라 출발지 저장 방식이 달라집니다.
- **버그 수정**
    - 출발지 생성 후 관련 경로 정보 캐시가 자동으로 갱신됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->