### PR TITLE
FEAT: #81 장소 상세 조회를 진행하기

### DIFF
--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -54,5 +54,4 @@ public class Event extends BaseEntity {
         }
         this.place = place;
     }
-
 }

--- a/src/main/java/com/meetup/server/place/dto/response/GoogleReviewResponse.java
+++ b/src/main/java/com/meetup/server/place/dto/response/GoogleReviewResponse.java
@@ -1,0 +1,34 @@
+package com.meetup.server.place.dto.response;
+
+import com.meetup.server.place.domain.value.GoogleReview;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.List;
+import java.util.Locale;
+
+@Builder
+public record GoogleReviewResponse(
+        String nickname,
+        String profileImage,
+        LocalDate date,
+        String day,
+        String content
+) {
+    public static GoogleReviewResponse from(GoogleReview googleReview) {
+        return GoogleReviewResponse.builder()
+                .nickname(googleReview.author())
+                .profileImage(googleReview.authorProfileImage())
+                .date(googleReview.publishTime().toLocalDate())
+                .day(googleReview.publishTime().getDayOfWeek().getDisplayName(TextStyle.SHORT_STANDALONE, Locale.KOREAN))
+                .content(googleReview.content())
+                .build();
+    }
+
+    public static List<GoogleReviewResponse> fromList(List<GoogleReview> googleReviews) {
+        return googleReviews.stream()
+                .map(GoogleReviewResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/meetup/server/place/dto/response/PlaceDetailResponse.java
+++ b/src/main/java/com/meetup/server/place/dto/response/PlaceDetailResponse.java
@@ -1,0 +1,63 @@
+package com.meetup.server.place.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.domain.type.PlaceCategory;
+import com.meetup.server.place.domain.value.Image;
+import com.meetup.server.review.domain.value.PlaceScore;
+import com.meetup.server.review.persistence.projection.PlaceQuietnessWithRating;
+import lombok.Builder;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+@Builder
+public record PlaceDetailResponse(
+        UUID id,
+        String kakaoPlaceId,
+        PlaceCategory category,
+        String name,
+        List<String> images,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime openTime,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime closeTime,
+        int distance,
+        Double averageRating,
+        PlaceQuietnessResponse placeQuietnessResponse,
+        PlaceScore placeScore,
+        List<ReviewResponse> reviews,
+        List<GoogleReviewResponse> googleReviews,
+        boolean isConfirmed,
+        boolean isChanged
+) {
+    public static PlaceDetailResponse of(Place place,
+                                         PlaceResponse placeResponse,
+                                         PlaceQuietnessWithRating placeQuietnessWithRating,
+                                         List<ReviewResponse> reviewResponses,
+                                         List<GoogleReviewResponse> googleReviewResponses,
+                                         boolean isConfirmed,
+                                         boolean isChanged) {
+
+        return PlaceDetailResponse.builder()
+                .id(placeResponse.id())
+                .kakaoPlaceId(place.getKakaoPlaceId())
+                .category(placeResponse.category())
+                .name(placeResponse.name())
+                .images(place.getImages().stream()
+                        .map(Image::photoUri)
+                        .toList())
+                .openTime(placeResponse.openTime())
+                .closeTime(placeResponse.closeTime())
+                .distance(placeResponse.distance())
+                .averageRating(placeResponse.averageRating())
+                .placeScore(placeResponse.placeScore())
+                .placeQuietnessResponse(PlaceQuietnessResponse.from(placeQuietnessWithRating))
+                .reviews(reviewResponses)
+                .googleReviews(googleReviewResponses)
+                .isConfirmed(isConfirmed)
+                .isChanged(isChanged)
+                .build();
+    }
+}

--- a/src/main/java/com/meetup/server/place/dto/response/PlaceQuietnessResponse.java
+++ b/src/main/java/com/meetup/server/place/dto/response/PlaceQuietnessResponse.java
@@ -1,0 +1,26 @@
+package com.meetup.server.place.dto.response;
+
+import com.meetup.server.review.persistence.projection.PlaceQuietnessWithRating;
+
+public record PlaceQuietnessResponse(
+        Integer morning,
+        Integer lunch,
+        Integer night
+) {
+    public static PlaceQuietnessResponse from(PlaceQuietnessWithRating rating) {
+        if (rating == null) {
+            return new PlaceQuietnessResponse(null, null, null);
+        }
+
+        return new PlaceQuietnessResponse(
+                roundQuietnessOrElseNull(rating.morning()),
+                roundQuietnessOrElseNull(rating.lunch()),
+                roundQuietnessOrElseNull(rating.night())
+        );
+    }
+
+    private static Integer roundQuietnessOrElseNull(Double value) {
+        if (value == null) return null;
+        return (int) Math.round(value);
+    }
+}

--- a/src/main/java/com/meetup/server/place/dto/response/ReviewResponse.java
+++ b/src/main/java/com/meetup/server/place/dto/response/ReviewResponse.java
@@ -1,0 +1,34 @@
+package com.meetup.server.place.dto.response;
+
+import com.meetup.server.review.domain.Review;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.List;
+import java.util.Locale;
+
+@Builder
+public record ReviewResponse(
+        String nickname,
+        String profileImage,
+        LocalDate date,
+        String day,
+        String content
+) {
+    public static ReviewResponse from(Review review) {
+        return ReviewResponse.builder()
+                .nickname(review.getUser().getNickname())
+                .profileImage(review.getUser().getProfileImage())
+                .date(review.getCreatedAt().toLocalDate())
+                .day(review.getCreatedAt().getDayOfWeek().getDisplayName(TextStyle.SHORT_STANDALONE, Locale.KOREAN))
+                .content(review.getVisitedReview().getContent())
+                .build();
+    }
+
+    public static List<ReviewResponse> fromList(List<Review> reviews) {
+        return reviews.stream()
+                .map(ReviewResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/meetup/server/place/implement/PlaceSorter.java
+++ b/src/main/java/com/meetup/server/place/implement/PlaceSorter.java
@@ -1,6 +1,8 @@
 package com.meetup.server.place.implement;
 
+import com.meetup.server.place.domain.value.GoogleReview;
 import com.meetup.server.place.dto.response.PlaceResponse;
+import com.meetup.server.review.domain.Review;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -25,5 +27,17 @@ public class PlaceSorter {
         mergedPlaceResponses.addAll(placeResponsesWithReview);
         mergedPlaceResponses.addAll(placeResponsesWithoutReview);
         return mergedPlaceResponses;
+    }
+
+    public List<Review> sortSpotReviewsByNewest(List<Review> reviews) {
+        return reviews.stream()
+                .sorted(Comparator.comparing(Review::getCreatedAt).reversed())
+                .toList();
+    }
+
+    public List<GoogleReview> sortGoogleReviewByNewest(List<GoogleReview> googleReviews) {
+        return googleReviews.stream()
+                .sorted(Comparator.comparing(GoogleReview::publishTime).reversed())
+                .toList();
     }
 }

--- a/src/main/java/com/meetup/server/place/presentation/PlaceController.java
+++ b/src/main/java/com/meetup/server/place/presentation/PlaceController.java
@@ -2,6 +2,7 @@ package com.meetup.server.place.presentation;
 
 import com.meetup.server.global.support.response.ApiResponse;
 import com.meetup.server.place.application.PlaceService;
+import com.meetup.server.place.dto.response.PlaceDetailResponse;
 import com.meetup.server.place.dto.response.PlaceResponseList;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,5 +35,14 @@ public class PlaceController {
     @GetMapping
     public ApiResponse<PlaceResponseList> getAllPlaces(@RequestParam UUID eventId) {
         return ApiResponse.success(placeService.getAllPlaces(eventId));
+    }
+
+    @Operation(summary = "장소 상세 조회 API", description = "장소 ID를 통해 장소의 상세 정보를 조회합니다.")
+    @GetMapping("/{placeId}")
+    public ApiResponse<PlaceDetailResponse> getPlaceDetails(
+            @PathVariable UUID placeId,
+            @RequestParam UUID eventId
+    ) {
+        return ApiResponse.success(placeService.getPlace(eventId, placeId));
     }
 }

--- a/src/main/java/com/meetup/server/review/implement/ReviewReader.java
+++ b/src/main/java/com/meetup/server/review/implement/ReviewReader.java
@@ -4,6 +4,7 @@ import com.meetup.server.place.domain.Place;
 import com.meetup.server.review.domain.Review;
 import com.meetup.server.review.persistence.ReviewRepository;
 import com.meetup.server.review.persistence.VisitedReviewRepository;
+import com.meetup.server.review.persistence.projection.PlaceQuietnessWithRating;
 import com.meetup.server.review.persistence.projection.PlaceWithRating;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -33,5 +34,9 @@ public class ReviewReader {
         return readPlaceRatings(placeIds)
                 .stream()
                 .collect(Collectors.toMap(PlaceWithRating::place, Function.identity()));
+    }
+
+    public PlaceQuietnessWithRating readQuietnessRating(UUID placeId) {
+        return visitedReviewRepository.findQuietnessRatingByPlaceId(placeId);
     }
 }

--- a/src/main/java/com/meetup/server/review/persistence/VisitedReviewRepository.java
+++ b/src/main/java/com/meetup/server/review/persistence/VisitedReviewRepository.java
@@ -1,6 +1,7 @@
 package com.meetup.server.review.persistence;
 
 import com.meetup.server.review.domain.VisitedReview;
+import com.meetup.server.review.persistence.projection.PlaceQuietnessWithRating;
 import com.meetup.server.review.persistence.projection.PlaceWithRating;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -23,4 +24,16 @@ public interface VisitedReviewRepository extends JpaRepository<VisitedReview, Lo
                 GROUP BY vr.review.place
             """)
     List<PlaceWithRating> findPlaceRatingsByPlaceIds(@Param("placeIds") List<UUID> placeIds);
+
+
+    @Query("""
+                SELECT new com.meetup.server.review.persistence.projection.PlaceQuietnessWithRating(
+                    AVG(CASE WHEN vr.visitedTime = 'MORNING' THEN vr.placeScore.quiet ELSE NULL END),
+                    AVG(CASE WHEN vr.visitedTime = 'LUNCH' THEN vr.placeScore.quiet ELSE NULL END),
+                    AVG(CASE WHEN vr.visitedTime = 'NIGHT' THEN vr.placeScore.quiet ELSE NULL END)
+                )
+                FROM VisitedReview vr
+                WHERE vr.review.place.id = :placeId
+            """)
+    PlaceQuietnessWithRating findQuietnessRatingByPlaceId(@Param("placeId") UUID placeId);
 }

--- a/src/main/java/com/meetup/server/review/persistence/init/ReviewDummy.java
+++ b/src/main/java/com/meetup/server/review/persistence/init/ReviewDummy.java
@@ -34,14 +34,26 @@ public class ReviewDummy implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         if (reviewRepository.count() > 0) {
-            log.info("[REVIEW]더미 데이터 존재");
+            log.info("[Review]더미 데이터 존재");
         } else {
             List<Review> reviewList = new ArrayList<>();
 
-            UUID placeId = UUID.fromString("0196e96a-3993-7035-8caf-0436872b6644");
+            UUID placeId = UUID.fromString("0196e4a6-e812-74a7-9525-7ae7c5345490");
             Place place = placeRepository.findById(placeId).orElseThrow();
 
             Review DUMMY_REVIEW_1 = Review.builder()
+                    .place(place)
+                    .user(userRepository.findById(1L).orElseThrow())
+                    .isVisited(true)
+                    .build();
+
+            Review DUMMY_REVIEW_2 = Review.builder()
+                    .place(place)
+                    .user(userRepository.findById(2L).orElseThrow())
+                    .isVisited(true)
+                    .build();
+
+            Review DUMMY_REVIEW_3 = Review.builder()
                     .place(place)
                     .user(userRepository.findById(4L).orElseThrow())
                     .isVisited(true)
@@ -54,8 +66,27 @@ public class ReviewDummy implements ApplicationRunner {
                     .content("아침에 갔는데 너무 좋았어요")
                     .build();
 
+            VisitedReview DUMMY_VISITED_REVIEW_2 = VisitedReview.builder()
+                    .review(DUMMY_REVIEW_2)
+                    .visitedTime(VisitedTime.LUNCH)
+                    .placeScore(PlaceScore.of(5, 4, 3))
+                    .content("점심에 갔는데 너무 좋았어요")
+                    .build();
+
+            VisitedReview DUMMY_VISITED_REVIEW_3 = VisitedReview.builder()
+                    .review(DUMMY_REVIEW_3)
+                    .visitedTime(VisitedTime.NIGHT)
+                    .placeScore(PlaceScore.of(5, 4, 3))
+                    .content("저녁에 갔는데 너무 좋았어요")
+                    .build();
+
             reviewList.add(DUMMY_REVIEW_1);
+            reviewList.add(DUMMY_REVIEW_2);
+            reviewList.add(DUMMY_REVIEW_3);
+
             DUMMY_REVIEW_1.addVisitedReview(DUMMY_VISITED_REVIEW_1);
+            DUMMY_REVIEW_2.addVisitedReview(DUMMY_VISITED_REVIEW_2);
+            DUMMY_REVIEW_3.addVisitedReview(DUMMY_VISITED_REVIEW_3);
 
             reviewRepository.saveAll(reviewList);
         }

--- a/src/main/java/com/meetup/server/review/persistence/projection/PlaceQuietnessWithRating.java
+++ b/src/main/java/com/meetup/server/review/persistence/projection/PlaceQuietnessWithRating.java
@@ -1,0 +1,8 @@
+package com.meetup.server.review.persistence.projection;
+
+public record PlaceQuietnessWithRating(
+        Double morning,
+        Double lunch,
+        Double night
+) {
+}

--- a/src/main/java/com/meetup/server/user/dto/response/UserEventHistoryResponse.java
+++ b/src/main/java/com/meetup/server/user/dto/response/UserEventHistoryResponse.java
@@ -3,6 +3,7 @@ package com.meetup.server.user.dto.response;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.global.util.TimeUtil;
 import com.meetup.server.place.domain.Place;
+import com.meetup.server.subway.domain.Subway;
 import com.meetup.server.user.domain.User;
 import lombok.Builder;
 
@@ -23,7 +24,9 @@ public record UserEventHistoryResponse(
     public static UserEventHistoryResponse of(List<User> userList, Event event, int participatedPeopleCount, boolean isReviewed) {
         return UserEventHistoryResponse.builder()
                 .eventId(event.getEventId())
-                .middlePointName(event.getSubway().getName())
+                .middlePointName(Optional.ofNullable(event.getSubway())
+                        .map(Subway::getName)
+                        .orElse(null))
                 .placeName(Optional.ofNullable(event.getPlace())
                         .map(Place::getName)
                         .orElse(null))


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #81 

## 💡 작업 내용
- 장소 상세 내용을 조회하는 기능을 구현했습니다
- 자체 리뷰와 구글 리뷰 모두 최신순으로 진행했습니다
- subwayId 가 아닌 eventId 로 넘겨 받도록 진행하였습니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/18e6acfa-35eb-4da5-8122-7596ec737c35)


## 💬리뷰 요구사항
- dto 구성이 많아서 혹시나 npe 발생하는 상황이 없을 지 확인 부탁드려요..!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 장소 상세 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 해당 API는 장소의 리뷰, 구글 리뷰, 조용함 점수, 거리, 평점, 이미지 등 다양한 정보를 통합하여 제공합니다.
    - 장소별 시간대(아침, 점심, 저녁) 조용함 점수와 리뷰 데이터를 상세하게 확인할 수 있습니다.

- **버그 수정**
    - 이벤트의 지하철 정보가 없는 경우에도 안전하게 처리되도록 개선되었습니다.

- **기타**
    - 더미 리뷰 데이터가 다양하게 생성되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->