### PR TITLE
[SPOT-77] 디스코드 웹훅을 사용한 서버 예외 알림 받기

### DIFF
--- a/src/main/java/com/meetup/server/global/presentation/ApiControllerAdvice.java
+++ b/src/main/java/com/meetup/server/global/presentation/ApiControllerAdvice.java
@@ -2,39 +2,47 @@ package com.meetup.server.global.presentation;
 
 import com.meetup.server.global.support.error.GlobalErrorType;
 import com.meetup.server.global.support.error.GlobalException;
+import com.meetup.server.global.support.error.discord.DiscordAlarmSender;
 import com.meetup.server.global.support.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class ApiControllerAdvice{
+
+    private final DiscordAlarmSender discordAlarmSender;
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         log.error("Exception : {}", e.getMessage(), e);
+        discordAlarmSender.sendErrorAlert(e);
         return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.INTERNAL_ERROR), GlobalErrorType.INTERNAL_ERROR.getStatus());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException : {}", e.getMessage(), e);
+        discordAlarmSender.sendErrorAlert(e);
         return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.FAILED_REQUEST_VALIDATION), GlobalErrorType.FAILED_REQUEST_VALIDATION.getStatus());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
         log.error("IllegalArgumentException : {}", e.getMessage(), e);
+        discordAlarmSender.sendErrorAlert(e);
         return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.INVALID_REQUEST_ARGUMENT), GlobalErrorType.INVALID_REQUEST_ARGUMENT.getStatus());
     }
 
     @ExceptionHandler(GlobalException.class)
     public ResponseEntity<ApiResponse<?>> handleGlobalException(GlobalException e) {
         log.error("GlobalException : {}", e.getMessage(), e);
+        discordAlarmSender.sendErrorAlert(e);
         return new ResponseEntity<>(ApiResponse.error(e.getErrorType()), e.getErrorType().getStatus());
     }
 

