### PR TITLE
[SPOT-131] PL 조회 시 모임 명 추가한다

### DIFF
--- a/src/main/java/com/meetup/server/place/application/PlaceService.java
+++ b/src/main/java/com/meetup/server/place/application/PlaceService.java
@@ -61,7 +61,7 @@ public class PlaceService {
         List<PlaceWithDistance> nearbyPlaces = placeReader.readAllWithinRadius(subway.getPoint(), RADIUS);
         List<PlaceResponse> recommendedPlaces = placeProcessor.getRecommendedPlaces(confirmedPlace, nearbyPlaces);
 
-        return PlaceResponseList.of(subway, confirmedPlaceResponse, recommendedPlaces);
+        return PlaceResponseList.of(event, subway, confirmedPlaceResponse, recommendedPlaces);
     }
 
     public PlaceDetailResponse getPlace(UUID eventId, UUID placeId, int subwayId) {
@@ -97,6 +97,6 @@ public class PlaceService {
 
         PlaceWithDistance placeWithDistance = placeReader.readWithDistance(place, subway.getPoint());
         PlaceWithRating placeWithRating = reviewReader.readPlaceRatingsAsMap(List.of(place.getId())).get(place);
-        return PlaceResponseList.of(subway, PlaceResponse.of(placeWithDistance, placeWithRating), null);
+        return PlaceResponseList.of(event, subway, PlaceResponse.of(placeWithDistance, placeWithRating), null);
     }
 }

--- a/src/main/java/com/meetup/server/place/dto/response/PlaceResponseList.java
+++ b/src/main/java/com/meetup/server/place/dto/response/PlaceResponseList.java
@@ -1,11 +1,15 @@
 package com.meetup.server.place.dto.response;
 
+import com.meetup.server.event.domain.Event;
 import com.meetup.server.subway.domain.Subway;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
 public record PlaceResponseList(
+        @Schema(description = "모임명", example = "개발자 모임")
+        String eventName,
+
         @Schema(description = "중간지점명", example = "선정릉")
         String middlePointName,
 
@@ -15,7 +19,12 @@ public record PlaceResponseList(
         @Schema(description = "장소 추천 리스트")
         List<PlaceResponse> placeResponses
 ) {
-    public static PlaceResponseList of(Subway subway, PlaceResponse confirmedPlaceResponse, List<PlaceResponse> placeResponses) {
-        return new PlaceResponseList(subway.getName(), confirmedPlaceResponse, placeResponses);
+    public static PlaceResponseList of(Event event, Subway subway, PlaceResponse confirmedPlaceResponse, List<PlaceResponse> placeResponses) {
+        return new PlaceResponseList(
+                event.getEventName(),
+                subway.getName(),
+                confirmedPlaceResponse,
+                placeResponses
+        );
     }
 }

--- a/src/main/java/com/meetup/server/place/presentation/PlaceController.java
+++ b/src/main/java/com/meetup/server/place/presentation/PlaceController.java
@@ -34,7 +34,10 @@ public class PlaceController {
 
     @Operation(summary = "장소 추천 리스트 조회 API", description = "역 주변의 장소 추천 리스트를 조회합니다")
     @GetMapping
-    public ApiResponse<PlaceResponseList> getAllPlaces(@RequestParam UUID eventId, @RequestParam int subwayId) {
+    public ApiResponse<PlaceResponseList> getAllPlaces(
+            @RequestParam UUID eventId,
+            @RequestParam int subwayId
+    ) {
         return ApiResponse.success(placeService.getAllPlaces(eventId, subwayId));
     }
 


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- PL 에서 모임 명을 반환하도록 진행합니다

## ✅ What - 무엇이 변경됐나요?

- 기존 DTO 인 `PlaceResponseList` 에서 모임 명을 추가하여 반환하도록 진행했습니다
- `PlaceResponseList` 에서 `of` 메서드 에 모임 명 추가되었습니다
- `PlaceResponseList` 를 공유하는 리뷰용 장소 조회 api 에서도 `of` 메서드 가 변경 됨에 따라 모임 명을 추가했습니다.

## 🛠️ How - 어떻게 해결했나요?
- DTO 필드 추가 작업으로 기존 로직에서 모임명을 추가하도록 로직을 수정했습니다.

## 🖼️ Attachment

### 장소 추천 리스트 조회 API
<img width="1340" height="1446" alt="image" src="https://github.com/user-attachments/assets/f6bc3cb0-96d0-464a-a83e-4a68f241ba95" />

### 리뷰용 장소 조회 API
<img width="1318" height="1084" alt="image" src="https://github.com/user-attachments/assets/aac68e2c-3fb3-473c-b2b9-46d972a019d1" />


## 💬 기타 코멘트

- 지난 회의 내용처럼 리뷰 방식에 대한 변경 사항이 있을 것이라 생각되어서 일단 리뷰용 장소 조회 api 에도 모임 명이 필요할 것 같아 DTO 를 따로 만들어 변경하지 않고 추가하는 방향으로 진행했습니다.
- 리뷰 관련 api 에 대해서는 추후에 PL 쪽 화면 제대로 나오는 대로  다시 확인해서 진행하면 좋을 것 같은데 어떤가요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 장소 목록 응답에 이벤트 이름 정보가 추가되었습니다.

* **스타일**
  * 일부 메서드의 파라미터 표기 방식이 가독성을 위해 여러 줄로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->