### PR TITLE
FEAT: #115 swagger 설정 추가하기

### DIFF
--- a/src/main/java/com/meetup/server/auth/presentation/filter/SwaggerAuthFilter.java
+++ b/src/main/java/com/meetup/server/auth/presentation/filter/SwaggerAuthFilter.java
@@ -1,0 +1,79 @@
+package com.meetup.server.auth.presentation.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Base64;
+
+@Component
+@Profile("!local")
+public class SwaggerAuthFilter extends OncePerRequestFilter {
+
+    @Value("${swagger.id}")
+    private String ADMIN_ID;
+
+    @Value("${swagger.pw}")
+    private String ADMIN_PW;
+
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final String[] SWAGGER_LIST = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-ui.html",
+            "/swagger-resources/**",
+            "/webjars/**"
+    };
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        if (isSwaggerRequest(request.getRequestURI())) {
+            String headerWithIDPW = request.getHeader("Authorization");
+
+            if (!isValidBasicAuth(headerWithIDPW)) {
+                response.setHeader("WWW-Authenticate", "Basic realm=\"Swagger API\"");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isSwaggerRequest(String uri) {
+        for (String pattern : SWAGGER_LIST) {
+            if (pathMatcher.match(pattern, uri)) return true;
+        }
+        return false;
+    }
+
+    private boolean isValidBasicAuth(String header) {
+        if (header == null || !header.startsWith("Basic ")) {
+            return false;
+        }
+
+        String base64Credentials = header.substring("Basic ".length());
+        String[] credentials = decodeCredentials(base64Credentials);
+        if (credentials == null || credentials.length != 2) {
+            return false;
+        }
+
+        return ADMIN_ID.equals(credentials[0]) && ADMIN_PW.equals(credentials[1]);
+    }
+
+    private String[] decodeCredentials(String base64) {
+        try {
+            String decoded = new String(Base64.getDecoder().decode(base64));
+            return decoded.split(":", 2);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SecurityConfig.java
@@ -1,14 +1,12 @@
 package com.meetup.server.global.config;
 
 import com.meetup.server.auth.application.CustomOAuth2UserService;
-import com.meetup.server.auth.presentation.filter.JwtAccessDeniedHandler;
-import com.meetup.server.auth.presentation.filter.JwtAuthenticationEntryPoint;
-import com.meetup.server.auth.presentation.filter.JwtAuthenticationFilter;
-import com.meetup.server.auth.presentation.filter.ResponseContextFilter;
+import com.meetup.server.auth.presentation.filter.*;
 import com.meetup.server.auth.support.handler.OAuth2LoginFailureHandler;
 import com.meetup.server.auth.support.handler.OAuth2LoginSuccessHandler;
 import com.meetup.server.auth.support.resolver.CustomAuthorizationRequestResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -23,6 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@ConditionalOnBean(SwaggerAuthFilter.class)
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
@@ -32,6 +31,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final ResponseContextFilter responseContextFilter;
+    private final SwaggerAuthFilter swaggerAuthFilter;
 
     private final String[] BLACK_LIST = {
             "/historys/**",
@@ -70,6 +70,7 @@ public class SecurityConfig {
                                 .successHandler(oAuth2LoginSuccessHandler)
                                 .failureHandler(oAuth2LoginFailureHandler)
                 )
+                .addFilterBefore(swaggerAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(responseContextFilter, JwtAuthenticationFilter.class);
 


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #115 

## 💡 작업 내용
- 현재 도메인이 많은 사람들에게 노출된 상태이고, spot 에서 사용하는 외부 api 가 많은 편이라 혹시 모를 과금 발생 위험을 줄이기 위해서 swagger 보안 설정을 진행했습니다.


## 📸 스크린샷

## 💬리뷰 요구사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- Swagger 관련 경로에 접근 시 기본 인증(Basic Authentication)이 적용되어, 관리자로 설정된 계정 정보로만 접근할 수 있도록 변경되었습니다. (운영/테스트 환경 등 비로컬 프로필에서 적용)
- **기타**
	- 내부 보안 구성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->