### PR TITLE
[SPOT-130] 대중교통 선택 여부 기반으로 상세 경로 조회하기

### DIFF
--- a/src/main/java/com/meetup/server/event/application/EventCacheService.java
+++ b/src/main/java/com/meetup/server/event/application/EventCacheService.java
@@ -3,16 +3,12 @@ package com.meetup.server.event.application;
 import com.meetup.server.event.dto.response.MeetingPointResult;
 import com.meetup.server.event.dto.response.MeetingPointRouteGroup;
 import com.meetup.server.event.dto.response.MeetingPointRoutesResponse;
-import com.meetup.server.event.implement.EventProcessor;
-import com.meetup.server.event.implement.EventReader;
 import com.meetup.server.event.implement.MeetingPointCalculator;
 import com.meetup.server.event.implement.RouteAssembler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -24,23 +20,13 @@ public class EventCacheService {
 
     private final MeetingPointCalculator meetingPointCalculator;
     private final RouteAssembler routeAssembler;
-    private final EventReader eventReader;
-    private final EventProcessor eventProcessor;
 
     @Cacheable(value = "routeDetails", key = "#eventId", unless = "#result == null")
     public MeetingPointRoutesResponse getCachedMeetingPointRoutes(UUID eventId) {
-        List<MeetingPointResult> resultResponses = meetingPointCalculator.calculate(eventId);
-        List<MeetingPointRouteGroup> meetingPointRouteGroups = resultResponses.stream()
-                .map(resultResponse -> routeAssembler.assemble(resultResponse.event(), resultResponse.startPoints(), resultResponse.subway()))
+        List<MeetingPointResult> meetingPointResults = meetingPointCalculator.calculate(eventId);
+        List<MeetingPointRouteGroup> meetingPointRouteGroups = meetingPointResults.stream()
+                .map(resultResponse -> routeAssembler.assemble(resultResponse.startPoints(), resultResponse.subway()))
                 .toList();
-        return new MeetingPointRoutesResponse(meetingPointRouteGroups);
-    }
-
-    @Transactional
-    @CachePut(value = "routeDetails", key = "#eventId")
-    public MeetingPointRoutesResponse updateTransit(UUID eventId, UUID startPointId, boolean isTransit) {
-        MeetingPointRoutesResponse meetingPointRoutes = eventReader.readEventCache(eventId);
-        eventProcessor.updateTransitForStartPoint(meetingPointRoutes.meetingPointRouteGroups(), startPointId, isTransit);
-        return meetingPointRoutes;
+        return MeetingPointRoutesResponse.of(meetingPointResults, meetingPointRouteGroups);
     }
 }

--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -49,6 +49,10 @@ public class Event extends BaseEntity {
         this.eventDateTime = eventDateTime;
     }
 
