### PR TITLE
FIX: #107 중간지점 최단 경로 미존재 시 대체 경로를 반환하도록 처리한다

### DIFF
--- a/src/main/java/com/meetup/server/global/util/CoordinateUtil.java
+++ b/src/main/java/com/meetup/server/global/util/CoordinateUtil.java
@@ -12,6 +12,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CoordinateUtil {
 
+    private static final double EARTH_RADIUS_KM = 6371.0;
+
     public static Point createPoint(double longitude, double latitude) {
         GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
         Coordinate coordinate = new Coordinate(longitude, latitude);
@@ -39,5 +41,20 @@ public class CoordinateUtil {
         double avgLatitude = sumLatitude / points.size();
 
         return createPoint(avgLongitude, avgLatitude);
+    }
+
+    public static double calculateDistance(Point start, Point end) {
+        double startLongitude = Math.toRadians(start.getX());
+        double startLatitude = Math.toRadians(start.getY());
+        double endLongitude = Math.toRadians(end.getX());
+        double endLatitude = Math.toRadians(end.getY());
+
+        double deltaLongitude = endLongitude - startLongitude;
+        double deltaLatitude = endLatitude - startLatitude;
+
+        double a = Math.sin(deltaLatitude / 2) * Math.sin(deltaLatitude / 2) +
+                Math.cos(startLatitude) * Math.cos(endLatitude) * Math.sin(deltaLongitude / 2) * Math.sin(deltaLongitude / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS_KM * c;
     }
 }

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathNode.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathNode.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record SubwayPathNode(
         int subwayId,
         int totalTime,
-        List<Integer> subwayIds
+        List<Integer> subwayIds,
+        int transferCount
 ) {
 }

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathProcessor.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathProcessor.java
@@ -1,12 +1,15 @@
 package com.meetup.server.subway.implement.processor;
 
+import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.subway.domain.Subway;
 import com.meetup.server.subway.domain.SubwayConnection;
 import com.meetup.server.subway.domain.TransferInfo;
 import com.meetup.server.subway.persistence.SubwayConnectionRepository;
 import com.meetup.server.subway.persistence.SubwayRepository;
 import com.meetup.server.subway.persistence.TransferInfoRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -15,30 +18,72 @@ import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SubwayPathProcessor {
 
+    // 환승에 소요되는 고정 시간 (초 단위, 3분)
     private static final int TRANSFER_TIME_SEC = 180;
+    // 직선 거리 1km당 평균 소요 시간 (초 단위, 2분/km)
+    private static final int AVERAGE_TIME_SEC_PER_KM = 120;
 
     private final SubwayRepository subwayRepository;
     private final SubwayConnectionRepository subwayConnectionRepository;
     private final TransferInfoRepository transferInfoRepository;
 
+    private Map<Integer, Subway> subwayMap;
+    private Map<Integer, List<SubwayConnection>> connectionsMap;
+    private Map<Integer, List<TransferInfo>> transfersMap;
+
+    @PostConstruct
+    public void init() {
+        this.subwayMap = subwayRepository.findAll()
+                .stream()
+                .collect(Collectors.toMap(Subway::getSubwayId, Function.identity()));
+
+        this.connectionsMap = subwayConnectionRepository.findAllWithSubways()
+                .stream()
+                .collect(Collectors.groupingBy(conn -> conn.getFromSubway().getSubwayId()));
+
+        this.transfersMap = transferInfoRepository.findAllWithSubways()
+                .stream()
+                .collect(Collectors.groupingBy(tr -> tr.getFromSubway().getSubwayId()));
+    }
+
+    /**
+     * 출발역에서 도착역까지의 최단 경로를 탐색.
+     * A* 알고리즘을 사용하여 최단 시간 경로를 찾으며, 노드 수 제한 시 대체 경로 반환.
+     *
+     * @param startSubwayId 출발역 ID
+     * @param endSubwayId   도착역 ID
+     * @return 최단 경로 결과 (SubwayPathResult) 또는 대체 경로
+     */
     public SubwayPathResult findShortestPath(int startSubwayId, int endSubwayId) {
-
-        Map<Integer, Subway> subwayMap = mapSubwaysById();
-        Map<Integer, List<SubwayConnection>> connectionsMap = groupConnectionsByFromId();
-        Map<Integer, List<TransferInfo>> transferMap = groupTransfersByFromId();
-
         PriorityQueue<SubwayPathNode> pathQueue = new PriorityQueue<>(
-                Comparator.comparingInt((SubwayPathNode node) -> node.subwayIds().size())
-                        .thenComparingInt(SubwayPathNode::totalTime)
+                Comparator.comparingDouble((SubwayPathNode node) -> node.totalTime() + heuristic(node.subwayId(), endSubwayId, subwayMap))
+                        .thenComparingInt(node -> node.subwayIds().size())
         );
-        pathQueue.offer(new SubwayPathNode(startSubwayId, 0, new ArrayList<>(List.of(startSubwayId))));
+        pathQueue.offer(new SubwayPathNode(startSubwayId, 0, new ArrayList<>(List.of(startSubwayId)), 0));
 
         Map<String, Integer> visitedTimeMap = new HashMap<>();
 
+        final int MAX_NODES = 500;
+        final int MAX_TRANSFERS = 3;
+
+        int nodeCount = 0;
+        SubwayPathNode bestNode = null;
+
         while (!pathQueue.isEmpty()) {
             SubwayPathNode currentNode = pathQueue.poll();
+            nodeCount++;
+
+            if (bestNode == null || currentNode.totalTime() < bestNode.totalTime()) {
+                bestNode = currentNode;
+            }
+
+            if (nodeCount >= MAX_NODES) {
+                log.warn("[SubwayPathProcessor] : 노드 수 제한 초과로 대체 경로 반환 (startSubwayId: {}, endSubwayId: {})", startSubwayId, endSubwayId);
+                return createFallbackPath(subwayMap, bestNode, startSubwayId, endSubwayId);
+            }
 
             String pathKey = currentNode.subwayId() + "-" + currentNode.subwayIds().size();
             if (visitedTimeMap.containsKey(pathKey) && visitedTimeMap.get(pathKey) <= currentNode.totalTime()) {
@@ -50,53 +95,99 @@ public class SubwayPathProcessor {
                 List<String> pathNames = currentNode.subwayIds().stream()
                         .map(id -> subwayMap.get(id).getName())
                         .collect(Collectors.toList());
-
                 return new SubwayPathResult(currentNode.totalTime(), currentNode.subwayIds(), pathNames);
             }
 
+            // 현재 역에서 연결된 다음 역 탐색
             List<SubwayConnection> connections = connectionsMap.getOrDefault(currentNode.subwayId(), List.of());
             for (SubwayConnection connection : connections) {
                 pathQueue.offer(new SubwayPathNode(
                         connection.getToSubway().getSubwayId(),
                         currentNode.totalTime() + connection.getSectionTimeSec(),
-                        addSubwayToPath(currentNode.subwayIds(), connection.getToSubway().getSubwayId())
+                        addSubwayToPath(currentNode.subwayIds(), connection.getToSubway().getSubwayId()),
+                        currentNode.transferCount()
                 ));
             }
 
-            List<TransferInfo> transfers = transferMap.getOrDefault(currentNode.subwayId(), List.of());
+            // 현재 역에서 가능한 환승 탐색
+            List<TransferInfo> transfers = transfersMap.getOrDefault(currentNode.subwayId(), List.of());
             for (TransferInfo transfer : transfers) {
+                if (currentNode.transferCount() >= MAX_TRANSFERS) {
+                    continue;
+                }
                 pathQueue.offer(new SubwayPathNode(
                         transfer.getToSubway().getSubwayId(),
                         currentNode.totalTime() + TRANSFER_TIME_SEC,
-                        addSubwayToPath(currentNode.subwayIds(), transfer.getToSubway().getSubwayId())
+                        addSubwayToPath(currentNode.subwayIds(), transfer.getToSubway().getSubwayId()),
+                        currentNode.transferCount() + 1
                 ));
             }
         }
 
-        return null;
+        log.warn("[SubwayPathProcessor] : 경로를 찾지 못해 대체 경로 반환 (startSubwayId: {}, endSubwayId: {})", startSubwayId, endSubwayId);
+        return createFallbackPath(subwayMap, bestNode, startSubwayId, endSubwayId);
     }
 
+    /**
+     * A* 알고리즘의 휴리스틱 함수.
+     * 현재 역에서 도착역까지의 직선 거리 기반 예상 소요 시간(초) 계산.
+     *
+     * @param subwayId     현재 역 ID
+     * @param endSubwayId  도착역 ID
+     * @param subwayMap    역 정보 맵
+     * @return 예상 소요 시간 (초)
+     */
+    private double heuristic(int subwayId, int endSubwayId, Map<Integer, Subway> subwayMap) {
+        Subway start = subwayMap.get(subwayId);
+        Subway end = subwayMap.get(endSubwayId);
+        double distance = CoordinateUtil.calculateDistance(start.getPoint(), end.getPoint());
+        return distance * AVERAGE_TIME_SEC_PER_KM;
+    }
+
+    /**
+     * 최단 경로 탐색 실패 시 대체 경로 생성.
+     * bestNode를 기반으로 경로를 만들고, 도착역 미도달 시 직선 거리 기반 시간 추가.
+     *
+     * @param subwayMap    역 정보 맵
+     * @param bestNode     가장 유망한 노드 (최소 totalTime)
+     * @param startSubwayId 출발역 ID
+     * @param endSubwayId   도착역 ID
+     * @return 대체 경로 결과
+     */
+    private SubwayPathResult createFallbackPath(Map<Integer, Subway> subwayMap, SubwayPathNode bestNode, int startSubwayId, int endSubwayId) {
+        List<Integer> path;
+        int estimatedTime;
+
+        if (bestNode == null) {
+            path = new ArrayList<>(List.of(startSubwayId, endSubwayId));
+            estimatedTime = (int) heuristic(startSubwayId, endSubwayId, subwayMap);
+        } else {
+            path = new ArrayList<>(bestNode.subwayIds());
+            estimatedTime = bestNode.totalTime();
+
+            if (!path.getLast().equals(endSubwayId)) {
+                path.add(endSubwayId);
+                estimatedTime += (int) heuristic(bestNode.subwayId(), endSubwayId, subwayMap);
+            }
+        }
+
+        List<String> pathNames = path.stream()
+                .map(id -> subwayMap.get(id).getName())
+                .collect(Collectors.toList());
+        log.info("[SubwayPathProcessor] : 대체 경로 생성 - path: {}, totalTime: {}", path, estimatedTime);
+        return new SubwayPathResult(estimatedTime, path, pathNames);
+    }
+
+    /**
+     * 기존 경로에 새로운 역 ID를 추가하여 새 경로 생성.
+     *
+     * @param path     기존 경로 (역 ID 리스트)
+     * @param subwayId 추가할 역 ID
+     * @return 새 경로
+     */
     private List<Integer> addSubwayToPath(List<Integer> path, int subwayId) {
         List<Integer> newPath = new ArrayList<>(path);
         newPath.add(subwayId);
         return newPath;
-    }
-
-    private Map<Integer, Subway> mapSubwaysById() {
-        return subwayRepository.findAll()
-                .stream()
-                .collect(Collectors.toMap(Subway::getSubwayId, Function.identity()));
-    }
-
-    private Map<Integer, List<SubwayConnection>> groupConnectionsByFromId() {
-        return subwayConnectionRepository.findAllWithSubways()
-                .stream()
-                .collect(Collectors.groupingBy(subwayConnection -> subwayConnection.getFromSubway().getSubwayId()));
-    }
-
-    private Map<Integer, List<TransferInfo>> groupTransfersByFromId() {
-        return transferInfoRepository.findAllWithSubways()
-                .stream()
-                .collect(Collectors.groupingBy(transferInfo -> transferInfo.getFromSubway().getSubwayId()));
     }
 }

--- a/src/test/java/com/meetup/server/ServerApplicationTests.java
+++ b/src/test/java/com/meetup/server/ServerApplicationTests.java
@@ -1,12 +1,13 @@
 package com.meetup.server;
 
+import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("h2")
+@ActiveProfiles("postgresql")
 @SpringBootTest
-class ServerApplicationTests {
+class ServerApplicationTests extends IntegrationTestContainer {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/meetup/server/ServerApplicationTests.java
+++ b/src/test/java/com/meetup/server/ServerApplicationTests.java
@@ -2,11 +2,7 @@ package com.meetup.server;
 
 import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("postgresql")
-@SpringBootTest
 class ServerApplicationTests extends IntegrationTestContainer {
 
 	@Test

--- a/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
@@ -2,16 +2,13 @@ package com.meetup.server.event.implement;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.persistence.EventRepository;
+import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("h2")
-@SpringBootTest
-class EventProcessorTest {
+class EventProcessorTest extends IntegrationTestContainer {
 
     @Autowired
     private EventProcessor eventProcessor;

--- a/src/test/java/com/meetup/server/global/clients/google/place/GooglePlaceClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/google/place/GooglePlaceClientTest.java
@@ -6,17 +6,15 @@ import com.meetup.server.global.clients.google.place.photo.GooglePhotoResponse;
 import com.meetup.server.global.clients.google.place.search.GoogleSearchTextClient;
 import com.meetup.server.global.clients.google.place.search.GoogleSearchTextRequest;
 import com.meetup.server.global.clients.google.place.search.GoogleSearchTextResponse;
+import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@ActiveProfiles("h2")
-@SpringBootTest
-class GooglePlaceClientTest {
+@Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
+class GooglePlaceClientTest extends IntegrationTestContainer {
 
     @Autowired
     private GoogleSearchTextClient googleSearchTextClient;
@@ -24,7 +22,6 @@ class GooglePlaceClientTest {
     @Autowired
     private GooglePhotoClient googlePhotoClient;
 
-    @Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
     @Test
     void 구글_텍스트_검색_요청에_성공하고_장소_사진_조회에_성공한다() {
         GoogleSearchTextRequest request = GoogleSearchTextRequest.from("스타벅스 방배점");

--- a/src/test/java/com/meetup/server/global/clients/kakao/local/KakaoLocalClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/kakao/local/KakaoLocalClientTest.java
@@ -1,17 +1,15 @@
 package com.meetup.server.global.clients.kakao.local;
 
+import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@ActiveProfiles("h2")
-@SpringBootTest
-class KakaoLocalClientTest {
+@Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
+class KakaoLocalClientTest extends IntegrationTestContainer {
 
     @Autowired
     private KakaoLocalCategoryClient kakaoLocalCategoryClient;
@@ -19,7 +17,6 @@ class KakaoLocalClientTest {
     @Autowired
     private KakaoLocalKeywordClient kakaoLocalKeywordClient;
 
-    @Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
     @Test
     void 카카오_카테고리_조회에_성공한다() {
         // given
@@ -36,7 +33,6 @@ class KakaoLocalClientTest {
         assertFalse(response.getKakaoSearchResponses().isEmpty());
     }
 
-    @Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
     @Test
     void 카카오_키워드_조회에_성공한다() {
         // given

--- a/src/test/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClientTest.java
@@ -1,21 +1,18 @@
 package com.meetup.server.global.clients.kakao.mobility;
 
+import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@ActiveProfiles("h2")
-@SpringBootTest
-class KakaoMobilityClientTest {
+@Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
+class KakaoMobilityClientTest extends IntegrationTestContainer {
 
     @Autowired
     private KakaoMobilityClient kakaoMobilityClient;
 
-    @Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
     @Test
     void 카카오_자동차_길찾기_조회에_성공한다() {
         // given

--- a/src/test/java/com/meetup/server/global/clients/odsay/OdsayClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/odsay/OdsayClientTest.java
@@ -2,22 +2,19 @@ package com.meetup.server.global.clients.odsay;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@ActiveProfiles("h2")
-@SpringBootTest
-class OdsayClientTest {
+@Disabled("API 호출 시, IP 등록이 필요하여 테스트 비활성화")
+class OdsayClientTest extends IntegrationTestContainer {
 
     @Autowired
     private OdsayTransitRouteSearchClient odsayTransitRouteSearchClient;
 
-    @Disabled("API 호출 시, IP 등록이 필요하여 테스트 비활성화")
     @Test
     void 오디세이_대중교통_길찾기_조회에_성공한다() throws JsonProcessingException {
         // given

--- a/src/test/java/com/meetup/server/support/IntegrationTestContainer.java
+++ b/src/test/java/com/meetup/server/support/IntegrationTestContainer.java
@@ -8,7 +8,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-@ActiveProfiles("postgres")
+@ActiveProfiles("test")
 @Testcontainers
 @SpringBootTest
 public abstract class IntegrationTestContainer {

--- a/src/test/java/com/meetup/server/user/application/UserServiceTest.java
+++ b/src/test/java/com/meetup/server/user/application/UserServiceTest.java
@@ -2,20 +2,17 @@ package com.meetup.server.user.application;
 
 
 import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.support.IntegrationTestContainer;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.dto.response.UserProfileInfoResponse;
 import com.meetup.server.user.persistence.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("h2")
-@SpringBootTest
-class UserServiceTest {
+class UserServiceTest extends IntegrationTestContainer {
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/com/meetup/server/user/implement/UserReaderTest.java
+++ b/src/test/java/com/meetup/server/user/implement/UserReaderTest.java
@@ -1,21 +1,18 @@
 package com.meetup.server.user.implement;
 
 import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.support.IntegrationTestContainer;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.persistence.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("h2")
-@SpringBootTest
-class UserReaderTest {
+class UserReaderTest extends IntegrationTestContainer {
 
     @Autowired
     private UserReader userReader;


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #107 

## 💡 작업 내용
### 문제 정의
![스크린샷 2025-05-27 오후 11 36 23](https://github.com/user-attachments/assets/91822fb1-81d6-407b-834d-25801d130a85)
- CPU 서버가 가끔씩 100%로 사용되고 이것이 감소하지 않고 100% 사용량을 유지하는 문제가 발생했습니다.
- 확인해보니, 중간지점 최단 경로를 찾는 도중에 환승이 깊어질수록 node 개수가 감소하지 않고 계속 증가하며 결국 무한루프가 발생하게 되었습니다. 즉 스레드가 중간지점 최단 경로를 찾을 때까지 Busy Waiting하여 CPU 자원을 계속 소모하고 있었습니다.

### 해결
- 다익스트라 알고리즘을 돌 때 노드의 수가 최대 500개가 넘을 경우, 대체 경로를 반환합니다. 대체 경로는 중간 지점 후보군 중 휴리스틱 함수를 활용하여 선정됩니다.
- 환승은 최대 3번까지만 가능하도록 변경하였습니다. 기존 방식은 환승이 계속 이뤄질 수 있어 노드가 비례하여 추가되기 때문입니다.

## 📸 스크린샷


### 문제가 된 모임을 로컬에서 테스트한 결과
![스크린샷 2025-05-27 오후 11 45 21](https://github.com/user-attachments/assets/96a4ee32-b645-4f2a-8e7b-507697cb9731)



## 💬리뷰 요구사항
- 추후 알고리즘 개선 및 리팩토링을 위해 주석을 달아두었습니다. 아무래도 이해하기 복잡한 로직인 만큼, 숙지가 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 두 지리적 지점 간 거리를 계산하는 기능이 추가되었습니다.

- **개선 사항**
  - 지하철 경로 탐색이 A* 알고리즘을 활용하여 더욱 효율적으로 개선되었습니다.
  - 경로 탐색 시 최대 환승 횟수(3회) 및 노드 탐색 제한(500개)이 적용되어 안정성이 향상되었습니다.
  - 경로 탐색 실패 시 대체 경로가 제공됩니다.

- **기타**
  - 경로 결과에 환승 횟수 정보가 추가되었습니다.
  - 테스트 환경이 통합 테스트 컨테이너 기반으로 변경되어 테스트 설정이 일원화되었습니다.
  - 일부 API 연동 테스트가 비용 및 환경 문제로 인해 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->