### PR TITLE
FIX: #96 비회원은 startPointId가 아닌 guestId로 판별하도록 변경한다

### DIFF
--- a/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
@@ -15,6 +15,9 @@ public record EventStartPointResponse(
         @Schema(description = "출발지 ID", example = "01968fe2-5277-712a-ad3c-98f29c2782e1")
         UUID startPointId,
 
+        @Schema(description = "비회원 ID", example = "01968fe2-5277-712a-ad3c-98f29c2782e1")
+        UUID guestId,
+
         @Schema(description = "지번주소", example = "땡수팟")
         String username
 ) {
@@ -22,6 +25,7 @@ public record EventStartPointResponse(
         return EventStartPointResponse.builder()
                 .eventId(event.getEventId())
                 .startPointId(startPoint.getStartPointId())
+                .guestId(startPoint.getGuestId())
                 .username(username)
                 .build();
     }

--- a/src/main/java/com/meetup/server/event/dto/response/RouteResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/RouteResponse.java
@@ -25,6 +25,8 @@ public class RouteResponse {
     private Boolean isTransit;  // true: 대중교통, false: 자동차
     private Boolean isMe;
     private UUID id;
+    private Long userId;
+    private UUID guestId;
     private String nickname;
     private String profileImage;
     private String startName;  // 출발지 주소
@@ -43,11 +45,12 @@ public class RouteResponse {
                                    KakaoMobilityResponse drivingResponse,
                                    int transitTime,
                                    int driveTime) {
-
         return RouteResponse.builder()
                 .isTransit(startPoint.isTransit())
                 .isMe(false)
                 .id(startPoint.getStartPointId())
+                .userId(startPoint.getIsUser() ? user.getUserId() : null)
+                .guestId(startPoint.getGuestId())
                 .nickname(startPoint.getIsUser() ? user.getNickname() : startPoint.getNonUserName())
                 .profileImage(startPoint.getIsUser() ? user.getProfileImage() : null)
                 .startName(convertStartPointName(startPoint.getAddress().getAddress()))

--- a/src/main/java/com/meetup/server/event/implement/EventProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/EventProcessor.java
@@ -11,8 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 @Component
 @RequiredArgsConstructor
@@ -42,17 +42,18 @@ public class EventProcessor {
         routeResponseList.updateRouteResponse(routes);
     }
 
-    public void prioritizeMyRoute(UUID startPointId, List<RouteResponse> routeList) {
-        if (startPointId != null) {
-            Optional<RouteResponse> myRoute = routeList.stream()
-                    .filter(route -> startPointId.equals(route.getId()))
-                    .findFirst();
+    public void prioritizeMyRoute(Long userId, UUID guestId, List<RouteResponse> routeList) {
+        Predicate<RouteResponse> isOwnedByUserOrGuest = (userId != null)
+                ? route -> userId.equals(route.getUserId())
+                : route -> guestId != null && guestId.equals(route.getGuestId());
 
-            myRoute.ifPresent(route -> {
-                route.updateIsMe(true);
-                routeList.remove(route);
-                routeList.addFirst(route);
-            });
-        }
+        routeList.stream()
+                .filter(isOwnedByUserOrGuest)
+                .findFirst()
+                .ifPresent(route -> {
+                    route.updateIsMe(true);
+                    routeList.remove(route);
+                    routeList.addFirst(route);
+                });
     }
 }

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -26,14 +26,20 @@ public class EventController {
 
     @Operation(summary = "모임 생성 API", description = "모임 생성자의 출발지를 입력받아 모임을 생성합니다")
     @PostMapping
-    public ApiResponse<EventStartPointResponse> createEvent(@Valid @RequestBody StartPointRequest startPointRequest, @AuthenticationPrincipal Long userId) {
-        return ApiResponse.success(eventService.createEvent(userId, startPointRequest));
+    public ApiResponse<EventStartPointResponse> createEvent(
+            @Valid @RequestBody StartPointRequest startPointRequest,
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) UUID guestId) {
+        return ApiResponse.success(eventService.createEvent(userId, guestId, startPointRequest));
     }
 
     @Operation(summary = "지도 조회 API", description = "모임의 중간 지점 계산 및 모임 참여자의 경로 조회를 진행합니다")
     @GetMapping("/{eventId}")
-    public ApiResponse<RouteResponseList> getEventMap(@PathVariable UUID eventId, @RequestParam(required = false) UUID startPointId) {
-        return ApiResponse.success(eventService.getEventMap(eventId, startPointId));
+    public ApiResponse<RouteResponseList> getEventMap(
+            @PathVariable UUID eventId,
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) UUID guestId) {
+        return ApiResponse.success(eventService.getEventMap(eventId, userId, guestId));
     }
 
     @Operation(summary = "대중교통 선택 API", description = "본인의 대중교통, 자가용 선택 여부를 설정합니다")

--- a/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
@@ -53,13 +53,20 @@ public class StartPoint extends BaseEntity {
     @Column(columnDefinition = "geography(Point, 4326)")
     private Point point;
 
+    @Column(name = "guest_id")
+    private UUID guestId;
+
     @PrePersist
     public void prePersist() {
         this.startPointId = UuidCreator.getTimeOrderedEpoch();
+
+        if (!isUser && this.guestId == null) {
+            this.guestId = UuidCreator.getTimeOrderedEpoch();
+        }
     }
 
     @Builder
-    public StartPoint(Event event, User user, String name, Address address, Location location, String nonUserName, Point point, boolean isUser) {
+    public StartPoint(Event event, User user, String name, Address address, Location location, String nonUserName, Point point, boolean isUser, UUID guestId) {
         this.event = event;
         this.user = user;
         this.name = name;
@@ -69,6 +76,7 @@ public class StartPoint extends BaseEntity {
         this.point = point;
         this.isUser = isUser;
         this.isTransit = true;
+        this.guestId = guestId;
     }
 
     public boolean getIsUser() {

--- a/src/main/java/com/meetup/server/startpoint/presentation/StartPointController.java
+++ b/src/main/java/com/meetup/server/startpoint/presentation/StartPointController.java
@@ -34,8 +34,9 @@ public class StartPointController {
     public ApiResponse<EventStartPointResponse> createStartPoint(
             @PathVariable UUID eventId,
             @Valid @RequestBody StartPointRequest startPointRequest,
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) UUID guestId
     ) {
-        return ApiResponse.success(startPointService.createStartPoint(eventId, userId, startPointRequest));
+        return ApiResponse.success(startPointService.createStartPoint(eventId, userId, guestId, startPointRequest));
     }
 }

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,16 +37,18 @@ class EventServiceTest extends IntegrationTestContainer {
 
     private User user;
     private StartPointRequest startPointRequest;
+    private UUID guestId;
 
     @BeforeEach
     void setUp() {
         user = userRepository.save(UserFixture.getUser());
         startPointRequest = StartPointFixture.getStartPointRequest();
+        guestId = UUID.randomUUID();
     }
 
     @Test
     void 비로그인_사용자가_이벤트를_생성한다() {
-        EventStartPointResponse eventStartPointResponse = eventService.createEvent(null, startPointRequest);
+        EventStartPointResponse eventStartPointResponse = eventService.createEvent(null, guestId, startPointRequest);
 
         Optional<Event> optionalEvent = eventRepository.findById(eventStartPointResponse.eventId());
         assertThat(optionalEvent).isPresent();
@@ -60,12 +63,13 @@ class EventServiceTest extends IntegrationTestContainer {
         assertThat(optionalStartPoint.get().getAddress().getRoadAddress()).isEqualTo(startPointRequest.roadAddress());
         assertThat(optionalStartPoint.get().getLocation().getRoadLongitude()).isEqualTo(startPointRequest.longitude());
         assertThat(optionalStartPoint.get().getLocation().getRoadLatitude()).isEqualTo(startPointRequest.latitude());
+        assertThat(optionalStartPoint.get().getGuestId()).isEqualTo(guestId);
     }
 
     @Transactional
     @Test
     void 로그인_사용자가_이벤트를_생성한다() {
-        EventStartPointResponse eventStartPointResponse = eventService.createEvent(user.getUserId(), startPointRequest);
+        EventStartPointResponse eventStartPointResponse = eventService.createEvent(user.getUserId(), null, startPointRequest);
 
         Optional<Event> optionalEvent = eventRepository.findById(eventStartPointResponse.eventId());
         assertThat(optionalEvent).isPresent();
@@ -80,6 +84,7 @@ class EventServiceTest extends IntegrationTestContainer {
         assertThat(optionalStartPoint.get().getAddress().getRoadAddress()).isEqualTo(startPointRequest.roadAddress());
         assertThat(optionalStartPoint.get().getLocation().getRoadLongitude()).isEqualTo(startPointRequest.longitude());
         assertThat(optionalStartPoint.get().getLocation().getRoadLatitude()).isEqualTo(startPointRequest.latitude());
+        assertThat(optionalStartPoint.get().getGuestId()).isNull();
     }
 
 }

--- a/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
+++ b/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,12 +39,14 @@ class StartPointServiceTest extends IntegrationTestContainer {
     private Event event;
     private StartPointRequest startPointRequest;
     private User user;
+    private UUID guestId;
 
     @BeforeEach
     void setUp() {
         event = eventRepository.save(EventFixture.getEvent());
         startPointRequest = StartPointFixture.getStartPointRequest();
         user = userRepository.save(UserFixture.getUser());
+        guestId = UUID.randomUUID();
     }
 
     @Test
@@ -51,7 +54,7 @@ class StartPointServiceTest extends IntegrationTestContainer {
         EventStartPointResponse eventStartPointResponse = startPointService.createStartPoint(
                 event.getEventId(),
                 null,
-                startPointRequest
+                guestId, startPointRequest
         );
 
         assertThat(event.getEventId()).isEqualTo(eventStartPointResponse.eventId());
@@ -59,7 +62,8 @@ class StartPointServiceTest extends IntegrationTestContainer {
         Optional<StartPoint> optionalStartPoint = startPointRepository.findById(eventStartPointResponse.startPointId());
         assertThat(optionalStartPoint).isPresent();
         assertThat(optionalStartPoint.get().getStartPointId()).isEqualTo(eventStartPointResponse.startPointId());
-        assertThat(optionalStartPoint.get().getUser()).isEqualTo(null);
+        assertThat(optionalStartPoint.get().getUser()).isNull();
+        assertThat(optionalStartPoint.get().getGuestId()).isEqualTo(guestId);
     }
 
     @Transactional
@@ -68,7 +72,7 @@ class StartPointServiceTest extends IntegrationTestContainer {
         EventStartPointResponse eventStartPointResponse = startPointService.createStartPoint(
                 event.getEventId(),
                 user.getUserId(),
-                startPointRequest
+                null, startPointRequest
         );
 
         assertThat(event.getEventId()).isEqualTo(eventStartPointResponse.eventId());
@@ -77,5 +81,6 @@ class StartPointServiceTest extends IntegrationTestContainer {
         assertThat(optionalStartPoint).isPresent();
         assertThat(optionalStartPoint.get().getStartPointId()).isEqualTo(eventStartPointResponse.startPointId());
         assertThat(optionalStartPoint.get().getUser()).isEqualTo(user);
+        assertThat(optionalStartPoint.get().getGuestId()).isNull();
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #96 

## 💡 작업 내용
- StartPointId로 판별하던 부분을 userId와 guestId로 판별하도록 변경하였습니다.
- 모임 생성 / 지도 조회 API에서 guestId가 추가되었습니다.
- StartPoint 엔티티에 guestId 필드 추가되었습니다.

## 📸 스크린샷
<img width="622" alt="스크린샷 2025-05-24 오후 4 32 22" src="https://github.com/user-attachments/assets/68ffa0fd-0b1e-49eb-b31c-31f954b7ce51" />


## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 게스트(비회원) 사용자를 위한 guestId 필드가 이벤트 생성, 출발지 생성, 경로 응답 등 주요 API와 응답 객체에 추가되었습니다.
    - 게스트 식별자를 활용해 비회원도 이벤트 참여 및 경로 조회가 가능해졌습니다.
    - 이벤트 및 출발지 생성, 경로 우선순위 지정 로직이 회원 ID와 게스트 ID를 모두 처리하도록 개선되었습니다.

- **버그 수정**
    - 없음

- **테스트**
    - 게스트 식별자(guestId) 처리와 관련한 테스트 케이스가 추가되어, 회원/비회원 구분 동작이 명확히 검증됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->