### PR TITLE
FEAT: #87 리뷰 작성 시 장소 정보 보여주기

### DIFF
--- a/src/main/java/com/meetup/server/place/application/PlaceService.java
+++ b/src/main/java/com/meetup/server/place/application/PlaceService.java
@@ -89,4 +89,14 @@ public class PlaceService {
                 isChanged
         );
     }
+
+    public PlaceResponseList getPlaceForReview(UUID eventId) {
+        Event event = eventReader.read(eventId);
+        Subway subway = event.getSubway();
+        Place place = event.getPlace();
+
+        PlaceWithDistance placeWithDistance = placeReader.readWithDistance(place, subway.getPoint());
+        PlaceWithRating placeWithRating = reviewReader.readPlaceRatingsAsMap(List.of(place.getId())).get(place);
+        return PlaceResponseList.of(subway, PlaceResponse.of(placeWithDistance, placeWithRating), null);
+    }
 }

--- a/src/main/java/com/meetup/server/place/dto/response/PlaceResponseList.java
+++ b/src/main/java/com/meetup/server/place/dto/response/PlaceResponseList.java
@@ -9,9 +9,6 @@ public record PlaceResponseList(
         @Schema(description = "중간지점명", example = "선정릉")
         String middlePointName,
 
-        @Schema(description = "중간지점 지하철역 ID", example = "1")
-        Integer subwayId,
-
         @Schema(description = "확정 장소")
         PlaceResponse confirmedPlaceResponse,
 
@@ -19,6 +16,6 @@ public record PlaceResponseList(
         List<PlaceResponse> placeResponses
 ) {
     public static PlaceResponseList of(Subway subway, PlaceResponse confirmedPlaceResponse, List<PlaceResponse> placeResponses) {
-        return new PlaceResponseList(subway.getName(), subway.getSubwayId(), confirmedPlaceResponse, placeResponses);
+        return new PlaceResponseList(subway.getName(), confirmedPlaceResponse, placeResponses);
     }
 }

--- a/src/main/java/com/meetup/server/place/presentation/PlaceController.java
+++ b/src/main/java/com/meetup/server/place/presentation/PlaceController.java
@@ -45,4 +45,10 @@ public class PlaceController {
     ) {
         return ApiResponse.success(placeService.getPlace(eventId, placeId));
     }
+
+    @Operation(summary = "리뷰용 장소 조회 API", description = "리뷰 작성을 위해 이벤트 ID로 확정된 장소 정보를 조회합니다.")
+    @GetMapping("/review")
+    public ApiResponse<PlaceResponseList> getPlaceForReview(@RequestParam UUID eventId) {
+        return ApiResponse.success(placeService.getPlaceForReview(eventId));
+    }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #87 

## 💡 작업 내용
- HI에서 이벤트 id를 받아서 리뷰 작성할 장소를 조회하는 기능을 구현했습니다.

## 📸 스크린샷
![스크린샷 2025-05-22 오후 5 16 52](https://github.com/user-attachments/assets/9244451b-6bf5-4ddb-bb13-140384d402dc)

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 ID로 리뷰 작성 시 확인된 장소 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.

- **기능 개선**
  - 장소 응답 데이터에서 subwayId 필드가 제거되어 응답 구조가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->