### PR TITLE
FIX: #99 모임 조회 쿼리를 수정한다

### DIFF
--- a/src/main/java/com/meetup/server/startpoint/persistence/StartPointCustomRepositoryImpl.java
+++ b/src/main/java/com/meetup/server/startpoint/persistence/StartPointCustomRepositoryImpl.java
@@ -39,9 +39,19 @@ public class StartPointCustomRepositoryImpl implements StartPointCustomRepositor
                 .join(startPoint.event, event)
                 .leftJoin(event.place)
                 .leftJoin(event.subway)
-                .where(cursorFilter)
+                .where(
+                        cursorFilter
+                                .and(
+                                        startPoint.event.eventId.in(
+                                                jpaQueryFactory
+                                                        .select(startPoint.event.eventId)
+                                                        .from(startPoint)
+                                                        .groupBy(startPoint.event.eventId)
+                                                        .having(startPoint.count().goe(2))
+                                        )
+                                )
+                )
                 .orderBy(event.createdAt.desc(), event.eventId.desc())
-                .distinct()
                 .limit(size)
                 .fetch();
     }

--- a/src/main/java/com/meetup/server/user/implement/UserEventHistoryAssembler.java
+++ b/src/main/java/com/meetup/server/user/implement/UserEventHistoryAssembler.java
@@ -32,7 +32,6 @@ public class UserEventHistoryAssembler {
         Map<UUID, Boolean> isReviewedMap = reviewReader.readReviewsWrittenByUser(eventHistories, userId);
 
         return eventHistories.stream()
-                .filter(event -> participantsMap.getOrDefault(event.eventId(), 0) > 1)
                 .map(event -> {
                     List<String> imageUrls = imageUrlMap.getOrDefault(event.eventId(), List.of());
 


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #99 

## 💡 작업 내용
- sevice 에서 진행하던 필터링을 QueryDSL 에서 진행하도록 쿼리를 수정하였습니다

## 📸 스크린샷

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이벤트 이력 조회 시, 참가자 수가 2명 이상인 이벤트만 표시되던 제한이 제거되어 모든 이벤트가 표시됩니다.
  - 이벤트 이력 필터링 조건이 변경되어 더 많은 이벤트가 조회될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->