### PR TITLE
[SPOT-100] 운영, 스테이징 서버 분리하기

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,98 @@
+name: Prod Deploy
+
+on:
+  push:
+    branches: [ "prod" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.gradle/caches
+          key: gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: gradle-
+
+      - name: Grant execute permission to gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+      - name: move jar file to deploy
+        run: mv ./build/libs/*.jar ./deploy
+
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v3.10.0
+
+      - name: Login to NCP Container Registry
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+          username: ${{ secrets.NCP_ACCESS_KEY }}
+          password: ${{ secrets.NCP_SECRET_KEY }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v6.15.0
+        with:
+          context: ./deploy
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}
+
+  deploy:
+    needs: build
+    name: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set IMAGE variable
+        run: echo "IMAGE=${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}" >> $GITHUB_ENV
+
+      - name: Substitute image tag in deployment.yaml
+        run: |
+          sed "s|__IMAGE__|${IMAGE}|g" deploy/prod/prod-deployment.yaml > deploy/prod/spot-deployment.yaml
+
+      - name: Copy deployment.yaml to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          password: ${{ secrets.NCP_PASSWORD }}
+          source: deploy/prod/spot-deployment.yaml
+          target: /home/ubuntu/deploy/prod
+          strip_components: 2
+
+      - name: Deploy to K3s via kubectl
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          password: ${{ secrets.NCP_PASSWORD }}
+          port: ${{ secrets.NCP_PORT }}
+          script: |
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+            kubectl apply -f /home/ubuntu/deploy/prod/spot-deployment.yaml

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Substitute image tag in deployment.yaml
         run: |
-          sed -i "s|__IMAGE__|${IMAGE}|g" deploy/prod/prod-deployment.yaml
+          sed -i "s|__IMAGE__|${IMAGE}|g" deploy/prod/spot-backend-deployment.yaml
 
       - name: Copy deployment.yaml to server
         uses: appleboy/scp-action@master
@@ -82,7 +82,7 @@ jobs:
           host: ${{ secrets.NCP_HOST }}
           username: ${{ secrets.NCP_USERNAME }}
           password: ${{ secrets.NCP_PASSWORD }}
-          source: deploy/prod/prod-deployment.yaml
+          source: deploy/prod/
           target: /home/ubuntu/deploy/prod
           strip_components: 2
 
@@ -95,4 +95,4 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           script: |
             export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-            kubectl apply -f /home/ubuntu/deploy/prod/prod-deployment.yaml
+            kubectl apply -f /home/ubuntu/deploy/prod/

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Substitute image tag in deployment.yaml
         run: |
-          sed "s|__IMAGE__|${IMAGE}|g" deploy/prod/prod-deployment.yaml > deploy/prod/spot-deployment.yaml
+          sed -i "s|__IMAGE__|${IMAGE}|g" deploy/prod/prod-deployment.yaml
 
       - name: Copy deployment.yaml to server
         uses: appleboy/scp-action@master
@@ -82,7 +82,7 @@ jobs:
           host: ${{ secrets.NCP_HOST }}
           username: ${{ secrets.NCP_USERNAME }}
           password: ${{ secrets.NCP_PASSWORD }}
-          source: deploy/prod/spot-deployment.yaml
+          source: deploy/prod/prod-deployment.yaml
           target: /home/ubuntu/deploy/prod
           strip_components: 2
 
@@ -95,4 +95,4 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           script: |
             export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-            kubectl apply -f /home/ubuntu/deploy/prod/spot-deployment.yaml
+            kubectl apply -f /home/ubuntu/deploy/prod/prod-deployment.yaml

--- a/.github/workflows/stg-deploy.yml
+++ b/.github/workflows/stg-deploy.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Substitute image tag in deployment.yaml
         run: |
-          sed "s|__IMAGE__|${IMAGE}|g" deploy/stg/stg-deployment.yaml > deploy/stg/spot-deployment.yaml
+          sed -i "s|__IMAGE__|${IMAGE}|g" deploy/stg/stg-deployment.yaml
 
       - name: Copy deployment.yaml to server
         uses: appleboy/scp-action@master
@@ -84,7 +84,7 @@ jobs:
           host: ${{ secrets.NCP_HOST }}
           username: ${{ secrets.NCP_USERNAME }}
           password: ${{ secrets.NCP_PASSWORD }}
-          source: deploy/stg/spot-deployment.yaml
+          source: deploy/stg/stg-deployment.yaml
           target: /home/ubuntu/deploy/stg
           strip_components: 2
 
@@ -97,4 +97,4 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           script: |
             export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-            kubectl apply -f /home/ubuntu/deploy/stg/spot-deployment.yaml
+            kubectl apply -f /home/ubuntu/deploy/stg/stg-deployment.yaml

--- a/.github/workflows/stg-deploy.yml
+++ b/.github/workflows/stg-deploy.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Substitute image tag in deployment.yaml
         run: |
-          sed -i "s|__IMAGE__|${IMAGE}|g" deploy/stg/stg-deployment.yaml
+          sed -i "s|__IMAGE__|${IMAGE}|g" deploy/stg/spot-backend-deployment.yaml
 
       - name: Copy deployment.yaml to server
         uses: appleboy/scp-action@master
@@ -84,7 +84,7 @@ jobs:
           host: ${{ secrets.NCP_HOST }}
           username: ${{ secrets.NCP_USERNAME }}
           password: ${{ secrets.NCP_PASSWORD }}
-          source: deploy/stg/stg-deployment.yaml
+          source: deploy/stg/
           target: /home/ubuntu/deploy/stg
           strip_components: 2
 
@@ -97,4 +97,4 @@ jobs:
           port: ${{ secrets.NCP_PORT }}
           script: |
             export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-            kubectl apply -f /home/ubuntu/deploy/stg/stg-deployment.yaml
+            kubectl apply -f /home/ubuntu/deploy/stg/

--- a/.github/workflows/stg-deploy.yml
+++ b/.github/workflows/stg-deploy.yml
@@ -1,7 +1,9 @@
-name: Deploy
+name: Stg Deploy
 
 on:
   push:
+    branches: [ "develop" ]
+  pull_request:
     branches: [ "develop" ]
 
 jobs:
@@ -69,17 +71,24 @@ jobs:
           submodules: true
           token: ${{ secrets.GH_TOKEN }}
 
-      - name: Copy docker-compose.yml to Server
+      - name: Set IMAGE variable
+        run: echo "IMAGE=${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}" >> $GITHUB_ENV
+
+      - name: Substitute image tag in deployment.yaml
+        run: |
+          sed "s|__IMAGE__|${IMAGE}|g" deploy/stg/stg-deployment.yaml > deploy/stg/spot-deployment.yaml
+
+      - name: Copy deployment.yaml to server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.NCP_HOST }}
           username: ${{ secrets.NCP_USERNAME }}
           password: ${{ secrets.NCP_PASSWORD }}
-          source: deploy/docker-compose.yml
-          target: /home/ubuntu/deploy
-          strip_components: 1
+          source: deploy/stg/spot-deployment.yaml
+          target: /home/ubuntu/deploy/stg
+          strip_components: 2
 
-      - name: Deploy to NCP Server and Run
+      - name: Deploy to K3s via kubectl
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.NCP_HOST }}
@@ -87,9 +96,5 @@ jobs:
           password: ${{ secrets.NCP_PASSWORD }}
           port: ${{ secrets.NCP_PORT }}
           script: |
-            cd /home/ubuntu/deploy
-            echo "SPOT_IMAGE=${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}" > .env
-            
-            sudo docker compose down
-            sudo docker compose pull
-            sudo docker compose up -d
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+            kubectl apply -f /home/ubuntu/deploy/stg/spot-deployment.yaml

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,4 +3,4 @@ FROM eclipse-temurin:21-alpine
 ARG JAR_FILE=./*.jar
 COPY ${JAR_FILE} spot.jar
 
-ENTRYPOINT ["java", "-jar", "spot.jar", "--spring.profiles.active=dev"]
+ENTRYPOINT ["java", "-jar", "spot.jar"]

--- a/deploy/prod/prod-deployment.yaml
+++ b/deploy/prod/prod-deployment.yaml
@@ -64,6 +64,18 @@ spec:
               value: prod
             - name: TZ
               value: Asia/Seoul
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 40
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
       imagePullSecrets:
         - name: ncp-registry-secret
 ---

--- a/deploy/prod/prod-deployment.yaml
+++ b/deploy/prod/prod-deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - mountPath: /data
+              name: redis-storage
+      volumes:
+        - name: redis-storage
+          emptyDir: { }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: prod
+spec:
+  type: NodePort
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      nodePort: 30079
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spot-backend
+  namespace: prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spot-backend
+  template:
+    metadata:
+      labels:
+        app: spot-backend
+    spec:
+      containers:
+        - name: spot-backend
+          image: __IMAGE__
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: TZ
+              value: Asia/Seoul
+      imagePullSecrets:
+        - name: ncp-registry-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spot-backend
+  namespace: prod
+spec:
+  selector:
+    app: spot-backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/deploy/prod/redis-deployment.yaml
+++ b/deploy/prod/redis-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - mountPath: /data
+              name: redis-storage
+      volumes:
+        - name: redis-storage
+          emptyDir: { }

--- a/deploy/prod/redis-service.yaml
+++ b/deploy/prod/redis-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: prod
+spec:
+  type: NodePort
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      nodePort: 30079

--- a/deploy/prod/spot-backend-deployment.yaml
+++ b/deploy/prod/spot-backend-deployment.yaml
@@ -1,47 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: redis
-  namespace: prod
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: redis
-  template:
-    metadata:
-      labels:
-        app: redis
-    spec:
-      containers:
-        - name: redis
-          image: redis:7.4
-          ports:
-            - containerPort: 6379
-          volumeMounts:
-            - mountPath: /data
-              name: redis-storage
-      volumes:
-        - name: redis-storage
-          emptyDir: { }
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: redis
-  namespace: prod
-spec:
-  type: NodePort
-  selector:
-    app: redis
-  ports:
-    - port: 6379
-      targetPort: 6379
-      nodePort: 30079
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   name: spot-backend
   namespace: prod
 spec:
@@ -78,16 +37,3 @@ spec:
             periodSeconds: 5
       imagePullSecrets:
         - name: ncp-registry-secret
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: spot-backend
-  namespace: prod
-spec:
-  selector:
-    app: spot-backend
-  ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 8080

--- a/deploy/prod/spot-backend-service.yaml
+++ b/deploy/prod/spot-backend-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spot-backend
+  namespace: prod
+spec:
+  selector:
+    app: spot-backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/deploy/stg/redis-deployment.yaml
+++ b/deploy/stg/redis-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: stg
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - mountPath: /data
+              name: redis-storage
+      volumes:
+        - name: redis-storage
+          emptyDir: { }

--- a/deploy/stg/redis-service.yaml
+++ b/deploy/stg/redis-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: stg
+spec:
+  type: NodePort
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      nodePort: 30080

--- a/deploy/stg/spot-backend-deployment.yaml
+++ b/deploy/stg/spot-backend-deployment.yaml
@@ -1,47 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: redis
-  namespace: stg
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: redis
-  template:
-    metadata:
-      labels:
-        app: redis
-    spec:
-      containers:
-        - name: redis
-          image: redis:7.4
-          ports:
-            - containerPort: 6379
-          volumeMounts:
-            - mountPath: /data
-              name: redis-storage
-      volumes:
-        - name: redis-storage
-          emptyDir: { }
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: redis
-  namespace: stg
-spec:
-  type: NodePort
-  selector:
-    app: redis
-  ports:
-    - port: 6379
-      targetPort: 6379
-      nodePort: 30080
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   name: spot-backend
   namespace: stg
 spec:
@@ -78,16 +37,3 @@ spec:
             periodSeconds: 5
       imagePullSecrets:
         - name: ncp-registry-secret
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: spot-backend
-  namespace: stg
-spec:
-  selector:
-    app: spot-backend
-  ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 8080

--- a/deploy/stg/spot-backend-service.yaml
+++ b/deploy/stg/spot-backend-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spot-backend
+  namespace: stg
+spec:
+  selector:
+    app: spot-backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/deploy/stg/stg-deployment.yaml
+++ b/deploy/stg/stg-deployment.yaml
@@ -64,6 +64,18 @@ spec:
               value: stg
             - name: TZ
               value: Asia/Seoul
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 40
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
       imagePullSecrets:
         - name: ncp-registry-secret
 ---

--- a/deploy/stg/stg-deployment.yaml
+++ b/deploy/stg/stg-deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: stg
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - mountPath: /data
+              name: redis-storage
+      volumes:
+        - name: redis-storage
+          emptyDir: { }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: stg
+spec:
+  type: NodePort
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      nodePort: 30080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spot-backend
+  namespace: stg
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spot-backend
+  template:
+    metadata:
+      labels:
+        app: spot-backend
+    spec:
+      containers:
+        - name: spot-backend
+          image: __IMAGE__
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: stg
+            - name: TZ
+              value: Asia/Seoul
+      imagePullSecrets:
+        - name: ncp-registry-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spot-backend
+  namespace: stg
+spec:
+  selector:
+    app: spot-backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

기존에는 단일 개발 서버에서만 운영되다 보니,
새로운 기능 개발 시 서비스에 직접 영향을 줄 수 있고 API 연동 전까지 서비스가 정상 동작하지 않는 등의 문제가 있었습니다.

물리적으로 서버를 하나 더 두기엔 비용 부담이 있으나, 
현재 사용 중인 NCP 서버는 고성능이므로 단일 서버 내에서 운영/스테이징 환경을 논리적으로 분리하여 문제를 해결하고자 했습니다.

## ✅ What - 무엇이 변경됐나요?

- k3s(Kubernetes 경량 배포판) 도입으로 단일 노드 내에 운영/스테이징 환경 구축
- application.yml을 prod, stg 환경으로 분리 및 관리
- DB 스키마를 운영용 / 스테이징용으로 분리
- GitHub Actions Workflow를 prod, develop 브랜치에 따라 동작하도록 분기
- Kubernetes 템플릿을 환경별로 작성
- Ingress Controller로 k3s 번들에 포함된 Traefik 사용
- Ingress 및 Let's Encrypt TLS 인증서 설정
  - 관련 설정 파일은 서버 내에 별도 저장

## 🛠️ How - 어떻게 해결했나요?

### Workflow 동작 방식
- 운영 : prod 브랜치로 Push될 경우 트리거 발동 -> 운영 서버로 배포 수행
- 스테이징 : develop 브랜치로 Push, PR 생성시 트리거 발동 -> 스테이징 서버로 배포 수행
- Build 과정(Spring Docker Image 생성)은 동일하며 deploy 과정에서 deployment.yaml을 적용하는 부분만 추가되었습니다.

### 연결 방식
- 외부 요청 → Ingress Controller (Traefik) → prod or stg Namespace
- 각 네임스페이스 구성: Spring 애플리케이션, Redis

## 🖼️ Attachment

- 접속 테스트 이미지는 개인적으로 전달

## 💬 기타 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 운영 및 스테이징 환경에 Redis와 spot-backend 서비스에 대한 Kubernetes 배포 및 서비스 리소스가 추가되었습니다.
  * 스테이징 환경을 위한 새로운 자동 배포 워크플로우가 도입되었습니다.

* **Refactor**
  * 운영 환경 배포 방식이 Docker Compose에서 Kubernetes 기반으로 전환되었습니다.

* **Chores**
  * config 모듈의 서브프로젝트 커밋 참조가 업데이트되었습니다.
  * Docker 컨테이너의 기본 Spring 프로필 지정이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->