### PR TITLE
[SPOT-121] 모임 생성 로직에 모임 시간과 날짜, 모임명을 추가하여 로직을 수정한다

### DIFF
--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -1,6 +1,7 @@
 package com.meetup.server.event.application;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.dto.response.RouteResponseList;
 import com.meetup.server.event.implement.EventProcessor;
@@ -24,9 +25,9 @@ public class EventService {
     private final EventCacheService eventCacheService;
 
     @Transactional
-    public EventStartPointResponse createEvent(Long userId, UUID guestId, StartPointRequest startPointRequest) {
-        Event event = eventProcessor.save();
-        StartPoint startPoint = startPointProcessor.save(event, userId, guestId, startPointRequest);
+    public EventStartPointResponse createEvent(Long userId, UUID guestId, EventRequest eventRequest) {
+        Event event = eventProcessor.save(eventRequest);
+        StartPoint startPoint = startPointProcessor.save(event, userId, guestId, eventRequest.toStartPointRequest());
         return EventStartPointResponse.of(event, startPoint);
     }
 

--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -26,7 +26,7 @@ public class Event extends BaseEntity {
     private String eventName;
 
     @Column(name = "event_date_time", nullable = false)
-    private LocalDateTime dateTime;
+    private LocalDateTime eventDateTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "subway_id", nullable = true)
@@ -42,11 +42,11 @@ public class Event extends BaseEntity {
     }
 
     @Builder
-    public Event(Subway subway, Place place, String eventName, LocalDateTime dateTime) {
+    public Event(Subway subway, Place place, String eventName, LocalDateTime eventDateTime) {
         this.subway = subway;
         this.place = place;
         this.eventName = eventName;
-        this.dateTime = dateTime;
+        this.eventDateTime = eventDateTime;
     }
 
     public void updateSubway(Subway subway) {

--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -20,6 +21,12 @@ public class Event extends BaseEntity {
     @Id
     @Column(name = "event_id")
     private UUID eventId;
+
+    @Column(name = "event_name", nullable = false)
+    private String eventName;
+
+    @Column(name = "event_date_time", nullable = false)
+    private LocalDateTime dateTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "subway_id", nullable = true)
@@ -35,9 +42,11 @@ public class Event extends BaseEntity {
     }
 
     @Builder
-    public Event(Subway subway, Place place) {
+    public Event(Subway subway, Place place, String eventName, LocalDateTime dateTime) {
         this.subway = subway;
         this.place = place;
+        this.eventName = eventName;
+        this.dateTime = dateTime;
     }
 
     public void updateSubway(Subway subway) {

--- a/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
@@ -1,0 +1,67 @@
+package com.meetup.server.event.dto.request;
+
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record EventRequest(
+
+        @NotBlank
+        @Size(min = 1, max = 15)
+        @Schema(description = "모임명", example = "입력핑")
+        String eventName,
+
+        @NotNull
+        @Schema(description = "모임 날짜", example = "2026-01-01")
+        LocalDate eventDate,
+
+        @NotNull
+        @Schema(description = "모임 시간", example = "15:30")
+        LocalTime eventTime,
+
+        @NotBlank
+        @Size(min = 1, max = 5)
+        @Schema(description = "사용자명", example = "김아무개")
+        String username,
+
+        @NotNull(message = "출발지명은 필수 값입니다.")
+        @Schema(description = "출발지명", example = "선정릉역 수인분당선")
+        String startPoint,
+
+        @NotNull(message = "지번주소는 필수 값입니다.")
+        @Schema(description = "지번주소", example = "서울특별시 강남구 삼성동 111-114")
+        String address,
+
+        @NotNull(message = "도로명주소는 필수 값입니다.")
+        @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580")
+        String roadAddress,
+
+        @DecimalMin(value = "-180.0", message = "경도는 -180.0보다 크거나 같아야 합니다.")
+        @DecimalMax(value = "180.0", message = "경도는 180.0보다 작거나 같아야 합니다.")
+        @Schema(description = "경도", example = "127.043999")
+        double longitude,
+
+        @DecimalMin(value = "-90.0", message = "위도는 -90.0보다 크거나 같아야 합니다.")
+        @DecimalMax(value = "90.0", message = "위도는 90.0보다 작거나 같아야 합니다.")
+        @Schema(description = "위도", example = "37.510297")
+        double latitude
+) {
+    public LocalDateTime toDateTime() {
+        return LocalDateTime.of(eventDate, eventTime);
+    }
+
+    public StartPointRequest toStartPointRequest() {
+        return new StartPointRequest(
+                username,
+                startPoint,
+                address,
+                roadAddress,
+                longitude,
+                latitude
+        );
+    }
+}

--- a/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
@@ -28,15 +28,15 @@ public record EventRequest(
         @Schema(description = "사용자명", example = "김아무개")
         String username,
 
-        @NotNull(message = "출발지명은 필수 값입니다.")
+        @NotBlank(message = "출발지명은 필수 값입니다.")
         @Schema(description = "출발지명", example = "선정릉역 수인분당선")
         String startPoint,
 
-        @NotNull(message = "지번주소는 필수 값입니다.")
+        @NotBlank(message = "지번주소는 필수 값입니다.")
         @Schema(description = "지번주소", example = "서울특별시 강남구 삼성동 111-114")
         String address,
 
-        @NotNull(message = "도로명주소는 필수 값입니다.")
+        @NotBlank(message = "도로명주소는 필수 값입니다.")
         @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580")
         String roadAddress,
 

--- a/src/main/java/com/meetup/server/event/implement/EventProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/EventProcessor.java
@@ -26,7 +26,7 @@ public class EventProcessor {
     public Event save(EventRequest eventRequest) {
         Event event = Event.builder()
                 .eventName(eventRequest.eventName())
-                .dateTime(eventRequest.toDateTime())
+                .eventDateTime(eventRequest.toDateTime())
                 .build();
         return eventRepository.save(event);
     }

--- a/src/main/java/com/meetup/server/event/implement/EventProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/EventProcessor.java
@@ -1,6 +1,7 @@
 package com.meetup.server.event.implement;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.response.RouteResponse;
 import com.meetup.server.event.dto.response.RouteResponseList;
 import com.meetup.server.event.persistence.EventRepository;
@@ -22,8 +23,11 @@ public class EventProcessor {
     private final StartPointReader startPointReader;
     private final StartPointProcessor startPointProcessor;
 
-    public Event save() {
-        Event event = Event.builder().build();
+    public Event save(EventRequest eventRequest) {
+        Event event = Event.builder()
+                .eventName(eventRequest.eventName())
+                .dateTime(eventRequest.toDateTime())
+                .build();
         return eventRepository.save(event);
     }
 

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -2,10 +2,10 @@ package com.meetup.server.event.presentation;
 
 import com.meetup.server.event.application.EventCacheService;
 import com.meetup.server.event.application.EventService;
+import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.dto.response.RouteResponseList;
 import com.meetup.server.global.support.response.ApiResponse;
-import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -27,10 +27,10 @@ public class EventController {
     @Operation(summary = "모임 생성 API", description = "모임 생성자의 출발지를 입력받아 모임을 생성합니다")
     @PostMapping
     public ApiResponse<EventStartPointResponse> createEvent(
-            @Valid @RequestBody StartPointRequest startPointRequest,
+            @Valid @RequestBody EventRequest eventRequest,
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) UUID guestId) {
-        return ApiResponse.success(eventService.createEvent(userId, guestId, startPointRequest));
+        return ApiResponse.success(eventService.createEvent(userId, guestId, eventRequest));
     }
 
     @Operation(summary = "지도 조회 API", description = "모임의 중간 지점 계산 및 모임 참여자의 경로 조회를 진행합니다")

--- a/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
+++ b/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
@@ -10,15 +10,15 @@ public record StartPointRequest(
         @Schema(description = "사용자명", example = "안연아바보")
         String username,
 
-        @NotNull(message = "출발지명은 필수 값입니다.")
+        @NotBlank(message = "출발지명은 필수 값입니다.")
         @Schema(description = "출발지명", example = "선정릉역 수인분당선")
         String startPoint,
 
-        @NotNull(message = "지번주소는 필수 값입니다.")
+        @NotBlank(message = "지번주소는 필수 값입니다.")
         @Schema(description = "지번주소", example = "서울특별시 강남구 삼성동 111-114")
         String address,
 
-        @NotNull(message = "도로명주소는 필수 값입니다.")
+        @NotBlank(message = "도로명주소는 필수 값입니다.")
         @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580")
         String roadAddress,
 

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -85,6 +85,8 @@ class EventServiceTest extends IntegrationTestContainer {
         assertThat(optionalStartPoint.get().getLocation().getRoadLongitude()).isEqualTo(eventRequest.longitude());
         assertThat(optionalStartPoint.get().getLocation().getRoadLatitude()).isEqualTo(eventRequest.latitude());
         assertThat(optionalStartPoint.get().getGuestId()).isNull();
+        assertThat(optionalEvent.get().getEventName()).isEqualTo(eventRequest.eventName());
+        assertThat(optionalEvent.get().getDateTime()).isEqualTo(eventRequest.toDateTime());
     }
 
 }

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -86,7 +86,7 @@ class EventServiceTest extends IntegrationTestContainer {
         assertThat(optionalStartPoint.get().getLocation().getRoadLatitude()).isEqualTo(eventRequest.latitude());
         assertThat(optionalStartPoint.get().getGuestId()).isNull();
         assertThat(optionalEvent.get().getEventName()).isEqualTo(eventRequest.eventName());
-        assertThat(optionalEvent.get().getDateTime()).isEqualTo(eventRequest.toDateTime());
+        assertThat(optionalEvent.get().getEventDateTime()).isEqualTo(eventRequest.toDateTime());
     }
 
 }

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -1,12 +1,12 @@
 package com.meetup.server.event.application;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.persistence.EventRepository;
-import com.meetup.server.fixture.StartPointFixture;
+import com.meetup.server.fixture.EventFixture;
 import com.meetup.server.fixture.UserFixture;
 import com.meetup.server.startpoint.domain.StartPoint;
-import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.startpoint.persistence.StartPointRepository;
 import com.meetup.server.support.IntegrationTestContainer;
 import com.meetup.server.user.domain.User;
@@ -36,54 +36,54 @@ class EventServiceTest extends IntegrationTestContainer {
     private UserRepository userRepository;
 
     private User user;
-    private StartPointRequest startPointRequest;
+    private EventRequest eventRequest;
     private UUID guestId;
 
     @BeforeEach
     void setUp() {
         user = userRepository.save(UserFixture.getUser());
-        startPointRequest = StartPointFixture.getStartPointRequest();
+        eventRequest = EventFixture.getEventRequest();
         guestId = UUID.randomUUID();
     }
 
     @Test
     void 비로그인_사용자가_이벤트를_생성한다() {
-        EventStartPointResponse eventStartPointResponse = eventService.createEvent(null, guestId, startPointRequest);
+        EventStartPointResponse eventStartPointResponse = eventService.createEvent(null, guestId, eventRequest);
 
         Optional<Event> optionalEvent = eventRepository.findById(eventStartPointResponse.eventId());
         assertThat(optionalEvent).isPresent();
 
         Optional<StartPoint> optionalStartPoint = startPointRepository.findById(eventStartPointResponse.startPointId());
         assertThat(optionalStartPoint).isPresent();
-        assertThat(eventStartPointResponse.username()).isEqualTo(startPointRequest.username());
+        assertThat(eventStartPointResponse.username()).isEqualTo(eventRequest.username());
         assertThat(optionalStartPoint.get().getStartPointId()).isEqualTo(eventStartPointResponse.startPointId());
-        assertThat(optionalStartPoint.get().getName()).isEqualTo(startPointRequest.startPoint());
+        assertThat(optionalStartPoint.get().getName()).isEqualTo(eventRequest.startPoint());
         assertThat(optionalStartPoint.get().getUser()).isNull();
-        assertThat(optionalStartPoint.get().getAddress().getAddress()).isEqualTo(startPointRequest.address());
-        assertThat(optionalStartPoint.get().getAddress().getRoadAddress()).isEqualTo(startPointRequest.roadAddress());
-        assertThat(optionalStartPoint.get().getLocation().getRoadLongitude()).isEqualTo(startPointRequest.longitude());
-        assertThat(optionalStartPoint.get().getLocation().getRoadLatitude()).isEqualTo(startPointRequest.latitude());
+        assertThat(optionalStartPoint.get().getAddress().getAddress()).isEqualTo(eventRequest.address());
+        assertThat(optionalStartPoint.get().getAddress().getRoadAddress()).isEqualTo(eventRequest.roadAddress());
+        assertThat(optionalStartPoint.get().getLocation().getRoadLongitude()).isEqualTo(eventRequest.longitude());
+        assertThat(optionalStartPoint.get().getLocation().getRoadLatitude()).isEqualTo(eventRequest.latitude());
         assertThat(optionalStartPoint.get().getGuestId()).isEqualTo(guestId);
     }
 
     @Transactional
     @Test
     void 로그인_사용자가_이벤트를_생성한다() {
-        EventStartPointResponse eventStartPointResponse = eventService.createEvent(user.getUserId(), null, startPointRequest);
+        EventStartPointResponse eventStartPointResponse = eventService.createEvent(user.getUserId(), null, eventRequest);
 
         Optional<Event> optionalEvent = eventRepository.findById(eventStartPointResponse.eventId());
         assertThat(optionalEvent).isPresent();
 
         Optional<StartPoint> optionalStartPoint = startPointRepository.findById(eventStartPointResponse.startPointId());
         assertThat(optionalStartPoint).isPresent();
-        assertThat(eventStartPointResponse.username()).isEqualTo(startPointRequest.username());
+        assertThat(eventStartPointResponse.username()).isEqualTo(eventRequest.username());
         assertThat(optionalStartPoint.get().getStartPointId()).isEqualTo(eventStartPointResponse.startPointId());
-        assertThat(optionalStartPoint.get().getName()).isEqualTo(startPointRequest.startPoint());
+        assertThat(optionalStartPoint.get().getName()).isEqualTo(eventRequest.startPoint());
         assertThat(optionalStartPoint.get().getUser()).isEqualTo(user);
-        assertThat(optionalStartPoint.get().getAddress().getAddress()).isEqualTo(startPointRequest.address());
-        assertThat(optionalStartPoint.get().getAddress().getRoadAddress()).isEqualTo(startPointRequest.roadAddress());
-        assertThat(optionalStartPoint.get().getLocation().getRoadLongitude()).isEqualTo(startPointRequest.longitude());
-        assertThat(optionalStartPoint.get().getLocation().getRoadLatitude()).isEqualTo(startPointRequest.latitude());
+        assertThat(optionalStartPoint.get().getAddress().getAddress()).isEqualTo(eventRequest.address());
+        assertThat(optionalStartPoint.get().getAddress().getRoadAddress()).isEqualTo(eventRequest.roadAddress());
+        assertThat(optionalStartPoint.get().getLocation().getRoadLongitude()).isEqualTo(eventRequest.longitude());
+        assertThat(optionalStartPoint.get().getLocation().getRoadLatitude()).isEqualTo(eventRequest.latitude());
         assertThat(optionalStartPoint.get().getGuestId()).isNull();
     }
 

--- a/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
@@ -1,8 +1,11 @@
 package com.meetup.server.event.implement;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.persistence.EventRepository;
+import com.meetup.server.fixture.EventFixture;
 import com.meetup.server.support.IntegrationTestContainer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -16,9 +19,16 @@ class EventProcessorTest extends IntegrationTestContainer {
     @Autowired
     private EventRepository eventRepository;
 
+    private EventRequest eventRequest;
+
+    @BeforeEach
+    void setUp() {
+        eventRequest = EventFixture.getEventRequest();
+    }
+
     @Test
     void 사용자가_이벤트를_저장한다() {
-        Event event = eventProcessor.save();
+        Event event = eventProcessor.save(eventRequest);
         assertThat(eventRepository.findById(event.getEventId())).isPresent();
     }
 }

--- a/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/EventProcessorTest.java
@@ -21,5 +21,4 @@ class EventProcessorTest extends IntegrationTestContainer {
         Event event = eventProcessor.save();
         assertThat(eventRepository.findById(event.getEventId())).isPresent();
     }
-
 }

--- a/src/test/java/com/meetup/server/fixture/EventFixture.java
+++ b/src/test/java/com/meetup/server/fixture/EventFixture.java
@@ -1,12 +1,32 @@
 package com.meetup.server.fixture;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.request.EventRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public class EventFixture {
 
     public static Event getEvent() {
         return Event.builder()
+                .eventName("모임핑")
+                .dateTime(LocalDateTime.parse("2025-10-01T10:00:00"))
                 .build();
     }
 
+    public static EventRequest getEventRequest() {
+        return new EventRequest(
+                "모임핑",
+                LocalDate.parse("2025-10-01"),
+                LocalTime.parse("10:00"),
+                "땡수팟",
+                "선정릉역 수인분당선",
+                "서울특별시 강남구 삼성동 111-114",
+                "서울특별시 강남구 선릉로 지하580",
+                127.043999,
+                37.510297
+        );
+    }
 }

--- a/src/test/java/com/meetup/server/fixture/EventFixture.java
+++ b/src/test/java/com/meetup/server/fixture/EventFixture.java
@@ -12,7 +12,7 @@ public class EventFixture {
     public static Event getEvent() {
         return Event.builder()
                 .eventName("모임핑")
-                .dateTime(LocalDateTime.parse("2025-10-01T10:00:00"))
+                .eventDateTime(LocalDateTime.parse("2025-10-01T10:00:00"))
                 .build();
     }
 


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

-  FI 에서 모임 생성 시 모임 명과 모임 날짜 , 시간 을 입력 받도록 화면이 수정되어서 이에 맞춰 서버 로직과 엔티티를 수정했습니다.


## ✅ What - 무엇이 변경됐나요?

- Event Entity 에 모임명과 모임 시간/날짜 칼럼을 추가했습니다. 
- 모임 생성 API 에서 기존에 사용하던 StartPointRequest 에서 EventRequest 를 추가해서 대체했습니다.

## 🛠️ How - 어떻게 해결했나요?

- EventRequest 에서는 모임 시간과 날짜를 따로 받되, 서버 내에서는 LocalDateTime으로 관리하도록 `toDateTime()` 변환 메서드를 추가했습니다.
- 기존의 이벤트 생성 로직에서 출발지 생성 로직과 메서드를 함께 사용하는 부분이 많아서 EventRequest 에서 StartPointRequest 를 생성하는 메서드를 두어 진행했습니다.

## 🖼️ Attachment
- 모임 생성 api
<img width="1321" height="721" alt="image" src="https://github.com/user-attachments/assets/4c839ba3-2999-46c1-9aaf-05371e4ac601" />

- 위의 생성한 모임으로 조회한 결과
<img width="1275" height="1417" alt="image" src="https://github.com/user-attachments/assets/945aab95-84b6-4fda-b1d4-e3d0ab574e1b" />



## 💬 기타 코멘트

- `리뷰어에게 전하고 싶은 말, 테스트 방법, 주의할 점 등`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**새로운 기능**
  * 이벤트 생성 시 이름과 날짜/시간을 입력할 수 있도록 개선되었습니다.
  * 이벤트 생성 요청 시 더 다양한 정보(이벤트명, 날짜, 시간, 장소 정보 등)를 입력할 수 있습니다.

**버그 수정**
  * 입력값 검증이 강화되어, 시작 위치 및 주소 입력 시 공백만 입력하는 경우에도 오류가 발생하도록 변경되었습니다.

**테스트**
  * 새로운 이벤트 생성 방식에 맞춰 테스트 코드와 테스트 데이터가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->