### PR TITLE
FIX: #94 방문하지 않은 리뷰를 작성한 경우에도 상세 조회가 가능하도록 하기

### DIFF
--- a/src/main/java/com/meetup/server/place/dto/response/ReviewResponse.java
+++ b/src/main/java/com/meetup/server/place/dto/response/ReviewResponse.java
@@ -1,12 +1,15 @@
 package com.meetup.server.place.dto.response;
 
 import com.meetup.server.review.domain.Review;
+import com.meetup.server.review.domain.VisitedReview;
+import com.meetup.server.user.domain.User;
 import lombok.Builder;
 
 import java.time.LocalDate;
 import java.time.format.TextStyle;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 @Builder
 public record ReviewResponse(
@@ -18,11 +21,17 @@ public record ReviewResponse(
 ) {
     public static ReviewResponse from(Review review) {
         return ReviewResponse.builder()
-                .nickname(review.getUser().getNickname())
-                .profileImage(review.getUser().getProfileImage())
+                .nickname(Optional.ofNullable(review.getUser())
+                        .map(User::getNickname)
+                        .orElse(null))
+                .profileImage(Optional.ofNullable(review.getUser())
+                        .map(User::getProfileImage)
+                        .orElse(null))
                 .date(review.getCreatedAt().toLocalDate())
                 .day(review.getCreatedAt().getDayOfWeek().getDisplayName(TextStyle.SHORT_STANDALONE, Locale.KOREAN))
-                .content(review.getVisitedReview().getContent())
+                .content(Optional.ofNullable(review.getVisitedReview())
+                        .map(VisitedReview::getContent)
+                        .orElse(null))
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #94

## 💡 작업 내용
- 확정된 장소를 방문하지 않은 경우에 대한 리뷰를 작성한 후, 장소 상세 조회가 가능하도록 진행했습니다

## 📸 스크린샷
- 미방문 리뷰 작성 후 장소 상세 조회를 진행했습니다
![image](https://github.com/user-attachments/assets/abc4b2f7-9025-462f-a10a-a7b56dde06b5)


## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 리뷰 작성자 정보 또는 방문 리뷰 정보가 없는 경우에도 오류 없이 리뷰 정보를 조회할 수 있도록 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->