### PR TITLE
FIX: #90 구글 평점이 없는 장소 정렬 시 NPE 발생 방지를 위해 null-safe하게 처리하기

### DIFF
--- a/src/main/java/com/meetup/server/place/implement/PlaceSorter.java
+++ b/src/main/java/com/meetup/server/place/implement/PlaceSorter.java
@@ -20,7 +20,10 @@ public class PlaceSorter {
 
         List<PlaceResponse> placeResponsesWithoutReview = placeResponses.stream()
                 .filter(placeResponse -> placeResponse.averageRating() == null)
-                .sorted(Comparator.comparing(PlaceResponse::googleRating).reversed())
+                .sorted(Comparator.comparing(
+                        PlaceResponse::googleRating,
+                        Comparator.nullsLast(Comparator.reverseOrder())
+                ))
                 .toList();
 
         List<PlaceResponse> mergedPlaceResponses = new ArrayList<>();


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #90 

## 💡 작업 내용
### 문제 정의
![스크린샷 2025-05-23 오전 1 22 43](https://github.com/user-attachments/assets/88d28e23-621f-4d69-811d-5e5120b3f77f)

- 구글 평점 내림차순으로 정렬해서 반환하고 있는데, 이때 구글 평점이 null이면 `Comparator.comparing()`에서 비교하는 도중 NPE가 발생한다.

### 해결
- `Comparator.nullsLast()`를 이용해 null일 경우 항상 마지막에 배치하도록 변경하였습니다.

## 📸 스크린샷
### AS-IS
![스크린샷 2025-05-23 오전 1 41 09](https://github.com/user-attachments/assets/4290595d-edd1-45ea-ac84-e771a58b8efe)

### TO-BE
![스크린샷 2025-05-23 오전 1 41 47](https://github.com/user-attachments/assets/3ce04f2c-c463-47a8-9444-f1023d5f993e)

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 평점 정보가 없는 장소의 정렬 시, Google 평점이 없는 항목이 목록의 마지막에 위치하도록 개선되었습니다. 이제 평점 값이 없는 장소가 잘못된 순서로 나타나거나 오류가 발생하는 문제가 해결되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->