### PR TITLE
FEAT: #117 clova studio 사용해서 리뷰 번역하기

### DIFF
--- a/src/main/java/com/meetup/server/global/clients/clova/ClovaClient.java
+++ b/src/main/java/com/meetup/server/global/clients/clova/ClovaClient.java
@@ -16,12 +16,10 @@ public class ClovaClient {
         return clovaWebClient
                 .post()
                 .uri(clovaProperties.basePath())
-                .header("Authorization", "Bearer " + clovaProperties.studioApiKey())
-                .header("X-NCP-CLOVASTUDIO-REQUEST-ID", clovaProperties.requestId())
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(ClovaResponse.class)
-                .block();
+            .block();
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/clova/ClovaClient.java
+++ b/src/main/java/com/meetup/server/global/clients/clova/ClovaClient.java
@@ -1,0 +1,27 @@
+package com.meetup.server.global.clients.clova;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class ClovaClient {
+
+    private final ClovaProperties clovaProperties;
+    private final WebClient clovaWebClient;
+
+    public ClovaResponse sendRequest(ClovaRequest request) {
+        return clovaWebClient
+                .post()
+                .uri(clovaProperties.basePath())
+                .header("Authorization", "Bearer " + clovaProperties.studioApiKey())
+                .header("X-NCP-CLOVASTUDIO-REQUEST-ID", clovaProperties.requestId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(ClovaResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/meetup/server/global/clients/clova/ClovaProperties.java
+++ b/src/main/java/com/meetup/server/global/clients/clova/ClovaProperties.java
@@ -1,0 +1,12 @@
+package com.meetup.server.global.clients.clova;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "clova")
+public record ClovaProperties(
+        String studioApiKey,
+        String requestId,
+        String baseUrl,
+        String basePath
+) {
+}

--- a/src/main/java/com/meetup/server/global/clients/clova/ClovaRequest.java
+++ b/src/main/java/com/meetup/server/global/clients/clova/ClovaRequest.java
@@ -1,0 +1,26 @@
+package com.meetup.server.global.clients.clova;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ClovaRequest(
+        List<Message> messages,
+        double topP,
+        int topK,
+        int maxTokens,
+        double temperature,
+        double repeatPenalty,
+        List<String> stopBefore,
+        boolean includeAiFilters,
+        int seed
+
+) {
+    @Builder
+    public record Message(
+            String role,
+            String content
+    ) {
+    }
+}

--- a/src/main/java/com/meetup/server/global/clients/clova/ClovaResponse.java
+++ b/src/main/java/com/meetup/server/global/clients/clova/ClovaResponse.java
@@ -1,0 +1,26 @@
+package com.meetup.server.global.clients.clova;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Builder;
+
+@Builder
+public record ClovaResponse(
+        Status status,
+        Result result
+) {
+    public record Status(
+            String code,
+            String message
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Result(
+            Message message
+    ) {
+        public record Message(
+                String role,
+                String content
+        ) {
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/global/config/ConfigurationPropertiesConfig.java
+++ b/src/main/java/com/meetup/server/global/config/ConfigurationPropertiesConfig.java
@@ -1,6 +1,7 @@
 package com.meetup.server.global.config;
 
 import com.meetup.server.auth.support.CookieProperties;
+import com.meetup.server.global.clients.clova.ClovaProperties;
 import com.meetup.server.global.clients.google.place.GooglePlaceProperties;
 import com.meetup.server.global.clients.kakao.local.KakaoLocalProperties;
 import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityProperties;
@@ -10,6 +11,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(value = {JwtProperties.class, KakaoLocalProperties.class, OdsayProperties.class, KakaoMobilityProperties.class, GooglePlaceProperties.class, CookieProperties.class})
+@EnableConfigurationProperties(value = {JwtProperties.class, KakaoLocalProperties.class, OdsayProperties.class, KakaoMobilityProperties.class, GooglePlaceProperties.class, CookieProperties.class, ClovaProperties.class})
 public class ConfigurationPropertiesConfig {
 }

--- a/src/main/java/com/meetup/server/global/config/WebClientConfig.java
+++ b/src/main/java/com/meetup/server/global/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package com.meetup.server.global.config;
 
+import com.meetup.server.global.clients.clova.ClovaProperties;
 import com.meetup.server.global.clients.google.place.GooglePlaceProperties;
 import com.meetup.server.global.clients.kakao.local.KakaoLocalProperties;
 import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityProperties;
@@ -15,6 +16,7 @@ public class WebClientConfig {
     private final KakaoLocalProperties kakaoLocalProperties;
     private final KakaoMobilityProperties kakaoMobilityProperties;
     private final GooglePlaceProperties googlePlaceProperties;
+    private final ClovaProperties clovaProperties;
 
     @Bean
     public WebClient webClient() {
@@ -43,6 +45,15 @@ public class WebClientConfig {
         return WebClient.builder()
                 .defaultHeader("X-Goog-Api-Key", googlePlaceProperties.secretKey())
                 .baseUrl(googlePlaceProperties.baseUrl())
+                .build();
+    }
+
+    @Bean
+    public WebClient clovaWebClient() {
+        return WebClient.builder()
+                .defaultHeader("X-NCP-CLOVASTUDIO-API-KEY",clovaProperties.studioApiKey())
+                .defaultHeader("X-NCP-CLOVASTUDIO-REQUEST-ID", clovaProperties.requestId())
+                .baseUrl(clovaProperties.baseUrl())
                 .build();
     }
 }

--- a/src/main/java/com/meetup/server/global/config/WebClientConfig.java
+++ b/src/main/java/com/meetup/server/global/config/WebClientConfig.java
@@ -51,7 +51,7 @@ public class WebClientConfig {
     @Bean
     public WebClient clovaWebClient() {
         return WebClient.builder()
-                .defaultHeader("X-NCP-CLOVASTUDIO-API-KEY",clovaProperties.studioApiKey())
+                .defaultHeader("Authorization", "Bearer " + clovaProperties.studioApiKey())
                 .defaultHeader("X-NCP-CLOVASTUDIO-REQUEST-ID", clovaProperties.requestId())
                 .baseUrl(clovaProperties.baseUrl())
                 .build();

--- a/src/main/java/com/meetup/server/place/domain/Place.java
+++ b/src/main/java/com/meetup/server/place/domain/Place.java
@@ -89,4 +89,11 @@ public class Place extends BaseEntity {
     public boolean isSamePlace(Place place) {
         return this.id.equals(place.getId());
     }
+
+    public void saveGoogleReviews(List<GoogleReview> googleReviews) {
+        if (googleReviews == null || googleReviews.isEmpty()) {
+            return;
+        }
+        this.googleReviews = googleReviews;
+    }
 }

--- a/src/main/java/com/meetup/server/place/domain/value/GoogleReview.java
+++ b/src/main/java/com/meetup/server/place/domain/value/GoogleReview.java
@@ -12,6 +12,7 @@ import static com.meetup.server.global.util.TimeUtil.KST_ZONE_ID;
 public record GoogleReview(
         Integer rating,
         String content,
+        String translatedContent,
         String author,
         String authorProfileImage,
         LocalDateTime publishTime
@@ -24,9 +25,14 @@ public record GoogleReview(
         return GoogleReview.builder()
                 .rating(review.rating())
                 .content(review.originalText().text())
+                .translatedContent(null)
                 .author(review.authorAttribution().displayName())
                 .authorProfileImage(review.authorAttribution().photoUri())
                 .publishTime(publishTime)
                 .build();
+    }
+
+    public GoogleReview updateContent(String translated) {
+        return new GoogleReview(rating, content, translated, author, authorProfileImage, publishTime);
     }
 }

--- a/src/main/java/com/meetup/server/place/domain/value/GoogleReview.java
+++ b/src/main/java/com/meetup/server/place/domain/value/GoogleReview.java
@@ -32,7 +32,7 @@ public record GoogleReview(
                 .build();
     }
 
-    public GoogleReview updateContent(String translated) {
+    public GoogleReview withTranslateContent(String translated) {
         return new GoogleReview(rating, content, translated, author, authorProfileImage, publishTime);
     }
 }

--- a/src/main/java/com/meetup/server/place/implement/PlaceReader.java
+++ b/src/main/java/com/meetup/server/place/implement/PlaceReader.java
@@ -30,4 +30,8 @@ public class PlaceReader {
     public List<PlaceWithDistance> readAllWithinRadius(Point point, double radius) {
         return placeRepository.findAllWithinRadius(point, radius);
     }
+
+    public List<Place> readAll() {
+        return placeRepository.findAll();
+    }
 }

--- a/src/main/java/com/meetup/server/place/implement/PlaceWriter.java
+++ b/src/main/java/com/meetup/server/place/implement/PlaceWriter.java
@@ -1,0 +1,21 @@
+package com.meetup.server.place.implement;
+
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.domain.value.GoogleReview;
+import com.meetup.server.place.persistence.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PlaceWriter {
+
+    private final PlaceRepository placeRepository;
+
+    public void saveGoogleReviews(Place place, List<GoogleReview> translatedReviews) {
+        place.saveGoogleReviews(translatedReviews);
+        placeRepository.save(place);
+    }
+}

--- a/src/main/java/com/meetup/server/review/application/TranslateGoogleReviewService.java
+++ b/src/main/java/com/meetup/server/review/application/TranslateGoogleReviewService.java
@@ -1,0 +1,106 @@
+package com.meetup.server.review.application;
+
+import com.meetup.server.global.clients.clova.ClovaClient;
+import com.meetup.server.global.clients.clova.ClovaRequest;
+import com.meetup.server.global.clients.clova.ClovaResponse;
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.domain.value.GoogleReview;
+import com.meetup.server.place.implement.PlaceReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TranslateGoogleReviewService {
+
+    private final ClovaClient clovaClient;
+    private final PlaceReader placeReader;
+
+    @Transactional
+    public void saveReviewForKor() {
+        List<Place> places = placeReader.readAll();
+        List<GoogleReview> translatedReviews = new ArrayList<>();
+
+        for (Place place : places) {
+            List<GoogleReview> googleReviews = place.getGoogleReviews();
+            if (googleReviews == null || googleReviews.isEmpty()) continue;
+
+            boolean hasForeignReview = false;
+
+            for (GoogleReview review : googleReviews) {
+                String originalContent = review.content();
+                if (originalContent == null || originalContent.isBlank() || !isForeignLang(originalContent)) {
+                    translatedReviews.add(review);
+                    continue;
+                }
+
+                hasForeignReview = true;
+
+                ClovaRequest request = generateFinalPrompt(originalContent);
+                log.info("[Clova Studio] Request: {}", request);
+                ClovaResponse clovaResponse = clovaClient.sendRequest(request);
+                log.info("[Clova Studio] Response: {}", clovaResponse);
+
+                if (clovaResponse == null || clovaResponse.result() == null || clovaResponse.result().message() == null) {
+                    log.warn("[Clova Studio] Empty or null response for review: {}", originalContent);
+                    translatedReviews.add(review);
+                    continue;
+                }
+
+                String translatedContent = clovaResponse.result().message().content();
+                log.info("[Clova Studio] Original: {}, Translated: {}", originalContent, translatedContent);
+
+                translatedReviews.add(review.updateContent(translatedContent));
+            }
+
+            if (hasForeignReview) {
+                place.saveGoogleReviews(translatedReviews);
+            }
+        }
+    }
+
+    private ClovaRequest generateFinalPrompt(String review) {
+        List<ClovaRequest.Message> messages = new ArrayList<>();
+        messages.add(generateSystemPrompt());
+
+        messages.add(ClovaRequest.Message.builder()
+                .role("user")
+                .content(review)
+                .build());
+
+        return ClovaRequest.builder()
+                .messages(messages)
+                .topP(0.8)
+                .topK(0)
+                .maxTokens(1000)
+                .temperature(0.8)
+                .repeatPenalty(5.0)
+                .includeAiFilters(false)
+                .build();
+    }
+
+    private ClovaRequest.Message generateSystemPrompt() {
+        return ClovaRequest.Message.builder()
+                .role("system")
+                .content("""
+                        당신은 한국어 번역가입니다. 다음 지침을 따르세요:
+                        - 입력하는 문장을 한국어로 번역합니다.
+                        - 질문에 대해 답변하지 말고, 질문을 한국어로 번역합니다.
+                        - 내용을 변경하지 않고 그대로 번역합니다.
+                        """)
+                .build();
+    }
+
+    private boolean isForeignLang(String content) {
+        if (content == null || content.isBlank()) return false;
+
+        String koreanRegex = ".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*";
+        return !content.matches(koreanRegex);
+    }
+}

--- a/src/main/java/com/meetup/server/review/application/TranslateGoogleReviewService.java
+++ b/src/main/java/com/meetup/server/review/application/TranslateGoogleReviewService.java
@@ -1,17 +1,17 @@
 package com.meetup.server.review.application;
 
-import com.meetup.server.global.clients.clova.ClovaClient;
-import com.meetup.server.global.clients.clova.ClovaRequest;
-import com.meetup.server.global.clients.clova.ClovaResponse;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.place.domain.value.GoogleReview;
 import com.meetup.server.place.implement.PlaceReader;
+import com.meetup.server.place.implement.PlaceWriter;
+import com.meetup.server.review.implement.ReviewTranslator;
+import com.meetup.server.review.util.TextUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -19,88 +19,49 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TranslateGoogleReviewService {
 
-    private final ClovaClient clovaClient;
     private final PlaceReader placeReader;
+    private final ReviewTranslator reviewTranslator;
+    private final PlaceWriter placeWriter;
+
 
     @Transactional
     public void saveReviewForKor() {
         List<Place> places = placeReader.readAll();
-        List<GoogleReview> translatedReviews = new ArrayList<>();
 
         for (Place place : places) {
-            List<GoogleReview> googleReviews = place.getGoogleReviews();
-            if (googleReviews == null || googleReviews.isEmpty()) continue;
-
-            boolean hasForeignReview = false;
-
-            for (GoogleReview review : googleReviews) {
-                String originalContent = review.content();
-                if (originalContent == null || originalContent.isBlank() || !isForeignLang(originalContent)) {
-                    translatedReviews.add(review);
-                    continue;
-                }
-
-                hasForeignReview = true;
-
-                ClovaRequest request = generateFinalPrompt(originalContent);
-                log.info("[Clova Studio] Request: {}", request);
-                ClovaResponse clovaResponse = clovaClient.sendRequest(request);
-                log.info("[Clova Studio] Response: {}", clovaResponse);
-
-                if (clovaResponse == null || clovaResponse.result() == null || clovaResponse.result().message() == null) {
-                    log.warn("[Clova Studio] Empty or null response for review: {}", originalContent);
-                    translatedReviews.add(review);
-                    continue;
-                }
-
-                String translatedContent = clovaResponse.result().message().content();
-                log.info("[Clova Studio] Original: {}, Translated: {}", originalContent, translatedContent);
-
-                translatedReviews.add(review.updateContent(translatedContent));
+            List<GoogleReview> originalReviews = place.getGoogleReviews();
+            if (CollectionUtils.isEmpty(originalReviews)) {
+                continue;
             }
 
-            if (hasForeignReview) {
-                place.saveGoogleReviews(translatedReviews);
+            List<GoogleReview> translatedReviews = translateGoogleReviews(originalReviews);
+
+            if (hasTranslatedContent(translatedReviews)) {
+                placeWriter.saveGoogleReviews(place, translatedReviews);
             }
         }
     }
 
-    private ClovaRequest generateFinalPrompt(String review) {
-        List<ClovaRequest.Message> messages = new ArrayList<>();
-        messages.add(generateSystemPrompt());
+    private List<GoogleReview> translateGoogleReviews(List<GoogleReview> reviews) {
+        return reviews.stream()
+                .map(review -> {
+                    String content = review.content();
+                    if (!isTranslatable(content)) {
+                        return review;
+                    }
 
-        messages.add(ClovaRequest.Message.builder()
-                .role("user")
-                .content(review)
-                .build());
-
-        return ClovaRequest.builder()
-                .messages(messages)
-                .topP(0.8)
-                .topK(0)
-                .maxTokens(1000)
-                .temperature(0.8)
-                .repeatPenalty(5.0)
-                .includeAiFilters(false)
-                .build();
+                    String translated = reviewTranslator.translate(content);
+                    return translated != null ? review.withTranslateContent(translated) : review;
+                })
+                .toList();
     }
 
-    private ClovaRequest.Message generateSystemPrompt() {
-        return ClovaRequest.Message.builder()
-                .role("system")
-                .content("""
-                        당신은 한국어 번역가입니다. 다음 지침을 따르세요:
-                        - 입력하는 문장을 한국어로 번역합니다.
-                        - 질문에 대해 답변하지 말고, 질문을 한국어로 번역합니다.
-                        - 내용을 변경하지 않고 그대로 번역합니다.
-                        """)
-                .build();
+    private boolean isTranslatable(String content) {
+        return content != null && !content.isBlank() && !TextUtils.isKorean(content);
     }
 
-    private boolean isForeignLang(String content) {
-        if (content == null || content.isBlank()) return false;
-
-        String koreanRegex = ".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*";
-        return !content.matches(koreanRegex);
+    private boolean hasTranslatedContent(List<GoogleReview> reviews) {
+        return reviews.stream()
+                .anyMatch(r -> r.translatedContent() != null);
     }
 }

--- a/src/main/java/com/meetup/server/review/application/TranslateService.java
+++ b/src/main/java/com/meetup/server/review/application/TranslateService.java
@@ -1,17 +1,14 @@
 package com.meetup.server.review.application;
 
-import com.meetup.server.global.clients.clova.ClovaClient;
-import com.meetup.server.global.clients.clova.ClovaRequest;
-import com.meetup.server.global.clients.clova.ClovaResponse;
 import com.meetup.server.review.domain.Review;
 import com.meetup.server.review.domain.VisitedReview;
 import com.meetup.server.review.implement.ReviewReader;
+import com.meetup.server.review.implement.ReviewTranslator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -19,89 +16,31 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TranslateService {
 
-    private final ClovaClient clovaClient;
     private final ReviewReader reviewReader;
+    private final ReviewTranslator reviewTranslator;
 
     @Transactional
     public void saveReviewForKor() {
         List<Review> reviews = reviewReader.readAll();
-        List<String> filteredForeignReviews = filterForeignReviews(reviews);
-
-        if (filteredForeignReviews.isEmpty()) return;
 
         for (Review review : reviews) {
             VisitedReview visitedReview = review.getVisitedReview();
-            String reviewContent = visitedReview.getContent();
+            String content = visitedReview.getContent();
 
-            if (reviewContent == null || reviewContent.isBlank() || !isForeignLang(reviewContent)) {
-                continue;
-            }
+            if (!isTranslatable(content)) continue;
 
-            ClovaRequest request = generateFinalPrompt(reviewContent);
-            log.info("[Clova Studio] Request: {}", request);
-            ClovaResponse clovaResponse = clovaClient.sendRequest(request);
-            log.info("[Clova Studio] response: {}", clovaResponse);
-
-            if (clovaResponse == null || clovaResponse.result() == null || clovaResponse.result().message() == null) {
-                log.warn("[Clova Studio] Empty or null response for review: {}", reviewContent);
-                continue;
-            }
-
-            String translatedContent = clovaResponse.result().message().content();
-            log.info("[Clova Studio] Original Content : {}, [Clova Studio] Translated Content: {}", reviewContent, translatedContent);
-
-            visitedReview.updateContent(translatedContent);
-        }
-    }
-
-    private List<String> filterForeignReviews(List<Review> reviews) {
-        List<String> foreignReviews = new ArrayList<>();
-        for (Review review: reviews) {
-            String content = review.getVisitedReview().getContent();
-
-            if (isForeignLang(content)) {
-                foreignReviews.add(content);
+            String translated = reviewTranslator.translate(content);
+            if (translated != null) {
+                visitedReview.updateContent(translated);
             }
         }
-        return foreignReviews;
     }
 
-    private ClovaRequest generateFinalPrompt(String review) {
-        List<ClovaRequest.Message> messages = new ArrayList<>();
-        messages.add(generateSystemPrompt());
-
-        messages.add(ClovaRequest.Message.builder()
-                .role("user")
-                .content(review)
-                .build());
-
-        return ClovaRequest.builder()
-                .messages(messages)
-                .topP(0.8)
-                .topK(0)
-                .maxTokens(1000)
-                .temperature(0.8)
-                .repeatPenalty(5.0)
-                .includeAiFilters(false)
-                .build();
+    private boolean isTranslatable(String content) {
+        return content != null && !content.isBlank() && !isKorean(content);
     }
 
-    private ClovaRequest.Message generateSystemPrompt() {
-        return ClovaRequest.Message.builder()
-                .role("system")
-                .content("""
-                        당신은 한국어 번역가입니다. 다음 지침을 따르세요:
-                        - 입력하는 문장을 한국어로 번역합니다.
-                        - 질문에 대해 답변하지 말고, 질문을 한국어로 번역합니다.
-                        - 내용을 변경하지 않고 그대로 번역합니다.
-                        """)
-                .build();
-    }
-
-    private boolean isForeignLang(String content) {
-        if (content == null || content.isBlank()) return false;
-
-        String koreanRegex = ".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*";
-        return !content.matches(koreanRegex);
+    private boolean isKorean(String text) {
+        return text.matches(".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*");
     }
 }

--- a/src/main/java/com/meetup/server/review/application/TranslateService.java
+++ b/src/main/java/com/meetup/server/review/application/TranslateService.java
@@ -1,0 +1,107 @@
+package com.meetup.server.review.application;
+
+import com.meetup.server.global.clients.clova.ClovaClient;
+import com.meetup.server.global.clients.clova.ClovaRequest;
+import com.meetup.server.global.clients.clova.ClovaResponse;
+import com.meetup.server.review.domain.Review;
+import com.meetup.server.review.domain.VisitedReview;
+import com.meetup.server.review.implement.ReviewReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TranslateService {
+
+    private final ClovaClient clovaClient;
+    private final ReviewReader reviewReader;
+
+    @Transactional
+    public void saveReviewForKor() {
+        List<Review> reviews = reviewReader.readAll();
+        List<String> filteredForeignReviews = filterForeignReviews(reviews);
+
+        if (filteredForeignReviews.isEmpty()) return;
+
+        for (Review review : reviews) {
+            VisitedReview visitedReview = review.getVisitedReview();
+            String reviewContent = visitedReview.getContent();
+
+            if (reviewContent == null || reviewContent.isBlank() || !isForeignLang(reviewContent)) {
+                continue;
+            }
+
+            ClovaRequest request = generateFinalPrompt(reviewContent);
+            log.info("[Clova Studio] Request: {}", request);
+            ClovaResponse clovaResponse = clovaClient.sendRequest(request);
+            log.info("[Clova Studio] response: {}", clovaResponse);
+
+            if (clovaResponse == null || clovaResponse.result() == null || clovaResponse.result().message() == null) {
+                log.warn("[Clova Studio] Empty or null response for review: {}", reviewContent);
+                continue;
+            }
+
+            String translatedContent = clovaResponse.result().message().content();
+            log.info("[Clova Studio] Original Content : {}, [Clova Studio] Translated Content: {}", reviewContent, translatedContent);
+
+            visitedReview.updateContent(translatedContent);
+        }
+    }
+
+    private List<String> filterForeignReviews(List<Review> reviews) {
+        List<String> foreignReviews = new ArrayList<>();
+        for (Review review: reviews) {
+            String content = review.getVisitedReview().getContent();
+
+            if (isForeignLang(content)) {
+                foreignReviews.add(content);
+            }
+        }
+        return foreignReviews;
+    }
+
+    private ClovaRequest generateFinalPrompt(String review) {
+        List<ClovaRequest.Message> messages = new ArrayList<>();
+        messages.add(generateSystemPrompt());
+
+        messages.add(ClovaRequest.Message.builder()
+                .role("user")
+                .content(review)
+                .build());
+
+        return ClovaRequest.builder()
+                .messages(messages)
+                .topP(0.8)
+                .topK(0)
+                .maxTokens(1000)
+                .temperature(0.8)
+                .repeatPenalty(5.0)
+                .includeAiFilters(false)
+                .build();
+    }
+
+    private ClovaRequest.Message generateSystemPrompt() {
+        return ClovaRequest.Message.builder()
+                .role("system")
+                .content("""
+                        당신은 한국어 번역가입니다. 다음 지침을 따르세요:
+                        - 입력하는 문장을 한국어로 번역합니다.
+                        - 질문에 대해 답변하지 말고, 질문을 한국어로 번역합니다.
+                        - 내용을 변경하지 않고 그대로 번역합니다.
+                        """)
+                .build();
+    }
+
+    private boolean isForeignLang(String content) {
+        if (content == null || content.isBlank()) return false;
+
+        String koreanRegex = ".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*";
+        return !content.matches(koreanRegex);
+    }
+}

--- a/src/main/java/com/meetup/server/review/domain/VisitedReview.java
+++ b/src/main/java/com/meetup/server/review/domain/VisitedReview.java
@@ -44,4 +44,8 @@ public class VisitedReview extends BaseEntity {
     public void assignTo(Review review) {
         this.review = review;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/meetup/server/review/implement/ReviewReader.java
+++ b/src/main/java/com/meetup/server/review/implement/ReviewReader.java
@@ -44,4 +44,8 @@ public class ReviewReader {
     public Map<UUID, Boolean> readReviewsWrittenByUser(List<EventHistory> projections, Long userId) {
         return reviewRepository.findReviewsWrittenByUser(projections, userId);
     }
+
+    public List<Review> readAll() {
+        return reviewRepository.findAll();
+    }
 }

--- a/src/main/java/com/meetup/server/review/implement/ReviewTranslator.java
+++ b/src/main/java/com/meetup/server/review/implement/ReviewTranslator.java
@@ -1,0 +1,62 @@
+package com.meetup.server.review.implement;
+
+import com.meetup.server.global.clients.clova.ClovaClient;
+import com.meetup.server.global.clients.clova.ClovaRequest;
+import com.meetup.server.global.clients.clova.ClovaResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReviewTranslator {
+
+    private final ClovaClient clovaClient;
+
+    private static final double TOP_P = 0.8;
+    private static final double TEMPERATURE = 0.8;
+    private static final int MAX_TOKENS = 1000;
+    private static final double REPEAT_PENALTY = 5.0;
+
+    public String translate(String originalContent) {
+        ClovaRequest request = createRequest(originalContent);
+        log.info("[Clova Studio] Request: {}", request);
+
+        ClovaResponse response = clovaClient.sendRequest(request);
+        if (response == null || response.result() == null || response.result().message() == null) {
+            log.warn("[Clova Studio] Failed to translate: {}", originalContent);
+            return null;
+        }
+
+        String translated = response.result().message().content();
+        log.info("[Clova Studio] Translated: {}", translated);
+        return translated;
+    }
+
+    private ClovaRequest createRequest(String content) {
+        return ClovaRequest.builder()
+                .messages(List.of(systemPrompt(),
+                        ClovaRequest.Message.builder()
+                                .role("user")
+                                .content(content)
+                                .build()))
+                .topP(TOP_P)
+                .temperature(TEMPERATURE)
+                .maxTokens(MAX_TOKENS)
+                .repeatPenalty(REPEAT_PENALTY)
+                .includeAiFilters(false)
+                .build();
+    }
+
+    private ClovaRequest.Message systemPrompt() {
+        return new ClovaRequest.Message("system", """
+            당신은 한국어 번역가입니다. 다음 지침을 따르세요:
+            - 입력하는 문장을 한국어로 번역합니다.
+            - 질문에 대해 답변하지 말고, 질문을 한국어로 번역합니다.
+            - 내용을 변경하지 않고 그대로 번역합니다.
+        """);
+    }
+}

--- a/src/main/java/com/meetup/server/review/presentation/TranslateReviewController.java
+++ b/src/main/java/com/meetup/server/review/presentation/TranslateReviewController.java
@@ -19,14 +19,14 @@ public class TranslateReviewController {
     private final TranslateService translateService;
     private final TranslateGoogleReviewService translateGoogleReviewService;
 
-    @Operation(summary = "외국어 리뷰를 한국어로 번역 후 저장 API", description = "외국어로 작성된 리뷰를 한국어로 번역하여 저장합니다")
+    @Operation(summary = "자체 리뷰 번역 API", description = "외국어로 작성된 리뷰를 한국어로 번역하여 저장합니다")
     @PostMapping("")
     public ApiResponse<?> translateAndSaveReview(){
         translateService.saveReviewForKor();
         return ApiResponse.success();
     }
 
-    @Operation(summary = "외국어 리뷰를 한국어로 번역 후 저장 API", description = "외국어로 작성된 리뷰를 한국어로 번역하여 저장합니다")
+    @Operation(summary = "구글 리뷰 번역 API", description = "장소의 구글 리뷰를 한국어로 번역하여 저장합니다")
     @PostMapping("/google")
     public ApiResponse<?> translateAndSaveGoogleReview(){
         translateGoogleReviewService.saveReviewForKor();

--- a/src/main/java/com/meetup/server/review/presentation/TranslateReviewController.java
+++ b/src/main/java/com/meetup/server/review/presentation/TranslateReviewController.java
@@ -1,0 +1,35 @@
+package com.meetup.server.review.presentation;
+
+import com.meetup.server.global.support.response.ApiResponse;
+import com.meetup.server.review.application.TranslateGoogleReviewService;
+import com.meetup.server.review.application.TranslateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Review API", description = "리뷰 API")
+@RestController
+@RequestMapping("/reviews/translation")
+@RequiredArgsConstructor
+public class TranslateReviewController {
+
+    private final TranslateService translateService;
+    private final TranslateGoogleReviewService translateGoogleReviewService;
+
+    @Operation(summary = "외국어 리뷰를 한국어로 번역 후 저장 API", description = "외국어로 작성된 리뷰를 한국어로 번역하여 저장합니다")
+    @PostMapping("")
+    public ApiResponse<?> translateAndSaveReview(){
+        translateService.saveReviewForKor();
+        return ApiResponse.success();
+    }
+
+    @Operation(summary = "외국어 리뷰를 한국어로 번역 후 저장 API", description = "외국어로 작성된 리뷰를 한국어로 번역하여 저장합니다")
+    @PostMapping("/google")
+    public ApiResponse<?> translateAndSaveGoogleReview(){
+        translateGoogleReviewService.saveReviewForKor();
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/meetup/server/review/util/TextUtils.java
+++ b/src/main/java/com/meetup/server/review/util/TextUtils.java
@@ -1,0 +1,13 @@
+package com.meetup.server.review.util;
+
+import java.util.regex.Pattern;
+
+public class TextUtils {
+
+    private static final Pattern KOREAN_PATTERN = Pattern.compile(".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*");
+
+    public static boolean isKorean(String text) {
+        if (text == null) return false;
+        return KOREAN_PATTERN.matcher(text).matches();
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #117 

## 💡 작업 내용
- clova studio 를 통해 리뷰 번역이 가능하도록 진행했습니다
- 이 과정에서 GoogleReview record 에 translatedContent 를 추가했습니다.

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/a952174d-fff3-4e73-909b-13df017a794e)

## 💬리뷰 요구사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**New Features**
  * Clova API 연동을 위한 클라이언트, 요청/응답 객체 및 설정 추가
  * Google 리뷰 번역 및 저장 기능 추가
  * 리뷰(방문 후기) 번역 및 저장 기능 추가
  * 리뷰 번역을 위한 REST API 엔드포인트 2종 추가
  * 한국어 여부 판별 유틸리티 추가

**Bug Fixes**
  * Google 리뷰에 번역 내용 필드 추가 및 관련 메서드 개선

**Chores**
  * 설정 파일 및 의존성 구성 업데이트 (Clova 연동 관련)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->