### PR TITLE
FIX: #102 사용자명을 5글자 이내로 노출하도록 변경한다

### DIFF
--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -27,7 +27,7 @@ public class EventService {
     public EventStartPointResponse createEvent(Long userId, UUID guestId, StartPointRequest startPointRequest) {
         Event event = eventProcessor.save();
         StartPoint startPoint = startPointProcessor.save(event, userId, guestId, startPointRequest);
-        return EventStartPointResponse.of(event, startPoint, startPointRequest.username());
+        return EventStartPointResponse.of(event, startPoint);
     }
 
     @Transactional

--- a/src/main/java/com/meetup/server/event/application/RouteService.java
+++ b/src/main/java/com/meetup/server/event/application/RouteService.java
@@ -44,7 +44,7 @@ public class RouteService {
 
         ClosestParkingLot closestParkingLot = parkingLotFinder.findClosestParkingLot(event.getSubway().getPoint());
 
-        String eventMaker = startPointReader.readName(event.getEventId());
-        return RouteResponseList.of(eventMaker, routeList, MeetingPoint.of(endStationName, endX, endY), closestParkingLot);
+        StartPoint earliestStartPoint = startPointReader.readEarliestByEventId(event.getEventId());
+        return RouteResponseList.of(earliestStartPoint, routeList, MeetingPoint.of(endStationName, endX, endY), closestParkingLot);
     }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
@@ -2,6 +2,7 @@ package com.meetup.server.event.dto.response;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.util.UsernameExtractor;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -18,15 +19,15 @@ public record EventStartPointResponse(
         @Schema(description = "비회원 ID", example = "01968fe2-5277-712a-ad3c-98f29c2782e1")
         UUID guestId,
 
-        @Schema(description = "지번주소", example = "땡수팟")
+        @Schema(description = "사용자명", example = "땡수팟")
         String username
 ) {
-    public static EventStartPointResponse of(Event event, StartPoint startPoint, String username) {
+    public static EventStartPointResponse of(Event event, StartPoint startPoint) {
         return EventStartPointResponse.builder()
                 .eventId(event.getEventId())
                 .startPointId(startPoint.getStartPointId())
                 .guestId(startPoint.getGuestId())
-                .username(username)
+                .username(UsernameExtractor.extractDisplayName(startPoint))
                 .build();
     }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/RouteResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/RouteResponse.java
@@ -3,6 +3,7 @@ package com.meetup.server.event.dto.response;
 import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityResponse;
 import com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchResponse;
 import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.util.UsernameExtractor;
 import com.meetup.server.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,7 +52,7 @@ public class RouteResponse {
                 .id(startPoint.getStartPointId())
                 .userId(startPoint.getIsUser() ? user.getUserId() : null)
                 .guestId(startPoint.getGuestId())
-                .nickname(startPoint.getIsUser() ? user.getNickname() : startPoint.getNonUserName())
+                .nickname(UsernameExtractor.extractDisplayName(startPoint))
                 .profileImage(startPoint.getIsUser() ? user.getProfileImage() : null)
                 .startName(convertStartPointName(startPoint.getAddress().getAddress()))
                 .startLongitude(startPoint.getLocation().getRoadLongitude())

--- a/src/main/java/com/meetup/server/event/dto/response/RouteResponseList.java
+++ b/src/main/java/com/meetup/server/event/dto/response/RouteResponseList.java
@@ -1,6 +1,8 @@
 package com.meetup.server.event.dto.response;
 
 import com.meetup.server.parkinglot.persistence.projection.ClosestParkingLot;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.util.UsernameExtractor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,9 +23,9 @@ public class RouteResponseList {
     private List<RouteResponse> routeResponse;
     private ParkingLotResponse parkingLot;
 
-    public static RouteResponseList of(String eventMaker, List<RouteResponse> routeResponse, MeetingPoint meetingPoint, ClosestParkingLot closestParkingLot) {
+    public static RouteResponseList of(StartPoint startPoint, List<RouteResponse> routeResponse, MeetingPoint meetingPoint, ClosestParkingLot closestParkingLot) {
         return RouteResponseList.builder()
-                .eventMaker(eventMaker)
+                .eventMaker(UsernameExtractor.extractDisplayName(startPoint))
                 .averageTime(calculateAverageTime(routeResponse))
                 .peopleCount(routeResponse.size())
                 .meetingPoint(meetingPoint)

--- a/src/main/java/com/meetup/server/global/util/CoordinateUtil.java
+++ b/src/main/java/com/meetup/server/global/util/CoordinateUtil.java
@@ -1,5 +1,7 @@
 package com.meetup.server.global.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
@@ -7,6 +9,7 @@ import org.locationtech.jts.geom.PrecisionModel;
 
 import java.util.List;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CoordinateUtil {
 
     public static Point createPoint(double longitude, double latitude) {

--- a/src/main/java/com/meetup/server/global/util/StringUtil.java
+++ b/src/main/java/com/meetup/server/global/util/StringUtil.java
@@ -1,0 +1,15 @@
+package com.meetup.server.global.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class StringUtil {
+
+    public static String truncate(String value, int maxLength) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        return value.length() <= maxLength ? value : value.substring(0, maxLength);
+    }
+}

--- a/src/main/java/com/meetup/server/global/util/TimeUtil.java
+++ b/src/main/java/com/meetup/server/global/util/TimeUtil.java
@@ -1,9 +1,13 @@
 package com.meetup.server.global.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TimeUtil {
 
     public static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");

--- a/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
+++ b/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
@@ -44,11 +44,11 @@ public class StartPointService {
                     null,
                     startPointRequest
             );
-            return EventStartPointResponse.of(event, startPoint, startPointRequest.username());
+            return EventStartPointResponse.of(event, startPoint);
         }
 
         StartPoint startPoint = startPointProcessor.save(event, userId, guestId, startPointRequest);
-        return EventStartPointResponse.of(event, startPoint, startPointRequest.username());
+        return EventStartPointResponse.of(event, startPoint);
     }
 
     private boolean validateAlreadyHasStartPoint(Long userId, List<StartPoint> startPointList) {

--- a/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
+++ b/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
@@ -1,11 +1,12 @@
 package com.meetup.server.startpoint.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.DecimalMax;
-import jakarta.validation.constraints.DecimalMin;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 public record StartPointRequest(
+
+        @NotBlank
+        @Size(min = 1, max = 5)
         @Schema(description = "사용자명", example = "안연아바보")
         String username,
 

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
@@ -43,7 +43,6 @@ public class StartPointProcessor {
                 .location(Location.of(startPointRequest.longitude(), startPointRequest.latitude()))
                 .point(CoordinateUtil.createPoint(startPointRequest.longitude(), startPointRequest.latitude()))
                 .isUser(true)
-                .nonUserName(user.getNickname())
                 .build();
 
         return startPointRepository.save(startPoint);

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
@@ -29,8 +29,8 @@ public class StartPointReader {
                 .orElseThrow(() -> new StartPointException(StartPointErrorType.PLACE_NOT_FOUND));
     }
 
-    public String readName(UUID eventId) {
-        return startPointRepository.findTopByEventIdOrderByCreatedAtAsc(eventId).getNonUserName();
+    public StartPoint readEarliestByEventId(UUID eventId) {
+        return startPointRepository.findTopByEventIdOrderByCreatedAtAsc(eventId);
     }
 
     public List<EventHistory> readEventHistories(Long userId, UUID lastViewedEventId, int size) {

--- a/src/main/java/com/meetup/server/startpoint/util/UsernameExtractor.java
+++ b/src/main/java/com/meetup/server/startpoint/util/UsernameExtractor.java
@@ -1,0 +1,20 @@
+package com.meetup.server.startpoint.util;
+
+import com.meetup.server.global.util.StringUtil;
+import com.meetup.server.startpoint.domain.StartPoint;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UsernameExtractor {
+
+    public static String extractDisplayName(StartPoint startPoint) {
+        if (startPoint == null) {
+            return null;
+        }
+        if (startPoint.getIsUser()) {
+            return StringUtil.truncate(startPoint.getUser().getNickname(), 5);
+        }
+        return startPoint.getNonUserName();
+    }
+}

--- a/src/main/java/com/meetup/server/user/presentation/UserController.java
+++ b/src/main/java/com/meetup/server/user/presentation/UserController.java
@@ -7,15 +7,19 @@ import com.meetup.server.user.dto.response.UserEventHistoryResponseList;
 import com.meetup.server.user.dto.response.UserProfileInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Slf4j
 @Tag(name = "User API", description = "사용자 API")
+@Slf4j
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -57,7 +61,7 @@ public class UserController {
     @PatchMapping("")
     public ApiResponse<?> updateNickname(
             @AuthenticationPrincipal Long userId,
-            @RequestParam String nickname
+            @RequestParam @NotBlank @Size(min = 1, max = 5) String nickname
     ) {
         userService.updateNickname(userId, nickname);
         return ApiResponse.success();


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #102 

## 💡 작업 내용
- 로그인, 비로그인 사용자를 nonUserName에 혼용하여 저장 및 조회하는 문제가 있었습니다. 
- 이를 해결하기 위해, 로그인 사용자는 연관관계를 맺는 User 객체에서 nickname을 가져오고 비로그인 사용자는 출발지 등록 시 저장되는 nonUserName을 사용해 조회하도록 하였습니다.
- 추가로, 로그인 사용자의 카카오 이름이 5글자 이상인 경우, 5글자 이내로 잘라서 반환하도록 변경하였습니다.

## 📸 스크린샷

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 닉네임 및 사용자명 추출을 위한 유틸리티 클래스가 추가되었습니다.
  - 문자열 자르기 기능을 제공하는 유틸리티가 도입되었습니다.

- **버그 수정**
  - 사용자명 및 닉네임이 일관되게 최대 5자로 제한되어 표시됩니다.

- **개선 사항**
  - 닉네임/사용자명 입력 시 1~5자 이내 및 공백 불가 등의 유효성 검사가 강화되었습니다.
  - 일부 입력 필드 및 응답에서 사용자명 처리 로직이 개선되었습니다.

- **기타**
  - 유틸리티 클래스의 불필요한 인스턴스화를 방지하도록 구조가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->