### PR TITLE
FEAT: #78 모임 장소 확정 및 변경하기

### DIFF
--- a/src/main/java/com/meetup/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/meetup/server/auth/presentation/AuthController.java
@@ -18,13 +18,13 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "Access Token 발급", description = "Swagger Test 를 위한 Access Token을 발급합니다.")
+    @Operation(summary = "Test 를 위한 Access Token 발급", description = "Swagger Test 를 위한 Access Token을 발급합니다.")
     @GetMapping("/test/{userId}")
     public String getAccessToken(@PathVariable Long userId) {
         return authService.createAccessTokenForUser(userId);
     }
 
-    @Operation(summary = "로그아웃", description = "사용자 로그아웃을 진행합니다.")
+    @Operation(summary = "로그아웃 API", description = "사용자 로그아웃을 진행합니다.")
     @PostMapping("/logout")
     public ApiResponse<?> logout(HttpServletResponse response) {
         authService.logout(response);

--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -43,4 +43,19 @@ public class Event extends BaseEntity {
     public void updateSubway(Subway subway) {
         this.subway = subway;
     }
+
+    public void confirmPlace(Place place) {
+        this.place = place;
+    }
+
+    public void updatePlace(Place place) {
+        if (this.place.getId().equals(place.getId())) {
+            return;
+        }
+        this.place = place;
+    }
+
+    public boolean hasNoPlace() {
+        return this.place == null;
+    }
 }

--- a/src/main/java/com/meetup/server/place/application/PlaceService.java
+++ b/src/main/java/com/meetup/server/place/application/PlaceService.java
@@ -1,0 +1,34 @@
+package com.meetup.server.place.application;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.implement.EventReader;
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.implement.PlaceReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PlaceService {
+
+    private final EventReader eventReader;
+    private final PlaceReader placeReader;
+
+    @Transactional
+    public void confirmPlace(UUID eventId, UUID placeId) {
+        Event event = eventReader.read(eventId);
+        Place place = placeReader.read(placeId);
+
+        if (event.hasNoPlace()) {
+            event.confirmPlace(place);
+        } else {
+            event.updatePlace(place);
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/place/exception/PlaceErrorType.java
+++ b/src/main/java/com/meetup/server/place/exception/PlaceErrorType.java
@@ -1,0 +1,17 @@
+package com.meetup.server.place.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlaceErrorType implements ErrorType {
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+
+    private final String message;
+}

--- a/src/main/java/com/meetup/server/place/exception/PlaceException.java
+++ b/src/main/java/com/meetup/server/place/exception/PlaceException.java
@@ -1,0 +1,11 @@
+package com.meetup.server.place.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+
+public class PlaceException extends GlobalException {
+
+    public PlaceException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/meetup/server/place/implement/PlaceReader.java
+++ b/src/main/java/com/meetup/server/place/implement/PlaceReader.java
@@ -1,0 +1,22 @@
+package com.meetup.server.place.implement;
+
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.exception.PlaceErrorType;
+import com.meetup.server.place.exception.PlaceException;
+import com.meetup.server.place.persistence.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PlaceReader {
+
+    private final PlaceRepository placeRepository;
+
+    public Place read(UUID placeId) {
+        return placeRepository.findById(placeId)
+                .orElseThrow(() -> new PlaceException(PlaceErrorType.PLACE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/meetup/server/place/presentation/PlaceController.java
+++ b/src/main/java/com/meetup/server/place/presentation/PlaceController.java
@@ -1,0 +1,31 @@
+package com.meetup.server.place.presentation;
+
+import com.meetup.server.global.support.response.ApiResponse;
+import com.meetup.server.place.application.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Slf4j
+@Tag(name = "Place API", description = "장소 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/places")
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @Operation(summary = "모임 장소 확정 및 변경 API", description = "모임 ID와 장소 ID를 통해 모임 장소를 확정/변경합니다.")
+    @PostMapping("/{placeId}")
+    public ApiResponse<?> confirmPlace(
+            @PathVariable UUID placeId,
+            @RequestParam UUID eventId
+    ) {
+        placeService.confirmPlace(eventId, placeId);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/meetup/server/startpoint/presentation/StartPointController.java
+++ b/src/main/java/com/meetup/server/startpoint/presentation/StartPointController.java
@@ -21,7 +21,7 @@ public class StartPointController {
 
     private final StartPointService startPointService;
 
-    @Operation(summary = "장소 검색하기", description = "외부 API를 통해 장소를 검색합니다.")
+    @Operation(summary = "장소 검색 API", description = "외부 API를 통해 장소를 검색합니다.")
     @GetMapping("/start-points/search")
     public ApiResponse<KakaoLocalResponse> searchStartPoint(
             @RequestParam(name = "textQuery") String textQuery) {

--- a/src/main/java/com/meetup/server/user/presentation/UserController.java
+++ b/src/main/java/com/meetup/server/user/presentation/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "유저 프로필 정보", description = "유저의 프로필 정보를 조회합니다")
+    @Operation(summary = "사용자 프로필 정보 조회 API", description = "유저의 프로필 정보를 조회합니다")
     @GetMapping("")
     public ApiResponse<?> getUserProfileInfo(
             @AuthenticationPrincipal Long userId
@@ -32,7 +32,7 @@ public class UserController {
         return ApiResponse.success(response);
     }
 
-    @Operation(summary = "유저 약관 동의 저장", description = "유저의 개인정보 이용 동의와 마케팅 이용 동의를 저장합니다")
+    @Operation(summary = "사용자 약관 동의 저장 API", description = "사용자의 개인정보 이용 동의와 마케팅 이용 동의를 저장합니다")
     @PostMapping("/agreement")
     public ApiResponse<?> saveUserAgreement(
             @AuthenticationPrincipal Long userId,
@@ -42,7 +42,7 @@ public class UserController {
         return ApiResponse.success();
     }
 
-    @Operation(summary = "유저 참여 모임 리스트 조회", description = "유저가 참여한 모임 리스트를 조회합니다")
+    @Operation(summary = "모임 히스토리 리스트 조회 API", description = "로그인 한 사용자가 참여한 모임 리스트를 조회합니다")
     @GetMapping("/events")
     public ApiResponse<List<UserEventHistoryResponse>> getUserEventHistory(
             @AuthenticationPrincipal Long userId


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #78 

## 💡 작업 내용
- 모임 장소를 확정 및 변경을 하나의 메서드로 통합하여 진행했습니다
- 모임 장소 변경 시 동일한 id 인 경우 중복 변경 되지 않도록 진행했습니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/ff7d0132-16f1-4888-b96e-a6563bfcd968)


## 💬리뷰 요구사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이벤트에 장소를 확정하거나 변경할 수 있는 API 엔드포인트가 추가되었습니다.
  - 장소 관련 예외 및 오류 메시지가 추가되었습니다.
  - 이벤트에 장소를 할당하거나 수정하는 기능이 도입되었습니다.

- **문서화**
  - 인증, 시작지점, 사용자 관련 API의 Swagger 문서 요약 및 설명이 더 명확하고 일관성 있게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->