--- a/src/main/java/com/meetup/server/global/support/error/discord/DiscordAlarmSender.java
+++ b/src/main/java/com/meetup/server/global/support/error/discord/DiscordAlarmSender.java
@@ -1,0 +1,63 @@
+package com.meetup.server.global.support.error.discord;
+
+import com.meetup.server.global.util.TimeUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Profile({"prod", "stg"})
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordAlarmSender {
+
+    @Value("${discord.error-alert-url}")
+    private String errorAlertUrl;
+
+    private static final RestClient restClient = RestClient.create();
+
+    private final Environment environment;
+
+    public void sendErrorAlert(Exception exception) {
+        String content = ":rotating_light: [" + getEnvironment() + "] 서버 예외 발생";
+        List<DiscordRequest.Embed> embeds = List.of(
+                DiscordRequest.Embed.of("Exception", exception.getClass().getSimpleName()),
+                DiscordRequest.Embed.of("Message", exception.getMessage()),
+                DiscordRequest.Embed.of("Timestamp", TimeUtil.formatAsDateTime(LocalDateTime.now())),
+                DiscordRequest.Embed.of("StackTrace", parseStackTrace(exception))
+        );
+
+        DiscordRequest discordRequest = DiscordRequest.of(content, embeds);
+
+        try {
+            restClient.post()
+                    .uri(errorAlertUrl)
+                    .body(discordRequest)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("[DiscordAlarmSender] Discord 메시지 전송 실패: {}", e.getMessage());
+        }
+    }
+
+    private String getEnvironment() {
+        return Optional.ofNullable(environment.getActiveProfiles()[0]).map(String::toUpperCase).orElse("-");
+    }
+
+    private String parseStackTrace(Exception exception) {
+        StringBuilder sb = new StringBuilder();
+        for (StackTraceElement element : exception.getStackTrace()) {
+            sb.append(element.toString()).append("\n");
+            if (sb.length() > 2000) break;
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/meetup/server/global/support/error/discord/DiscordAlarmSender.java
+++ b/src/main/java/com/meetup/server/global/support/error/discord/DiscordAlarmSender.java
@@ -4,7 +4,6 @@ import com.meetup.server.global.util.TimeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -13,7 +12,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-@Profile({"prod", "stg"})
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -27,6 +25,11 @@ public class DiscordAlarmSender {
     private final Environment environment;
 
     public void sendErrorAlert(Exception exception) {
+        String env = getEnvironment();
+        if (!List.of("PROD", "STG").contains(env)) {
+            return;
+        }
+
         String content = ":rotating_light: [" + getEnvironment() + "] 서버 예외 발생";
         List<DiscordRequest.Embed> embeds = List.of(
                 DiscordRequest.Embed.of("Exception", exception.getClass().getSimpleName()),

--- a/src/main/java/com/meetup/server/global/support/error/discord/DiscordRequest.java
+++ b/src/main/java/com/meetup/server/global/support/error/discord/DiscordRequest.java
@@ -1,0 +1,20 @@
+package com.meetup.server.global.support.error.discord;
+
+import java.util.List;
+
+public record DiscordRequest(
+        String content,
+        List<Embed> embeds
+) {
+
+    public static DiscordRequest of(String content, List<Embed> embeds) {
+        return new DiscordRequest(content, embeds);
+    }
+
+    public record Embed(String title, String description) {
+
+        public static Embed of(String title, String description) {
+            return new Embed(title, description);
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/global/util/TimeUtil.java
+++ b/src/main/java/com/meetup/server/global/util/TimeUtil.java
@@ -13,6 +13,8 @@ public class TimeUtil {
 
     public static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
 
+    private static final DateTimeFormatter YYYY_MM_DD_HH_MM_SS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
     private static final DateTimeFormatter YYYY_MM_DD_DOT_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
     private static final DateTimeFormatter HH_MM_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
@@ -23,6 +25,10 @@ public class TimeUtil {
 
     public static int calculateHoursAgo(LocalDateTime createdAt) {
         return (int) ChronoUnit.HOURS.between(createdAt, LocalDateTime.now(KST_ZONE_ID));
+    }
+
+    public static String formatAsDateTime(LocalDateTime dateTime) {
+        return dateTime.format(YYYY_MM_DD_HH_MM_SS_FORMATTER);
     }
 
     public static String formatAsDate(LocalDateTime dateTime) {


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 서버 예외 발생 시, 신속한 대응을 위해 디스코드로 예외를 확인할 수 있도록 했습니다.

## ✅ What - 무엇이 변경됐나요?

- 디스코드 알림 전송 클래스가 추가되었고, `RestControllerAdvice`에서 예외를 핸들링할 때 디스코드 알림 전송을 웹훅을 통해 보내도록 하였습니다.
- LocalDateTime의 Formatter를 추가하여 디스코드 알림에서 초단위까지만 보이도록 하였습니다.

## 🛠️ How - 어떻게 해결했나요?

- PROD(운영), STG(스테이징) 서버 별로 디스코드 알림에서 제목으로 구분을 지어 확인할 수 있게 했습니다.
- [참고 블로그](https://unan.palms.blog/discord-alarm), [웹훅 공식 문서](https://discord.com/developers/docs/resources/webhook)

## 🖼️ Attachment

<img width="621" height="897" alt="스크린샷 2025-07-23 오후 11 24 03" src="https://github.com/user-attachments/assets/65ef9099-79e7-4a44-b62a-e40164175519" />

## 💬 기타 코멘트
채널을 PROD, STG 분리하지 않고, 하나의 예외 알림 채널만 팠습니다.
스테이징에서 QA중 발생하는 예외보다 운영 환경에서 발생하는 예외가 훨씬 많고, SPOT 서비스의 특성상 불필요한 예외 발생을 최대한 줄여야 하기 때문입니다.

허나, 분리하는 방향도 고려중이라 의견 주시면 좋을 것 같습니다!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 예외 발생 시 Discord로 에러 알림을 전송하는 기능이 추가되었습니다.
  * Discord 알림 메시지에 환경 정보, 예외 정보, 발생 시각, 스택 트레이스가 포함됩니다.

* **기타**
  * 날짜 및 시간을 "yyyy-MM-dd HH:mm:ss" 형식으로 반환하는 유틸리티 메소드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->