### PR TITLE
FIX: #60 여러 호선을 가진 지하철이 하나만 반환되도록 수정하기

### DIFF
--- a/src/main/java/com/meetup/server/subway/implement/reader/SubwayReader.java
+++ b/src/main/java/com/meetup/server/subway/implement/reader/SubwayReader.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -13,6 +14,8 @@ import java.util.List;
 public class SubwayReader {
 
     private static final double NEAREST_SUBWAY_RADIUS_M = 1500;
+    private static final double MAX_SEARCH_RADIUS_M = 5000;
+    private static final double RADIUS_INCREMENT_M = 500;
 
     private final SubwayRepository subwayRepository;
 
@@ -29,6 +32,20 @@ public class SubwayReader {
     }
 
     public List<Subway> readNearbySubways(Point centerPoint) {
-        return readAllWithinRadius(centerPoint, NEAREST_SUBWAY_RADIUS_M);
+        double radius = NEAREST_SUBWAY_RADIUS_M;
+
+        List<Subway> nearbySubways = new ArrayList<>();
+
+        while (radius <= MAX_SEARCH_RADIUS_M) {
+            nearbySubways = readAllWithinRadius(centerPoint, radius);
+
+            if (!nearbySubways.isEmpty()) {
+                break;
+            }
+
+            radius += RADIUS_INCREMENT_M;
+        }
+
+        return nearbySubways;
     }
 }

--- a/src/main/java/com/meetup/server/subway/persistence/SubwayRepository.java
+++ b/src/main/java/com/meetup/server/subway/persistence/SubwayRepository.java
@@ -17,13 +17,15 @@ public interface SubwayRepository extends JpaRepository<Subway, Integer> {
 
     Optional<Subway> findByCode(Integer code);
 
-    @Query("""
-                SELECT s
-                FROM Subway s
-                WHERE st_distance(s.point, :startPoint) = (
-                    SELECT MIN(st_distance(s2.point, :startPoint))
-                    FROM Subway s2)
-            """)
+    @Query(value = """
+                SELECT s.*
+                FROM subway s
+                WHERE ST_Distance(s.point, :startPoint) = (
+                    SELECT MIN(ST_Distance(s2.point, :startPoint))
+                    FROM subway s2
+                )
+                LIMIT 1
+            """, nativeQuery = true)
     Subway findClosestSubway(@Param("startPoint") Point startPoint);
 
     @Query("""


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #60 

## 💡 작업 내용
### 중복 지하철역 문제 해결
- 동일한 이름을 가진 지하철역이 여러 호선에 걸쳐 존재하여, 특정 상황에서 중복 조회로 인한 예외가 발생하였습니다.
-> LIMIT 1을 사용하여 가장 가까운 지하철역 1개만 반환하도록 수정하였습니다.

### 반경 내 지하철역 미존재 시 예외 처리 개선
- 기존에는 중심 좌표로부터 반경 1500m 내에 지하철역이 없을 경우, 예외가 발생했습니다.
- 서비스 특성상 무조건 지하철역을 반환하는 것이 맞다고 판단하여, 1500m → 5000m까지 반경을 점진적으로 확장하며 지하철역을 탐색하는 방식으로 변경했습니다.

## 📸 스크린샷
### AS-IS
![스크린샷 2025-05-14 오후 6 29 35](https://github.com/user-attachments/assets/2df59736-be0f-4626-a3fc-335840403d84)

### TO-BE
<img width="728" alt="스크린샷 2025-05-14 오후 6 29 16" src="https://github.com/user-attachments/assets/7c16986e-d634-4446-9eeb-f6b310edb1af" />

## 💬리뷰 요구사항
- 최대 반경 거리(`MAX_SEARCH_RADIUS_M`)와 증가량(`RADIUS_INCREMENT_M`)을 임의로 설정해 두었는데 괜찮은지 확인해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 지하철역 검색 시 반경 내 결과가 없을 경우, 최대 5km까지 점진적으로 반경을 넓혀 재검색하도록 개선되었습니다.
	- 가장 가까운 지하철역을 찾는 기능의 정확도가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->