+    public void updateSubway(Subway subway) {
+        this.subway = subway;
+    }
+
     public void updateMeetingPlace(Place place, Subway subway) {
         this.place = place;
         this.subway = subway;

--- a/src/main/java/com/meetup/server/event/dto/response/DrivingInfoResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/DrivingInfoResponse.java
@@ -21,7 +21,7 @@ public record DrivingInfoResponse(
     }
 
     public static DrivingInfoResponse from(KakaoMobilityResponse kakaoMobilityResponse) {
-        if (kakaoMobilityResponse.routes() == null || kakaoMobilityResponse.routes().isEmpty()) {
+        if (kakaoMobilityResponse == null || kakaoMobilityResponse.routes() == null || kakaoMobilityResponse.routes().isEmpty()) {
             return null;
         }
 

--- a/src/main/java/com/meetup/server/event/dto/response/DrivingRouteResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/DrivingRouteResponse.java
@@ -12,8 +12,8 @@ public record DrivingRouteResponse(
         List<Coordinate> coordinates
 ) {
     public static List<DrivingRouteResponse> from(KakaoMobilityResponse kakaoMobilityResponse) {
-        if (kakaoMobilityResponse.routes() == null || kakaoMobilityResponse.routes().isEmpty()) {
-            return List.of();
+        if (kakaoMobilityResponse == null || kakaoMobilityResponse.routes() == null || kakaoMobilityResponse.routes().isEmpty()) {
+            return null;
         }
 
         Route route = kakaoMobilityResponse.routes().getFirst();

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRouteGroup.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRouteGroup.java
@@ -1,8 +1,6 @@
 package com.meetup.server.event.dto.response;
 
 import com.meetup.server.parkinglot.persistence.projection.ClosestParkingLot;
-import com.meetup.server.startpoint.domain.StartPoint;
-import com.meetup.server.startpoint.util.UsernameExtractor;
 import com.meetup.server.subway.domain.Subway;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.UUID;
 
 @Getter
 @Builder
@@ -19,19 +16,15 @@ import java.util.UUID;
 public class MeetingPointRouteGroup {
 
     private int subwayId;
-    private String eventMaker;
-    private int peopleCount;
     private int averageTime;
     private MeetingPoint meetingPoint;
     private List<RouteResponse> routeResponse;
     private ParkingLotResponse parkingLot;
 
-    public static MeetingPointRouteGroup of(StartPoint startPoint, List<RouteResponse> routeResponse, Subway subway, ClosestParkingLot closestParkingLot) {
+    public static MeetingPointRouteGroup of(List<RouteResponse> routeResponse, Subway subway, ClosestParkingLot closestParkingLot) {
         return MeetingPointRouteGroup.builder()
                 .subwayId(subway.getSubwayId())
-                .eventMaker(UsernameExtractor.extractDisplayName(startPoint))
                 .averageTime(calculateAverageTime(routeResponse))
-                .peopleCount(routeResponse.size())
                 .meetingPoint(MeetingPoint.from(subway))
                 .routeResponse(routeResponse)
                 .parkingLot(ParkingLotResponse.from(closestParkingLot))
@@ -42,13 +35,5 @@ public class MeetingPointRouteGroup {
         return routeResponse.stream()
                 .mapToInt(RouteResponse::getTotalTime)
                 .sum() / routeResponse.size();
-    }
-
-    public void updateIsTransitForStartPoint(UUID startPointId, boolean isTransit) {
-        this.routeResponse.stream()
-                .filter(route -> startPointId.equals(route.getId()))
-                .findFirst()
-                .ifPresent(route -> route.updateIsTransit(isTransit));
-        this.averageTime = calculateAverageTime(this.routeResponse);
     }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -1,8 +1,46 @@
 package com.meetup.server.event.dto.response;
 
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.global.util.TimeUtil;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.util.UsernameExtractor;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 
 public record MeetingPointRoutesResponse(
+        String eventName,
+        String eventDate,
+        String eventTime,
+        String eventMaker,
+        int peopleCount,
         List<MeetingPointRouteGroup> meetingPointRouteGroups
 ) {
+
+    public static MeetingPointRoutesResponse of(List<MeetingPointResult> meetingPointResults, List<MeetingPointRouteGroup> meetingPointRouteGroups) {
+        MeetingPointResult meetingPointResult = meetingPointResults.get(0);
+
+        Event event = meetingPointResult.event();
+        LocalDateTime eventDateTime = event.getEventDateTime();
+
+        List<StartPoint> startPoints = meetingPointResult.startPoints();
+
+        String eventMaker = startPoints.stream()
+                .sorted(Comparator.comparing(StartPoint::getCreatedAt))
+                .findFirst()
+                .map(UsernameExtractor::extractDisplayName)
+                .orElse(null);
+
+        int peopleCount = startPoints.size();
+
+        return new MeetingPointRoutesResponse(
+                event.getEventName(),
+                TimeUtil.formatAsDate(eventDateTime),
+                TimeUtil.formatAsTime(eventDateTime),
+                eventMaker,
+                peopleCount,
+                meetingPointRouteGroups
+        );
+    }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -19,7 +19,7 @@ public record MeetingPointRoutesResponse(
 ) {
 
     public static MeetingPointRoutesResponse of(List<MeetingPointResult> meetingPointResults, List<MeetingPointRouteGroup> meetingPointRouteGroups) {
-        MeetingPointResult meetingPointResult = meetingPointResults.get(0);
+        MeetingPointResult meetingPointResult = meetingPointResults.getFirst();
 
         Event event = meetingPointResult.event();
         LocalDateTime eventDateTime = event.getEventDateTime();
@@ -27,8 +27,7 @@ public record MeetingPointRoutesResponse(
         List<StartPoint> startPoints = meetingPointResult.startPoints();
 
         String eventMaker = startPoints.stream()
-                .sorted(Comparator.comparing(StartPoint::getCreatedAt))
-                .findFirst()
+                .min(Comparator.comparing(StartPoint::getCreatedAt))
                 .map(UsernameExtractor::extractDisplayName)
                 .orElse(null);
 

--- a/src/main/java/com/meetup/server/event/dto/response/RouteResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/RouteResponse.java
@@ -4,7 +4,6 @@ import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityResponse;
 import com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchResponse;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.util.UsernameExtractor;
-import com.meetup.server.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,11 +36,8 @@ public class RouteResponse {
     private DrivingInfoResponse drivingInfo;
     private List<DrivingRouteResponse> drivingRoute;
     private int totalTime;
-    private int transitTime;
-    private int driveTime;
 
     public static RouteResponse of(StartPoint startPoint,
-                                   User user,
                                    OdsayTransitRouteSearchResponse transitResponse,
                                    KakaoMobilityResponse drivingResponse,
                                    int transitTime,
@@ -50,10 +46,10 @@ public class RouteResponse {
                 .isTransit(startPoint.isTransit())
                 .isMe(false)
                 .id(startPoint.getStartPointId())
-                .userId(startPoint.getIsUser() ? user.getUserId() : null)
+                .userId(startPoint.getIsUser() ? startPoint.getUser().getUserId() : null)
                 .guestId(startPoint.getGuestId())
                 .nickname(UsernameExtractor.extractDisplayName(startPoint))
-                .profileImage(startPoint.getIsUser() ? user.getProfileImage() : null)
+                .profileImage(startPoint.getIsUser() ? startPoint.getUser().getProfileImage() : null)
                 .startName(convertStartPointName(startPoint.getAddress().getAddress()))
                 .startLongitude(startPoint.getLocation().getRoadLongitude())
                 .startLatitude(startPoint.getLocation().getRoadLatitude())
@@ -61,8 +57,6 @@ public class RouteResponse {
                 .drivingInfo(DrivingInfoResponse.from(drivingResponse))
                 .drivingRoute(DrivingRouteResponse.from(drivingResponse))
                 .totalTime(startPoint.isTransit() ? transitTime : driveTime)
-                .transitTime(transitTime)
-                .driveTime(driveTime)
                 .build();
     }
 
@@ -74,15 +68,6 @@ public class RouteResponse {
             return matcher.group(1) + " " + matcher.group(3);
         }
         return "";
-    }
-
-    public void updateIsTransit(boolean isTransit) {
-        if (isTransit) {
-            this.totalTime = transitTime;
-        } else {
-            this.totalTime = driveTime;
-        }
-        this.isTransit = isTransit;
     }
 
     public void updateIsMe(boolean isMe) {

--- a/src/main/java/com/meetup/server/event/implement/EventProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/EventProcessor.java
@@ -1,12 +1,9 @@
 package com.meetup.server.event.implement;
 
 import com.meetup.server.event.domain.Event;
-import com.meetup.server.event.dto.response.MeetingPointRouteGroup;
 import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.response.RouteResponse;
 import com.meetup.server.event.persistence.EventRepository;
-import com.meetup.server.startpoint.domain.StartPoint;
-import com.meetup.server.startpoint.implement.StartPointReader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -19,7 +16,6 @@ import java.util.function.Predicate;
 public class EventProcessor {
 
     private final EventRepository eventRepository;
-    private final StartPointReader startPointReader;
 
     public Event save(EventRequest eventRequest) {
         Event event = Event.builder()
@@ -27,15 +23,6 @@ public class EventProcessor {
                 .eventDateTime(eventRequest.toDateTime())
                 .build();
         return eventRepository.save(event);
-    }
-
-    public void updateTransitForStartPoint(List<MeetingPointRouteGroup> meetingPointRouteGroup, UUID startPointId, boolean isTransit) {
-        for (MeetingPointRouteGroup routeResponse : meetingPointRouteGroup) {
-            routeResponse.updateIsTransitForStartPoint(startPointId, isTransit);
-        }
-
-        StartPoint startPoint = startPointReader.read(startPointId);
-        startPoint.updateIsTransit(isTransit);
     }
 
     public void prioritizeMyRoute(Long userId, UUID guestId, List<RouteResponse> routeList) {

--- a/src/main/java/com/meetup/server/event/implement/MeetingPointCalculator.java
+++ b/src/main/java/com/meetup/server/event/implement/MeetingPointCalculator.java
@@ -52,7 +52,12 @@ public class MeetingPointCalculator {
             throw new EventException(EventErrorType.PATH_CALCULATION_FAILED);
         }
 
-        return subwayReader.readAllByIdIn(topFairSubwayIds).stream()
+        List<Subway> topFairSubways = subwayReader.readAllByIdIn(topFairSubwayIds);
+
+        Subway firstSubway = topFairSubways.get(0);
+        event.updateSubway(firstSubway);
+
+        return topFairSubways.stream()
                 .map(subway -> MeetingPointResult.of(event, startPoints, subway))
                 .toList();
     }

--- a/src/main/java/com/meetup/server/event/implement/MeetingPointCalculator.java
+++ b/src/main/java/com/meetup/server/event/implement/MeetingPointCalculator.java
@@ -54,7 +54,7 @@ public class MeetingPointCalculator {
 
         List<Subway> topFairSubways = subwayReader.readAllByIdIn(topFairSubwayIds);
 
-        Subway firstSubway = topFairSubways.get(0);
+        Subway firstSubway = topFairSubways.getFirst();
         event.updateSubway(firstSubway);
 
         return topFairSubways.stream()

--- a/src/main/java/com/meetup/server/event/implement/RouteAssembler.java
+++ b/src/main/java/com/meetup/server/event/implement/RouteAssembler.java
@@ -1,12 +1,14 @@
 package com.meetup.server.event.implement;
 
-import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.response.DrivingInfoResponse;
 import com.meetup.server.event.dto.response.MeetingPointRouteGroup;
 import com.meetup.server.event.dto.response.RouteResponse;
+import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityResponse;
+import com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchResponse;
 import com.meetup.server.parkinglot.implement.ParkingLotFinder;
 import com.meetup.server.parkinglot.persistence.projection.ClosestParkingLot;
 import com.meetup.server.startpoint.domain.StartPoint;
-import com.meetup.server.startpoint.implement.StartPointReader;
+import com.meetup.server.startpoint.util.RouteExtractor;
 import com.meetup.server.subway.domain.Subway;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,21 +24,33 @@ public class RouteAssembler {
 
     private final ParkingLotFinder parkingLotFinder;
     private final RouteDetailFetcher routeDetailFetcher;
-    private final StartPointReader startPointReader;
 
-    public MeetingPointRouteGroup assemble(Event event, List<StartPoint> startPointList, Subway subway) {
+    public MeetingPointRouteGroup assemble(List<StartPoint> startPointList, Subway subway) {
         List<RouteResponse> routeList = startPointList.stream()
-                .map(startPoint -> routeDetailFetcher.fetch(
-                        startPoint,
-                        String.valueOf(startPoint.getLocation().getRoadLongitude()),
-                        String.valueOf(startPoint.getLocation().getRoadLatitude()),
-                        String.valueOf(subway.getLocation().getRoadLongitude()),
-                        String.valueOf(subway.getLocation().getRoadLatitude())
-                ))
+                .map(startPoint -> {
+                    String startX = String.valueOf(startPoint.getLocation().getRoadLongitude());
+                    String startY = String.valueOf(startPoint.getLocation().getRoadLatitude());
+                    String endX = String.valueOf(subway.getLocation().getRoadLongitude());
+                    String endY = String.valueOf(subway.getLocation().getRoadLatitude());
+
+                    OdsayTransitRouteSearchResponse transitRoute = null;
+                    KakaoMobilityResponse drivingRoute = null;
+                    int transitTotalTime = 0;
+                    int drivingTotalTime = 0;
+
+                    if (startPoint.isTransit()) {
+                        transitRoute = routeDetailFetcher.fetchTransitRoute(startX, startY, endX, endY);
+                        transitTotalTime = RouteExtractor.extractValidTransitTotalTime(transitRoute);
+                    } else {
+                        drivingRoute = routeDetailFetcher.fetchDrivingRoute(startX, startY, endX, endY);
+                        drivingTotalTime = RouteExtractor.extractValidDrivingTotalTime(DrivingInfoResponse.from(drivingRoute));
+                    }
+
+                    return RouteResponse.of(startPoint, transitRoute, drivingRoute, transitTotalTime, drivingTotalTime);
+                })
                 .collect(Collectors.toList());
 
         ClosestParkingLot closestParkingLot = parkingLotFinder.findClosestParkingLot(subway.getPoint());
-        StartPoint earliestStartPoint = startPointReader.readEarliestByEventId(event.getEventId());
-        return MeetingPointRouteGroup.of(earliestStartPoint, routeList, subway, closestParkingLot);
+        return MeetingPointRouteGroup.of(routeList, subway, closestParkingLot);
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/RouteDetailFetcher.java
+++ b/src/main/java/com/meetup/server/event/implement/RouteDetailFetcher.java
@@ -1,13 +1,9 @@
 package com.meetup.server.event.implement;
 
-import com.meetup.server.event.dto.response.DrivingInfoResponse;
-import com.meetup.server.event.dto.response.RouteResponse;
 import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityResponse;
 import com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchResponse;
-import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.exception.StartPointErrorType;
 import com.meetup.server.startpoint.exception.StartPointException;
-import com.meetup.server.startpoint.util.RouteExtractor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,23 +15,13 @@ public class RouteDetailFetcher {
 
     private final RouteApiCaller routeApiCaller;
 
-    public RouteResponse fetch(
-            StartPoint startPoint,
-            String startX, String startY, String endX, String endY
-    ) {
+    public OdsayTransitRouteSearchResponse fetchTransitRoute(String startX, String startY, String endX, String endY) {
         OdsayTransitRouteSearchResponse transitRoute = routeApiCaller.getTransitRoute(startX, startY, endX, endY);
+        return transitRoute;
+    }
+
+    public KakaoMobilityResponse fetchDrivingRoute(String startX, String startY, String endX, String endY) {
         KakaoMobilityResponse drivingRoute = routeApiCaller.getDrivingRoute(startX, startY, endX, endY);
-
-        if (transitRoute == null) {
-            throw new StartPointException(StartPointErrorType.ODSAY_ERROR);
-        }
-        if (drivingRoute == null) {
-            throw new StartPointException(StartPointErrorType.KAKAO_ERROR);
-        }
-
-        int transitTotalTime = RouteExtractor.extractValidTransitTotalTime(transitRoute);
-        int drivingTotalTime = RouteExtractor.extractValidDrivingTotalTime(DrivingInfoResponse.from(drivingRoute));
-
-        return RouteResponse.of(startPoint, startPoint.getUser(), transitRoute, drivingRoute, transitTotalTime, drivingTotalTime);
+        return drivingRoute;
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/RouteDetailFetcher.java
+++ b/src/main/java/com/meetup/server/event/implement/RouteDetailFetcher.java
@@ -2,8 +2,6 @@ package com.meetup.server.event.implement;
 
 import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityResponse;
 import com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchResponse;
-import com.meetup.server.startpoint.exception.StartPointErrorType;
-import com.meetup.server.startpoint.exception.StartPointException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -16,12 +14,20 @@ public class RouteDetailFetcher {
     private final RouteApiCaller routeApiCaller;
 
     public OdsayTransitRouteSearchResponse fetchTransitRoute(String startX, String startY, String endX, String endY) {
-        OdsayTransitRouteSearchResponse transitRoute = routeApiCaller.getTransitRoute(startX, startY, endX, endY);
-        return transitRoute;
+        try {
+            return routeApiCaller.getTransitRoute(startX, startY, endX, endY);
+        } catch (Exception e) {
+            log.warn("대중교통 경로 조회 실패: startX={}, startY={}, endX={}, endY={}", startX, startY, endX, endY, e);
+            return null;
+        }
     }
 
     public KakaoMobilityResponse fetchDrivingRoute(String startX, String startY, String endX, String endY) {
-        KakaoMobilityResponse drivingRoute = routeApiCaller.getDrivingRoute(startX, startY, endX, endY);
-        return drivingRoute;
+        try {
+            return routeApiCaller.getDrivingRoute(startX, startY, endX, endY);
+        } catch (Exception e) {
+            log.warn("자동차 경로 조회 실패: startX={}, startY={}, endX={}, endY={}", startX, startY, endX, endY, e);
+            return null;
+        }
     }
 }

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -1,6 +1,5 @@
 package com.meetup.server.event.presentation;
 
-import com.meetup.server.event.application.EventCacheService;
 import com.meetup.server.event.application.EventService;
 import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
@@ -22,7 +21,6 @@ import java.util.UUID;
 public class EventController {
 
     private final EventService eventService;
-    private final EventCacheService eventCacheService;
 
     @Operation(summary = "모임 생성 API", description = "모임 생성자의 출발지를 입력받아 모임을 생성합니다")
     @PostMapping
@@ -40,12 +38,5 @@ public class EventController {
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) UUID guestId) {
         return ApiResponse.success(eventService.getMeetingPointRoutes(eventId, userId, guestId));
-    }
-
-    @Operation(summary = "대중교통 선택 API", description = "본인의 대중교통, 자가용 선택 여부를 설정합니다")
-    @PatchMapping("/{eventId}")
-    public ApiResponse<?> updateTransit(@PathVariable UUID eventId, @RequestParam UUID startPointId, @RequestParam boolean isTransit) {
-        eventCacheService.updateTransit(eventId, startPointId, isTransit);
-        return ApiResponse.success();
     }
 }

--- a/src/main/java/com/meetup/server/startpoint/exception/StartPointErrorType.java
+++ b/src/main/java/com/meetup/server/startpoint/exception/StartPointErrorType.java
@@ -9,8 +9,6 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum StartPointErrorType implements ErrorType {
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소를 찾을 수 없습니다."),
-    ODSAY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ODsay API 호출에 실패했습니다."),
-    KAKAO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Kakao API 호출에 실패했습니다."),
     INVALID_START_POINT(HttpStatus.BAD_REQUEST, "해당 이벤트에 속하지 않는 출발지입니다.")
     ;
 

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
@@ -29,10 +29,6 @@ public class StartPointReader {
                 .orElseThrow(() -> new StartPointException(StartPointErrorType.PLACE_NOT_FOUND));
     }
 
-    public StartPoint readEarliestByEventId(UUID eventId) {
-        return startPointRepository.findTopByEventIdOrderByCreatedAtAsc(eventId);
-    }
-
     public List<EventHistory> readEventHistories(Long userId, UUID lastViewedEventId, int size) {
         return startPointRepository.findEventHistories(userId, lastViewedEventId, size);
     }

--- a/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
+++ b/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
@@ -15,20 +15,4 @@ public interface StartPointRepository extends JpaRepository<StartPoint, UUID>, S
 
     @Query("SELECT DISTINCT s FROM StartPoint s JOIN FETCH s.event WHERE s.event = :event")
     List<StartPoint> findAllByEvent(@Param("event") Event event);
-
-    @Query("""
-                SELECT s
-                FROM StartPoint s
-                WHERE s.event.eventId = :eventId
-                ORDER BY s.createdAt ASC
-                LIMIT 1
-            """)
-    StartPoint findTopByEventIdOrderByCreatedAtAsc(@Param("eventId") UUID eventId);
-
-    @Query("""
-            SELECT sp
-            FROM StartPoint sp
-            JOIN FETCH sp.user
-            WHERE sp.user.userId = :userId""")
-    List<StartPoint> findAllByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 대중교통 여부에 따라 대중교통, 자가용 경로를 선택적으로 가져옵니다.
- 중간지점이 확정되지 않을 경우, 디폴트로 첫 번째 중간지점(지하철역)을 보여줍니다.
- 맵뷰 화면에서 약속 시간과 모임명을 보여줍니다.

## ✅ What - 무엇이 변경됐나요?

- 기존 대중교통 선택 API 및 관련 로직을 제거했습니다.
- 중간지점 확정 전의 로직을 추가했습니다. (확정 후의 로직은 중간지점 3개 반환 작업에서 진행)
<img width="1054" height="420" alt="스크린샷 2025-07-18 오후 4 48 04" src="https://github.com/user-attachments/assets/fda69939-1739-4ae9-b5b7-3b1db1670fbd" />

- 중간지점 여러개 반환되면서 중복되는 `eventMaker`, `peopleCount`는 최상위 JSON 필드로 옮겼습니다.
- 경로 데이터가 없을 경우, 빈 리스트와 null이 혼용되어 null로 통일했습니다.
- 외부 API에서 경로를 가져올 수 없는 경우, 예외를 터뜨리는데 예외가 발생하면 경로가 있는 출발지까지 예외가 전파되어 예외 처리를 제거하고 null로 반환하도록 하였습니다.

## 🛠️ How - 어떻게 해결했나요?

- startPoint의 대중교통 선택 여부에 따라 분기처리하여 특정 경로를 가져오는 방식으로 처리했습니다.

## 🖼️ Attachment
### 모임명, 모임 날짜 반환 + `eventMaker`, `peopleCount` 최상위 추가
<img width="690" height="688" alt="스크린샷 2025-07-18 오후 4 25 51" src="https://github.com/user-attachments/assets/a6479a35-fcce-4785-8067-0711cb6cf0d7" />

### 대중교통 선택 케이스
<img width="369" height="94" alt="스크린샷 2025-07-18 오후 4 26 03" src="https://github.com/user-attachments/assets/a03506d7-21b6-4f68-b9de-bf30067c8b18" />

### 자가용 선택 케이스
<img width="610" height="315" alt="스크린샷 2025-07-18 오후 4 26 13" src="https://github.com/user-attachments/assets/5e742e65-96e6-4ab2-be34-df2aca48d8ac" />

## 💬 기타 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 모임 경로 응답에 행사명, 날짜, 시간, 모임 생성자, 인원수를 포함하도록 확장되었습니다.
  * 이벤트에 지하철 정보 업데이트 기능이 추가되었습니다.

* **버그 수정**
  * 경로 응답 생성 시 외부 API 응답이 null이거나 데이터가 없을 때 null을 반환하여 예외 상황을 방지합니다.

* **기능 개선**
  * 경로 그룹 및 경로 응답에서 불필요한 필드(이동 방식, 인원수 등)를 제거하여 구조가 간소화되었습니다.
  * 경로 조립 및 API 호출 방식이 개선되어 출발지별로 대중교통 또는 운전 경로를 명확히 구분하여 처리합니다.

* **불필요 코드 제거**
  * 사용하지 않는 API, 서비스, 리포지토리 메서드, 예외 타입, 컨트롤러 메서드 등이 삭제되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->