### PR TITLE
FEAT: #63 모임생성자를 추가한다

### DIFF
--- a/src/main/java/com/meetup/server/event/application/EventCacheService.java
+++ b/src/main/java/com/meetup/server/event/application/EventCacheService.java
@@ -23,7 +23,7 @@ public class EventCacheService {
     private final EventReader eventReader;
     private final EventProcessor eventProcessor;
 
-    @Cacheable(value = "routeDetails", key = "#eventId")
+    @Cacheable(value = "routeDetails", key = "#eventId", unless = "#result == null")
     public RouteResponseList getEventMap(UUID eventId) {
         MiddlePointResultResponse result = middlePointService.getMiddlePoint(eventId);
         return routeService.getAllRouteDetails(result.event(), result.startPoints());
@@ -36,5 +36,4 @@ public class EventCacheService {
         eventProcessor.updateTransitForStartPoint(routeResponseList, startPointId, isTransit);
         return routeResponseList;
     }
-
 }

--- a/src/main/java/com/meetup/server/event/application/RouteDetailService.java
+++ b/src/main/java/com/meetup/server/event/application/RouteDetailService.java
@@ -34,5 +34,4 @@ public class RouteDetailService {
 
         return RouteResponse.of(startPoint, startPoint.getUser(), transitRoute, drivingRoute);
     }
-
 }

--- a/src/main/java/com/meetup/server/event/application/RouteService.java
+++ b/src/main/java/com/meetup/server/event/application/RouteService.java
@@ -8,6 +8,7 @@ import com.meetup.server.event.implement.EventLocationInfoFinder;
 import com.meetup.server.parkinglot.dto.ClosestParkingLot;
 import com.meetup.server.parkinglot.implement.ParkingLotFinder;
 import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.implement.StartPointReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ public class RouteService {
     private final ParkingLotFinder parkingLotFinder;
     private final RouteDetailService routeDetailService;
     private final EventLocationInfoFinder eventLocationInfoFinder;
+    private final StartPointReader startPointReader;
 
     public RouteResponseList getAllRouteDetails(Event event, List<StartPoint> startPointList) {
 
@@ -42,7 +44,7 @@ public class RouteService {
 
         ClosestParkingLot closestParkingLot = parkingLotFinder.findClosestParkingLot(event.getSubway().getPoint());
 
-        return RouteResponseList.of(routeList, MeetingPoint.of(endStationName, endX, endY), closestParkingLot);
+        String eventMaker = startPointReader.readName(event.getEventId());
+        return RouteResponseList.of(eventMaker, routeList, MeetingPoint.of(endStationName, endX, endY), closestParkingLot);
     }
-
 }

--- a/src/main/java/com/meetup/server/event/dto/response/RouteResponseList.java
+++ b/src/main/java/com/meetup/server/event/dto/response/RouteResponseList.java
@@ -14,14 +14,16 @@ import java.util.List;
 @AllArgsConstructor
 public class RouteResponseList {
 
+    private String eventMaker;
     private int peopleCount;
     private int averageTime;
     private MeetingPoint meetingPoint;
     private List<RouteResponse> routeResponse;
     private ParkingLotResponse parkingLot;
 
-    public static RouteResponseList of(List<RouteResponse> routeResponse, MeetingPoint meetingPoint, ClosestParkingLot closestParkingLot) {
+    public static RouteResponseList of(String eventMaker, List<RouteResponse> routeResponse, MeetingPoint meetingPoint, ClosestParkingLot closestParkingLot) {
         return RouteResponseList.builder()
+                .eventMaker(eventMaker)
                 .averageTime(calculateAverageTime(routeResponse))
                 .peopleCount(routeResponse.size())
                 .meetingPoint(meetingPoint)

--- a/src/main/java/com/meetup/server/event/persistence/EventRepository.java
+++ b/src/main/java/com/meetup/server/event/persistence/EventRepository.java
@@ -6,6 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface EventRepository extends JpaRepository<Event, UUID> {
-
-
 }

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
@@ -25,4 +25,8 @@ public class StartPointReader {
         return startPointRepository.findById(startPointId)
                 .orElseThrow(() -> new StartPointException(StartPointErrorType.PLACE_NOT_FOUND));
     }
+
+    public String readName(UUID eventId) {
+        return startPointRepository.findTopByEventIdOrderByCreatedAtAsc(eventId).getNonUserName();
+    }
 }

--- a/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
+++ b/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
@@ -15,4 +15,13 @@ public interface StartPointRepository extends JpaRepository<StartPoint, UUID> {
 
     @Query("SELECT DISTINCT s FROM StartPoint s JOIN FETCH s.event WHERE s.event = :event")
     List<StartPoint> findAllByEvent(@Param("event") Event event);
+
+    @Query("""
+                SELECT s
+                FROM StartPoint s
+                WHERE s.event.eventId = :eventId
+                ORDER BY s.createdAt ASC
+                LIMIT 1
+            """)
+    StartPoint findTopByEventIdOrderByCreatedAtAsc(@Param("eventId") UUID eventId);
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #63 

## 💡 작업 내용
- response 에 모임 생성자의 이름을 반환하도록 진행했습니다.
- Notion에 있는 지도 조회 api 명세서에 해당 수정 사항을 추가하여 진행했습니다 

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/065cd0c0-ea1a-4a97-ad08-8816db558efb)


## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 이벤트 상세 정보에 이벤트 개설자 이름이 추가되어 표시됩니다.

- **버그 수정**
    - 이벤트 경로 정보가 없는 경우 캐시되지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->