### PR TITLE
FIX: #65 출발지 검색 시 서울 지역만 검색되도록 필터링한다

### DIFF
--- a/src/main/java/com/meetup/server/global/clients/kakao/local/KakaoLocalResponse.java
+++ b/src/main/java/com/meetup/server/global/clients/kakao/local/KakaoLocalResponse.java
@@ -1,39 +1,55 @@
 package com.meetup.server.global.clients.kakao.local;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
 
-public record KakaoLocalResponse(
-        @JsonProperty("meta") KakaoSearchMeta kakaoSearchMeta,
-        @JsonProperty("documents") KakaoSearchResponse[] kakaoSearchResponses
-) {
+import java.util.List;
 
-    public record KakaoSearchMeta(
-            @JsonProperty("total_count") Integer totalCount,
-            @JsonProperty("pageable_count") Integer pageableCount,
-            @JsonProperty("is_end") Boolean isEnd,
-            @JsonProperty("same_name") SameName sameName
-    ) {
-        public record SameName(
-                String[] region,
-                String keyword,
-                @JsonProperty("selected_region") String selectedRegion
-        ) {
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoLocalResponse {
+    @JsonProperty("meta")
+    private KakaoSearchMeta kakaoSearchMeta;
+    @JsonProperty("documents")
+    private List<KakaoSearchResponse> kakaoSearchResponses;
+
+    @Getter
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class KakaoSearchMeta {
+        private Integer totalCount;
+        private Integer pageableCount;
+        private Boolean isEnd;
+        private SameName sameName;
+
+        @Getter
+        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+        public static class SameName {
+            private List<String> region;
+            private String keyword;
+            private String selectedRegion;
         }
     }
 
-    public record KakaoSearchResponse(
-            String id,
-            @JsonProperty("place_name") String placeName,
-            @JsonProperty("category_name") String categoryName,
-            @JsonProperty("category_group_code") String categoryGroupCode,
-            @JsonProperty("category_group_name") String categoryGroupName,
-            String phone,
-            @JsonProperty("address_name") String addressName,
-            @JsonProperty("road_address_name") String roadAddressName,
-            String x,
-            String y,
-            @JsonProperty("place_url") String placeUrl,
-            String distance
-    ) {
+    @Getter
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class KakaoSearchResponse {
+        private String id;
+        private String placeName;
+        private String categoryName;
+        private String categoryGroupCode;
+        private String categoryGroupName;
+        private String phone;
+        private String addressName;
+        private String roadAddressName;
+        private String x;
+        private String y;
+        private String placeUrl;
+        private String distance;
+    }
+
+    public void updateKakaoSearchResponse(List<KakaoSearchResponse> kakaoSearchResponses) {
+        this.kakaoSearchResponses = kakaoSearchResponses;
     }
 }

--- a/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
+++ b/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
@@ -3,15 +3,12 @@ package com.meetup.server.startpoint.application;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.implement.EventReader;
-import com.meetup.server.global.clients.kakao.local.KakaoLocalKeywordClient;
-import com.meetup.server.global.clients.kakao.local.KakaoLocalRequest;
 import com.meetup.server.global.clients.kakao.local.KakaoLocalResponse;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
-import com.meetup.server.startpoint.exception.StartPointErrorType;
-import com.meetup.server.startpoint.exception.StartPointException;
 import com.meetup.server.startpoint.implement.StartPointProcessor;
 import com.meetup.server.startpoint.implement.StartPointReader;
+import com.meetup.server.startpoint.implement.StartPointSearcher;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.implement.UserReader;
 import lombok.RequiredArgsConstructor;
@@ -29,24 +26,14 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class StartPointService {
 
-    private final KakaoLocalKeywordClient kakaoLocalKeywordClient;
+    private final StartPointReader startPointReader;
     private final StartPointProcessor startPointProcessor;
+    private final StartPointSearcher startPointSearcher;
     private final EventReader eventReader;
     private final UserReader userReader;
-    private final StartPointReader startPointReader;
 
     public KakaoLocalResponse searchStartPoint(String textQuery) {
-
-        KakaoLocalResponse response = kakaoLocalKeywordClient.sendRequest(
-                KakaoLocalRequest.builder()
-                        .query(textQuery)
-                        .build()
-        );
-
-        if (response == null) {
-            throw new StartPointException(StartPointErrorType.PLACE_NOT_FOUND);
-        }
-        return response;
+        return startPointSearcher.search(textQuery);
     }
 
     @Transactional

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointSearcher.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointSearcher.java
@@ -1,0 +1,50 @@
+package com.meetup.server.startpoint.implement;
+
+import com.meetup.server.global.clients.kakao.local.KakaoLocalKeywordClient;
+import com.meetup.server.global.clients.kakao.local.KakaoLocalRequest;
+import com.meetup.server.global.clients.kakao.local.KakaoLocalResponse;
+import com.meetup.server.global.clients.kakao.local.KakaoLocalResponse.KakaoSearchResponse;
+import com.meetup.server.startpoint.exception.StartPointErrorType;
+import com.meetup.server.startpoint.exception.StartPointException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class StartPointSearcher {
+
+    private static final String SEOUL = "서울";
+
+    private final KakaoLocalKeywordClient kakaoLocalKeywordClient;
+
+    public KakaoLocalResponse search(String textQuery) {
+        KakaoLocalResponse response = kakaoLocalKeywordClient.sendRequest(
+                KakaoLocalRequest.builder()
+                        .query(textQuery)
+                        .build()
+        );
+        if (response == null) {
+            throw new StartPointException(StartPointErrorType.PLACE_NOT_FOUND);
+        }
+
+        List<KakaoSearchResponse> filteredSeoulResponse = response.getKakaoSearchResponses().stream()
+                .filter(this::isSeoulAddress)
+                .toList();
+        response.updateKakaoSearchResponse(filteredSeoulResponse);
+        return response;
+    }
+
+    private boolean isSeoulAddress(KakaoSearchResponse response) {
+        String address = response.getAddressName();
+        if (address == null || address.isBlank()) {
+            return false;
+        }
+
+        int spaceIdx = address.indexOf(' ');
+        String firstWord = (spaceIdx == -1) ? address : address.substring(0, spaceIdx);
+        return SEOUL.equals(firstWord);
+    }
+
+}

--- a/src/test/java/com/meetup/server/global/clients/kakao/local/KakaoLocalClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/kakao/local/KakaoLocalClientTest.java
@@ -5,8 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ActiveProfiles("h2")
 @SpringBootTest
@@ -31,7 +31,7 @@ class KakaoLocalClientTest {
 
         // then
         assertNotNull(response);
-        assertTrue(response.kakaoSearchResponses().length > 0);
+        assertFalse(response.getKakaoSearchResponses().isEmpty());
     }
 
     @Test
@@ -48,6 +48,6 @@ class KakaoLocalClientTest {
 
         // then
         assertNotNull(response);
-        assertTrue(response.kakaoSearchResponses().length > 0);
+        assertFalse(response.getKakaoSearchResponses().isEmpty());
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #65 

## 💡 작업 내용
- 카카오 Local 검색 시, 서울시의 데이터만 필터링하여 반환하도록 변경하였습니다.
- 반환 클래스는 서울 데이터로 필터링되어 갱신되기 때문에 클래스로 변경하였습니다.
- split()을 사용하려 했으나, 내부에서 Pattern 인스턴스가 매번 생성되는 문제가 발생하여 index를 구해 substring()으로 구하는 방식을 선택했습니다.

## 📸 스크린샷
### 왼쪽 (TO-BE), 오른쪽 (AS-IS)
![스크린샷 2025-05-15 오후 1 26 53](https://github.com/user-attachments/assets/b90372fb-8b21-4a7f-a35f-6feecd9deac8)

### `split()`으로 필터링
<img width="841" alt="스크린샷 2025-05-15 오전 10 46 04" src="https://github.com/user-attachments/assets/3a5c6729-f9ea-4c5c-a4f5-df57fe557b02" />

### `indexOf() + substring()` 으로 필터링
<img width="835" alt="스크린샷 2025-05-15 오전 10 42 02" src="https://github.com/user-attachments/assets/a7ee5b72-f2c0-4b82-b437-d4b03201daa6" />

3배 이상의 TPS가 향상한 것으로 보아 `split()`은 주의해서 쓰면 좋겠네요!

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
  - KakaoLocalResponse 및 관련 데이터 구조가 불변 record에서 가변 클래스 구조로 변경되었습니다.
  - StartPointService의 내부 검색 로직이 StartPointSearcher 컴포넌트로 위임되었습니다.
  - StartPointSearcher가 새롭게 추가되어, 검색 결과에서 서울 주소만 필터링하여 반환합니다.

- **테스트**
  - KakaoLocalResponse의 검색 결과 검증 방식이 배열 길이 확인에서 리스트 비어있음 확인으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->