### PR TITLE
FIX: #113 리뷰 조회에서 eventId 를 고려하도록 변경하기

### DIFF
--- a/src/main/java/com/meetup/server/auth/support/resolver/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/meetup/server/auth/support/resolver/CustomAuthorizationRequestResolver.java
@@ -37,7 +37,7 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
         String to = request.getParameter("to");
         String eventId = request.getParameter("eventId");
 
-        if (to == null || eventId == null) {
+        if (to == null && eventId == null) {
             return req;
         }
 

--- a/src/main/java/com/meetup/server/review/application/ReviewService.java
+++ b/src/main/java/com/meetup/server/review/application/ReviewService.java
@@ -1,5 +1,7 @@
 package com.meetup.server.review.application;
 
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.implement.EventReader;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.place.implement.PlaceReader;
 import com.meetup.server.review.dto.request.NonVisitedReviewRequest;
@@ -20,20 +22,23 @@ public class ReviewService {
     private final PlaceReader placeReader;
     private final UserReader userReader;
     private final ReviewWriter reviewWriter;
+    private final EventReader eventReader;
 
     @Transactional
-    public void createVisitedReview(UUID placeId, Long userId, VisitedReviewRequest visitedReviewRequest) {
+    public void createVisitedReview(UUID eventId, UUID placeId, Long userId, VisitedReviewRequest visitedReviewRequest) {
         Place place = placeReader.read(placeId);
         User user = userReader.read(userId);
+        Event event = eventReader.read(eventId);
 
-        reviewWriter.saveVisitedReview(place, user, visitedReviewRequest);
+        reviewWriter.saveVisitedReview(event, place, user, visitedReviewRequest);
     }
 
     @Transactional
-    public void createNonVisitedReview(UUID placeId, Long userId, NonVisitedReviewRequest nonVisitedReviewRequest) {
+    public void createNonVisitedReview(UUID eventId, UUID placeId, Long userId, NonVisitedReviewRequest nonVisitedReviewRequest) {
         Place place = placeReader.read(placeId);
         User user = userReader.read(userId);
+        Event event = eventReader.read(eventId);
 
-        reviewWriter.saveNonVisitedReview(place, user, nonVisitedReviewRequest);
+        reviewWriter.saveNonVisitedReview(event, place, user, nonVisitedReviewRequest);
     }
 }

--- a/src/main/java/com/meetup/server/review/domain/Review.java
+++ b/src/main/java/com/meetup/server/review/domain/Review.java
@@ -1,5 +1,6 @@
 package com.meetup.server.review.domain;
 
+import com.meetup.server.event.domain.Event;
 import com.meetup.server.global.domain.BaseEntity;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.user.domain.User;
@@ -24,6 +25,10 @@ public class Review extends BaseEntity {
     private Place place;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
@@ -37,12 +42,13 @@ public class Review extends BaseEntity {
     private NonVisitedReview nonVisitedReview;
 
     @Builder
-    public Review(Place place, User user, boolean isVisited, VisitedReview visitedReview, NonVisitedReview nonVisitedReview) {
+    public Review(Place place, User user, boolean isVisited, VisitedReview visitedReview, NonVisitedReview nonVisitedReview, Event event) {
         this.place = place;
         this.user = user;
         this.isVisited = isVisited;
         this.visitedReview = visitedReview;
         this.nonVisitedReview = nonVisitedReview;
+        this.event = event;
     }
 
     public boolean isWrittenBy(Long userId) {

--- a/src/main/java/com/meetup/server/review/implement/ReviewValidator.java
+++ b/src/main/java/com/meetup/server/review/implement/ReviewValidator.java
@@ -1,5 +1,6 @@
 package com.meetup.server.review.implement;
 
+import com.meetup.server.event.domain.Event;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.review.exception.ReviewErrorType;
 import com.meetup.server.review.exception.ReviewException;
@@ -14,8 +15,8 @@ public class ReviewValidator {
 
     private final ReviewRepository reviewRepository;
 
-    public void validateReviewIsAlreadyWritten(Place place, User user) {
-        if (reviewRepository.existsByPlaceAndUser(place, user)) {
+    public void validateReviewIsAlreadyWritten(Event event, Place place, User user) {
+        if (reviewRepository.existsByEventAndPlaceAndUser(event, place, user)) {
             throw new ReviewException(ReviewErrorType.ALREADY_REVIEW_EXISTS);
         }
     }

--- a/src/main/java/com/meetup/server/review/implement/ReviewWriter.java
+++ b/src/main/java/com/meetup/server/review/implement/ReviewWriter.java
@@ -1,5 +1,6 @@
 package com.meetup.server.review.implement;
 
+import com.meetup.server.event.domain.Event;
 import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.review.domain.NonVisitedReview;
@@ -23,10 +24,10 @@ public class ReviewWriter {
     private final ReviewRepository reviewRepository;
     private final ReviewValidator reviewValidator;
 
-    public void saveVisitedReview(Place place, User user, VisitedReviewRequest visitedReviewRequest) {
-        reviewValidator.validateReviewIsAlreadyWritten(place, user);
+    public void saveVisitedReview(Event event, Place place, User user, VisitedReviewRequest visitedReviewRequest) {
+        reviewValidator.validateReviewIsAlreadyWritten(event, place, user);
 
-        Review review = createReview(place, user, true);
+        Review review = createReview(event, place, user, true);
 
         VisitedReview visitedReview = VisitedReview.builder()
                 .review(review)
@@ -39,10 +40,10 @@ public class ReviewWriter {
         reviewRepository.save(review);
     }
 
-    public void saveNonVisitedReview(Place place, User user, NonVisitedReviewRequest nonVisitedReviewRequest) {
-        reviewValidator.validateReviewIsAlreadyWritten(place, user);
+    public void saveNonVisitedReview(Event event, Place place, User user, NonVisitedReviewRequest nonVisitedReviewRequest) {
+        reviewValidator.validateReviewIsAlreadyWritten(event, place, user);
 
-        Review review = createReview(place, user, false);
+        Review review = createReview(event, place, user, false);
 
         NonVisitedReview.NonVisitedReviewBuilder nonVisitedReviewBuilder = NonVisitedReview.builder()
                 .review(review)
@@ -66,8 +67,9 @@ public class ReviewWriter {
         reviewRepository.save(review);
     }
 
-    private Review createReview(Place place, User user, boolean isVisited) {
+    private Review createReview(Event event, Place place, User user, boolean isVisited) {
         return Review.builder()
+                .event(event)
                 .place(place)
                 .user(user)
                 .isVisited(isVisited)

--- a/src/main/java/com/meetup/server/review/persistence/ReviewRepository.java
+++ b/src/main/java/com/meetup/server/review/persistence/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.meetup.server.review.persistence;
 
+import com.meetup.server.event.domain.Event;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.review.domain.Review;
 import com.meetup.server.user.domain.User;
@@ -11,5 +12,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewCus
 
     List<Review> findAllByPlace(Place place);
 
-    boolean existsByPlaceAndUser(Place place, User user);
+    boolean existsByEventAndPlaceAndUser(Event event, Place place, User user);
 }

--- a/src/main/java/com/meetup/server/review/persistence/init/ReviewDummy.java
+++ b/src/main/java/com/meetup/server/review/persistence/init/ReviewDummy.java
@@ -1,5 +1,7 @@
 package com.meetup.server.review.persistence.init;
 
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.persistence.EventRepository;
 import com.meetup.server.global.support.DummyDataInit;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.place.persistence.PlaceRepository;
@@ -30,6 +32,7 @@ public class ReviewDummy implements ApplicationRunner {
     private final ReviewRepository reviewRepository;
     private final PlaceRepository placeRepository;
     private final UserRepository userRepository;
+    private final EventRepository eventRepository;
 
     @Override
     public void run(ApplicationArguments args) {
@@ -40,20 +43,25 @@ public class ReviewDummy implements ApplicationRunner {
 
             UUID placeId = UUID.fromString("0196e4a6-e812-74a7-9525-7ae7c5345490");
             Place place = placeRepository.findById(placeId).orElseThrow();
+            UUID eventId = UUID.fromString("01971cac-d384-734e-ad79-ef8568129841");
+            Event event = eventRepository.findById(eventId).orElseThrow();
 
             Review DUMMY_REVIEW_1 = Review.builder()
+                    .event(event)
                     .place(place)
                     .user(userRepository.findById(1L).orElseThrow())
                     .isVisited(true)
                     .build();
 
             Review DUMMY_REVIEW_2 = Review.builder()
+                    .event(event)
                     .place(place)
                     .user(userRepository.findById(2L).orElseThrow())
                     .isVisited(true)
                     .build();
 
             Review DUMMY_REVIEW_3 = Review.builder()
+                    .event(event)
                     .place(place)
                     .user(userRepository.findById(4L).orElseThrow())
                     .isVisited(true)

--- a/src/main/java/com/meetup/server/review/presentation/ReviewController.java
+++ b/src/main/java/com/meetup/server/review/presentation/ReviewController.java
@@ -26,9 +26,10 @@ public class ReviewController {
     public ApiResponse<?> createVisitedReview(
             @PathVariable("placeId") UUID placeId,
             @AuthenticationPrincipal Long userId,
+            @RequestParam(value = "eventId") UUID eventId,
             @Valid @RequestBody VisitedReviewRequest visitedReviewRequest) {
 
-        reviewService.createVisitedReview(placeId, userId, visitedReviewRequest);
+        reviewService.createVisitedReview(eventId, placeId, userId, visitedReviewRequest);
         return ApiResponse.success();
     }
 
@@ -37,9 +38,10 @@ public class ReviewController {
     public ApiResponse<?> createNonVisitedReview(
             @PathVariable("placeId") UUID placeId,
             @AuthenticationPrincipal Long userId,
+            @RequestParam(value = "eventId") UUID eventId,
             @Valid @RequestBody NonVisitedReviewRequest nonVisitedReviewRequest) {
 
-        reviewService.createNonVisitedReview(placeId, userId, nonVisitedReviewRequest);
+        reviewService.createNonVisitedReview(eventId, placeId, userId, nonVisitedReviewRequest);
         return ApiResponse.success();
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #113 

## 💡 작업 내용
- 리뷰 조회에서 eventId 를 고려하여 조회 가능하도록 수정했습니다
- review 테이블의 event 칼럼을 추가했습니다
- 리뷰 저장 과정을 변경했습니다

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/3fc45a03-65d5-4529-9e97-db0914ee4d88)


## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 리뷰 작성 시 이벤트 정보를 함께 등록할 수 있도록 개선되었습니다.

- **버그 수정**
    - 리뷰 중복 작성 여부를 이벤트, 장소, 사용자 기준으로 더 정확하게 검증합니다.

- **기타**
    - 리뷰 조회 시 이벤트 조건이 추가되어 더욱 정확한 결과를 제공합니다.
    - OAuth2 인증 요청 처리 조건이 일부 변경되었습니다.
    - 리뷰 작성 API에 이벤트 ID 파라미터가 추가되었습니다.
    - 배포 워크플로우가 풀 리퀘스트 이벤트에도 동작하도록 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->