### PR TITLE
FIX: #105 resolver 추가를 통해 state 를 유지해서 프론트로 값 포함하여 redirect 가능하도록 하기

### DIFF
--- a/src/main/java/com/meetup/server/auth/support/CookieUtil.java
+++ b/src/main/java/com/meetup/server/auth/support/CookieUtil.java
@@ -14,8 +14,8 @@ public class CookieUtil {
 
     private final CookieProperties cookieProperties;
 
-    private void setCommonCookie(HttpServletResponse response, String cookieName, String cookieValue, int maxAge) {
-        ResponseCookie cookie = ResponseCookie.from(cookieName, cookieValue)
+    private void setCommonCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(cookieProperties.httpOnly())
                 .secure(cookieProperties.secure())
                 .path("/")

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -19,9 +18,6 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-
-    @Value("${app.oauth2.successRedirectUri}")
-    private String successRedirectUri;
 
     private final JwtTokenProvider tokenProvider;
     private final CookieUtil cookieUtil;
@@ -39,13 +35,45 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         cookieUtil.setAccessTokenCookie(response, accessToken);
         cookieUtil.setRefreshTokenCookie(response, refreshToken);
 
-        String targetUrl = createRedirectUrlWithTokens();
+        String targetUrl = createRedirectUrlWithTokens(request);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 
-    private String createRedirectUrlWithTokens() {
-        return UriComponentsBuilder.fromUriString(successRedirectUri)
+    private String createRedirectUrlWithTokens(HttpServletRequest request) {
+        log.info("[Redriect URI] - {}", createRedirectUrl(request));
+        return UriComponentsBuilder.fromUriString(createRedirectUrl(request))
                 .build()
                 .toUriString();
+    }
+
+    private String createRedirectUrl(HttpServletRequest request) {
+        String state = request.getParameter("state");
+        String decodedState = java.net.URLDecoder.decode(state, java.nio.charset.StandardCharsets.UTF_8);
+
+        String to = null;
+        String eventId = null;
+
+        for (String param : decodedState.split("&")) {
+            String[] keyValue = param.split("=", 2);
+            if (keyValue.length == 2) {
+                if ("to".equals(keyValue[0])) {
+                    to = keyValue[1];
+                } else if ("eventId".equals(keyValue[0])) {
+                    eventId = keyValue[1];
+                }
+            }
+        }
+
+        if (to == null) {
+            to = "http://localhost:5173/history"; // 원하는 fallback URL
+        }
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(to);
+
+        if (eventId != null) {
+            uriBuilder.queryParam("eventId", eventId);
+        }
+
+        return uriBuilder.build().toUriString();
     }
 }

--- a/src/main/java/com/meetup/server/auth/support/resolver/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/meetup/server/auth/support/resolver/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,51 @@
+package com.meetup.server.auth.support.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final OAuth2AuthorizationRequestResolver defaultResolver;
+
+    public CustomAuthorizationRequestResolver(ClientRegistrationRepository repo, String authorizationRequestBaseUri) {
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(repo, authorizationRequestBaseUri);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest req = defaultResolver.resolve(request);
+        return customizeAuthorizationRequest(request, req);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest req = defaultResolver.resolve(request, clientRegistrationId);
+        return customizeAuthorizationRequest(request, req);
+    }
+
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(HttpServletRequest request, OAuth2AuthorizationRequest req) {
+        if (req == null) {
+            return null;
+        }
+
+        String to = request.getParameter("to");
+        String eventId = request.getParameter("eventId");
+
+        if (to == null || eventId == null) {
+            return req;
+        }
+
+        String stateValue = "to=" + to + "&eventId=" + eventId;
+        stateValue = URLEncoder.encode(stateValue, StandardCharsets.UTF_8);
+
+        return OAuth2AuthorizationRequest.from(req)
+                .state(stateValue)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #105 

## 💡 작업 내용
- resolver 추가를 통해 state 를 유지 하도록 했습니다
- redirect 시  to와 eventId 겂을 함께 넘기도록 진행했습니다. eventId 가 안들어온 경우에는 값을 넘기지 않고 기본 redirect uri 로 진행합니다

## 📸 스크린샷

## 💬리뷰 요구사항
- server 를 구분하여 redirect 를 다르게 보내주는 자동화 부분은 수정 사항과 함께 반영하기에 무리인 것 같아 코드를 삭제하고 
- 프론트에서 요구한 값을 넘겨주며 redirect 한 과정만 진행하였습니다

- 추가로 프론트에서  redirect uri 를 도메인을 모두 포함해서 넘기는 것에 무리가 있다고 해서, 자동화 하는 과정은 추후에 진행하도록 하겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OAuth2 인증 플로우에서 요청 파라미터(to, eventId)를 state 값으로 전달하여 인증 후 리다이렉트 시 동적으로 반영되도록 개선되었습니다.

- **버그 수정**
  - 인증 성공 후 리다이렉트 URL이 요청에 따라 동적으로 생성되어, eventId와 to 파라미터가 반영됩니다.

- **기타**
  - 내부 파라미터 명칭이 일부 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->