### PR TITLE
FEAT: #106 API Rate Limiter로 API 호출 관리하기

### DIFF
--- a/src/main/java/com/meetup/server/global/clients/exception/ClientErrorType.java
+++ b/src/main/java/com/meetup/server/global/clients/exception/ClientErrorType.java
@@ -1,0 +1,17 @@
+package com.meetup.server.global.clients.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ClientErrorType implements ErrorType {
+    EXCEED_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "일일 제한 호출수를 초과하였습니다.")
+    ;
+
+    private final HttpStatus status;
+
+    private final String message;
+}

--- a/src/main/java/com/meetup/server/global/clients/exception/ClientException.java
+++ b/src/main/java/com/meetup/server/global/clients/exception/ClientException.java
@@ -1,0 +1,11 @@
+package com.meetup.server.global.clients.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+
+public class ClientException extends GlobalException {
+
+    public ClientException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
+++ b/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
@@ -1,5 +1,6 @@
 package com.meetup.server.global.clients.kakao.mobility;
 
+import com.meetup.server.global.clients.util.LimitRequestPerDay;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -12,6 +13,10 @@ public class KakaoMobilityClient {
 
     private final WebClient kakaoMobilityWebClient;
 
+    @LimitRequestPerDay(
+            key = "kakao-mobility",
+            count = 10000
+    )
     public KakaoMobilityResponse sendRequest(KakaoMobilityRequest request) {
         return kakaoMobilityWebClient
                 .get()

--- a/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
+++ b/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
@@ -1,5 +1,6 @@
 package com.meetup.server.global.clients.odsay;
 
+import com.meetup.server.global.clients.util.LimitRequestPerDay;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,6 +16,10 @@ public class OdsayTransitRouteSearchClient {
     private final WebClient webClient;
     private final OdsayProperties odsayProperties;
 
+    @LimitRequestPerDay(
+            key = "odsay-transit",
+            count = 1000
+    )
     public OdsayTransitRouteSearchResponse sendRequest(OdsayTransitRouteSearchRequest request) {
         URI uri = UriComponentsBuilder.fromUriString(odsayProperties.baseUrl() + "/searchPubTransPathT")
                 .queryParam("apiKey", odsayProperties.secretKey())

--- a/src/main/java/com/meetup/server/global/clients/util/LimitRequestPerDay.java
+++ b/src/main/java/com/meetup/server/global/clients/util/LimitRequestPerDay.java
@@ -1,0 +1,15 @@
+package com.meetup.server.global.clients.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = {ElementType.TYPE, ElementType.METHOD})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface LimitRequestPerDay {
+
+    String key() default "";
+
+    int count();
+}

--- a/src/main/java/com/meetup/server/global/clients/util/RateLimiter.java
+++ b/src/main/java/com/meetup/server/global/clients/util/RateLimiter.java
@@ -1,0 +1,6 @@
+package com.meetup.server.global.clients.util;
+
+public interface RateLimiter {
+
+    void tryApiCall(LimitRequestPerDay limitRequestPerDay);
+}

--- a/src/main/java/com/meetup/server/global/clients/util/RateLimiterAspect.java
+++ b/src/main/java/com/meetup/server/global/clients/util/RateLimiterAspect.java
@@ -1,0 +1,42 @@
+package com.meetup.server.global.clients.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+@Slf4j
+@Aspect
+@Component
+public class RateLimiterAspect {
+
+    private final RateLimiter rateLimiter;
+
+    public RateLimiterAspect(@Qualifier("redisRateLimiter") RateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    @Around("execution(* com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchClient.*(..)) || " +
+            "execution(* com.meetup.server.global.clients.kakao.mobility.KakaoMobilityClient.*(..))")
+    public Object findLimitRequestPerDayAnnotation(ProceedingJoinPoint joinPoint) throws Throwable {
+        LimitRequestPerDay limitRequestPerDay = getLimitRequestPerDayAnnotationFromMethod(joinPoint);
+        if (Objects.isNull(limitRequestPerDay)) {
+            return joinPoint.proceed();
+        }
+
+        rateLimiter.tryApiCall(limitRequestPerDay);
+        return joinPoint.proceed();
+    }
+
+    private LimitRequestPerDay getLimitRequestPerDayAnnotationFromMethod(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        return method.getAnnotation(LimitRequestPerDay.class);
+    }
+}

--- a/src/main/java/com/meetup/server/global/clients/util/RateLimiterAspect.java
+++ b/src/main/java/com/meetup/server/global/clients/util/RateLimiterAspect.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
-import java.util.Objects;
 
 @Slf4j
 @Aspect
@@ -22,14 +21,9 @@ public class RateLimiterAspect {
         this.rateLimiter = rateLimiter;
     }
 
-    @Around("execution(* com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchClient.*(..)) || " +
-            "execution(* com.meetup.server.global.clients.kakao.mobility.KakaoMobilityClient.*(..))")
-    public Object findLimitRequestPerDayAnnotation(ProceedingJoinPoint joinPoint) throws Throwable {
+    @Around("@annotation(com.meetup.server.global.clients.util.LimitRequestPerDay)")
+    public Object applyRateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
         LimitRequestPerDay limitRequestPerDay = getLimitRequestPerDayAnnotationFromMethod(joinPoint);
-        if (Objects.isNull(limitRequestPerDay)) {
-            return joinPoint.proceed();
-        }
-
         rateLimiter.tryApiCall(limitRequestPerDay);
         return joinPoint.proceed();
     }

--- a/src/main/java/com/meetup/server/global/clients/util/RedisRateLimiter.java
+++ b/src/main/java/com/meetup/server/global/clients/util/RedisRateLimiter.java
@@ -1,0 +1,43 @@
+package com.meetup.server.global.clients.util;
+
+import com.meetup.server.global.clients.exception.ClientErrorType;
+import com.meetup.server.global.clients.exception.ClientException;
+import com.meetup.server.global.util.TimeUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisRateLimiter implements RateLimiter {
+
+    private final RedisTemplate<String, String> redisRateLimitTemplate;
+    private final RedisScript<Long> redisRateLimitScript;
+
+    @Override
+    public void tryApiCall(LimitRequestPerDay limitRequestPerDay) {
+        Long result = redisRateLimitTemplate.execute(
+                redisRateLimitScript,
+                Collections.singletonList(limitRequestPerDay.key()),
+                String.valueOf(getTTL().toSeconds()),
+                String.valueOf(limitRequestPerDay.count())
+        );
+
+        if (result == -1) {
+            throw new ClientException(ClientErrorType.EXCEED_RATE_LIMIT_PER_DAY);
+        }
+    }
+
+    private Duration getTTL() {
+        ZonedDateTime now = ZonedDateTime.now(TimeUtil.KST_ZONE_ID);
+        ZonedDateTime midnight = now.plusDays(1).toLocalDate().atStartOfDay(TimeUtil.KST_ZONE_ID);
+        return Duration.between(now, midnight);
+    }
+}

--- a/src/main/java/com/meetup/server/global/config/RedisConfig.java
+++ b/src/main/java/com/meetup/server/global/config/RedisConfig.java
@@ -9,8 +9,6 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
@@ -21,12 +19,6 @@ import java.time.Duration;
 @Slf4j
 @Configuration
 public class RedisConfig {
-
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Value("${spring.data.redis.host}")
-    private String host;
 
     @Value("${spring.data.redis.time-to-live}")
     private long timeToLive;
@@ -47,20 +39,12 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisRateLimitTemplate() {
+    public RedisTemplate<String, String> redisRateLimitTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
-        redisTemplate.setConnectionFactory(redisRateLimitConnectionFactory());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.afterPropertiesSet();
         return redisTemplate;
-    }
-
-    @Bean
-    public RedisConnectionFactory redisRateLimitConnectionFactory() {
-        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
-        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
-        lettuceConnectionFactory.afterPropertiesSet();
-        return lettuceConnectionFactory;
     }
 }

--- a/src/main/java/com/meetup/server/global/config/RedisScriptConfig.java
+++ b/src/main/java/com/meetup/server/global/config/RedisScriptConfig.java
@@ -1,0 +1,17 @@
+package com.meetup.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@Configuration
+public class RedisScriptConfig {
+
+    @Bean
+    public RedisScript<Long> redisRateLimitScript() {
+        Resource redisRateLimitScript = new ClassPathResource("scripts/rate_limit_script.lua");
+        return RedisScript.of(redisRateLimitScript, Long.class);
+    }
+}

--- a/src/main/resources/scripts/rate_limit_script.lua
+++ b/src/main/resources/scripts/rate_limit_script.lua
@@ -1,0 +1,15 @@
+local key = KEYS[1]
+local current = tonumber(redis.call('GET', key))
+local limitCount = tonumber(ARGV[2])
+
+if not current then
+    redis.call('SET', key, 1, 'EX', ARGV[1])
+    return 1
+end
+
+if current >= limitCount then
+    return -1
+else
+    redis.call('INCR', key)
+    return current + 1
+end

--- a/src/test/java/com/meetup/server/global/clients/util/RateLimiterTest.java
+++ b/src/test/java/com/meetup/server/global/clients/util/RateLimiterTest.java
@@ -1,0 +1,112 @@
+package com.meetup.server.global.clients.util;
+
+import com.meetup.server.global.clients.exception.ClientException;
+import com.meetup.server.support.IntegrationTestContainer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.lang.annotation.Annotation;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class RateLimiterTest extends IntegrationTestContainer {
+
+    @Autowired
+    RedisTemplate<String, String> redisRateLimitTemplate;
+
+    @Autowired
+    RateLimiter rateLimiter;
+
+    @BeforeEach
+    void resetKeys() {
+        redisRateLimitTemplate.delete("test");
+    }
+
+    @Test
+    void 싱글스레드에서_최대요청수만큼만_허용한다() {
+        // given
+        LimitRequestPerDay annotation = new LimitRequestPerDay() {
+            @Override
+            public String key() {
+                return "test";
+            }
+
+            @Override
+            public int count() {
+                return 5;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return LimitRequestPerDay.class;
+            }
+        };
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < 10; i++) {
+            try {
+                rateLimiter.tryApiCall(annotation);
+                successCount.incrementAndGet();
+            } catch (ClientException e) {
+                failCount.incrementAndGet();
+            }
+        }
+
+        Assertions.assertEquals(5, successCount.get());
+        Assertions.assertEquals(5, failCount.get());
+
+    }
+
+    @Test
+    void 동시_요청_상황에서도_요청제한을_원자적으로_보장한다() throws InterruptedException {
+        // given
+        LimitRequestPerDay annotation = new LimitRequestPerDay() {
+            @Override
+            public String key() {
+                return "test";
+            }
+
+            @Override
+            public int count() {
+                return 10;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return LimitRequestPerDay.class;
+            }
+        };
+
+        int totalThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(totalThreads);
+        CountDownLatch latch = new CountDownLatch(totalThreads);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < totalThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    rateLimiter.tryApiCall(annotation);
+                    successCount.incrementAndGet();
+                } catch (ClientException e) {
+                    failCount.incrementAndGet();
+                }
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        Assertions.assertEquals(10, successCount.get());
+    }
+
+}

--- a/src/test/resources/scripts/rate_limit_script.lua
+++ b/src/test/resources/scripts/rate_limit_script.lua
@@ -1,0 +1,15 @@
+local key = KEYS[1]
+local current = tonumber(redis.call('GET', key))
+local limitCount = tonumber(ARGV[2])
+
+if not current then
+    redis.call('SET', key, 1, 'EX', ARGV[1])
+    return 1
+end
+
+if current >= limitCount then
+    return -1
+else
+    redis.call('INCR', key)
+    return current + 1
+end


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #106 

## 💡 작업 내용
- Redis와 Lua Script를 사용해서 API 호출을 관리할 수 있도록 하였습니다.
- 자세한 내용은 [블로그](https://developer-anxi.tistory.com/76)를 참고해주세요!
- 추가로 Redis Key를 가지고 GET하는 과정에서 Race Condition이 발생하여 Lua Script를 사용해 원자적으로 처리하였습니다.

## 📸 스크린샷
![스크린샷 2025-05-29 오후 12 21 03](https://github.com/user-attachments/assets/321959c7-fab6-423f-890f-4ac76ef01118)

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 일일 API 호출 제한 기능이 도입되어, 각 외부 클라이언트 요청에 대해 일일 최대 호출 횟수가 적용됩니다.
  - 호출 제한 초과 시, "일일 제한 호출수를 초과하였습니다."라는 메시지와 함께 요청이 차단됩니다.

- **버그 수정**
  - 없음

- **테스트**
  - 단일 및 동시 요청 상황에서 호출 제한이 정상적으로 동작하는지 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->