### PR TITLE
[SPOT-106] URL 을 바이너리 변환 후 S3 업로드 및 생성 객체 URL 반환받기

### DIFF
--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.174'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'

--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.174'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'

--- a/gradle/util.gradle
+++ b/gradle/util.gradle
@@ -2,6 +2,6 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'com.opencsv:opencsv:5.10'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.174'
     implementation 'io.micrometer:micrometer-registry-prometheus'
-
 }

--- a/src/main/java/com/meetup/server/global/clients/simplestorage/SimpleStorageProperties.java
+++ b/src/main/java/com/meetup/server/global/clients/simplestorage/SimpleStorageProperties.java
@@ -1,0 +1,12 @@
+package com.meetup.server.global.clients.simplestorage;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aws.s3")
+public record SimpleStorageProperties(
+        String bucketName,
+        String accessKey,
+        String secretKey,
+        String region
+) {
+}

--- a/src/main/java/com/meetup/server/global/clients/simplestorage/SimpleStorageUploader.java
+++ b/src/main/java/com/meetup/server/global/clients/simplestorage/SimpleStorageUploader.java
@@ -7,12 +7,12 @@ import com.meetup.server.global.support.error.GlobalErrorType;
 import com.meetup.server.global.support.error.GlobalException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
 
 @Slf4j
-@Configuration
+@Component
 @RequiredArgsConstructor
 public class SimpleStorageUploader {
 

--- a/src/main/java/com/meetup/server/global/clients/simplestorage/SimpleStorageUploader.java
+++ b/src/main/java/com/meetup/server/global/clients/simplestorage/SimpleStorageUploader.java
@@ -1,0 +1,49 @@
+package com.meetup.server.global.clients.simplestorage;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.meetup.server.global.support.error.GlobalErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.ByteArrayInputStream;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class SimpleStorageUploader {
+
+    private final AmazonS3 amazonS3;
+    private final SimpleStorageProperties properties;
+
+    public String uploadImage(byte[] data, String key, String contentType) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(data.length);
+        metadata.setContentType(contentType);
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(data)) {
+            amazonS3.putObject(new PutObjectRequest(properties.bucketName(), key, inputStream, metadata));
+            return amazonS3.getUrl(properties.bucketName(), key).toString();
+
+        } catch (Exception e) {
+            throw new GlobalException(GlobalErrorType.IMAGE_UPLOAD_ERROR);
+        }
+    }
+
+    public String generateObjectKey(String placeId, int index, String originalUrl) {
+        String extension = extractExtensionOrDefault(originalUrl);
+        String normalizedPlaceId = placeId.startsWith("places/") ? placeId.substring("places/".length()) : placeId;
+        return String.format("places/%s/photos/%d%s", normalizedPlaceId, index, extension);
+    }
+
+    private String extractExtensionOrDefault(String url) {
+        int lastDotIndex = url.lastIndexOf('.');
+        if (lastDotIndex != -1 && lastDotIndex > url.lastIndexOf('/')) {
+            return url.substring(lastDotIndex);
+        }
+        return ".png";
+    }
+}

--- a/src/main/java/com/meetup/server/global/config/ConfigurationPropertiesConfig.java
+++ b/src/main/java/com/meetup/server/global/config/ConfigurationPropertiesConfig.java
@@ -6,11 +6,12 @@ import com.meetup.server.global.clients.google.place.GooglePlaceProperties;
 import com.meetup.server.global.clients.kakao.local.KakaoLocalProperties;
 import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityProperties;
 import com.meetup.server.global.clients.odsay.OdsayProperties;
+import com.meetup.server.global.clients.simplestorage.SimpleStorageProperties;
 import com.meetup.server.global.support.jwt.JwtProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(value = {JwtProperties.class, KakaoLocalProperties.class, OdsayProperties.class, KakaoMobilityProperties.class, GooglePlaceProperties.class, CookieProperties.class, ClovaProperties.class})
+@EnableConfigurationProperties(value = {JwtProperties.class, KakaoLocalProperties.class, OdsayProperties.class, KakaoMobilityProperties.class, GooglePlaceProperties.class, CookieProperties.class, ClovaProperties.class, SimpleStorageProperties.class})
 public class ConfigurationPropertiesConfig {
 }

--- a/src/main/java/com/meetup/server/global/config/SimpleStorageConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SimpleStorageConfig.java
@@ -1,0 +1,27 @@
+package com.meetup.server.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.meetup.server.global.clients.simplestorage.SimpleStorageProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SimpleStorageConfig {
+
+    private final SimpleStorageProperties properties;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(properties.accessKey(), properties.secretKey());
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(properties.region())
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
+++ b/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
@@ -12,6 +12,8 @@ public enum GlobalErrorType implements ErrorType {
     FAILED_REQUEST_VALIDATION(HttpStatus.BAD_REQUEST, "요청 데이터 검증에 실패하였습니다."),
     INVALID_REQUEST_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 요청 인자입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다."),
+    IMAGE_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환 중 예외가 발생했습니다."),
+    IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 예외가 발생했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/global/util/ImageConverter.java
+++ b/src/main/java/com/meetup/server/global/util/ImageConverter.java
@@ -3,7 +3,7 @@ package com.meetup.server.global.util;
 import com.meetup.server.global.support.error.GlobalErrorType;
 import com.meetup.server.global.support.error.GlobalException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -14,7 +14,7 @@ import java.net.URI;
 import java.net.URL;
 
 @Slf4j
-@Configuration
+@Component
 public class ImageConverter {
 
     private static final String IMAGE_FORMAT = "png";

--- a/src/main/java/com/meetup/server/global/util/ImageConverter.java
+++ b/src/main/java/com/meetup/server/global/util/ImageConverter.java
@@ -3,7 +3,6 @@ package com.meetup.server.global.util;
 import com.meetup.server.global.support.error.GlobalErrorType;
 import com.meetup.server.global.support.error.GlobalException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -14,12 +13,11 @@ import java.net.URI;
 import java.net.URL;
 
 @Slf4j
-@Component
 public class ImageConverter {
 
     private static final String IMAGE_FORMAT = "png";
 
-    public byte[] downloadImage(String url) {
+    public static byte[] downloadImage(String url) {
         try {
             URL imageUrl = URI.create(url).toURL();
             return convertUrlToBytes(imageUrl, url);
@@ -30,7 +28,7 @@ public class ImageConverter {
         }
     }
 
-    private byte[] convertUrlToBytes(URL imageUrl, String originalUrl) throws IOException {
+    private static byte[] convertUrlToBytes(URL imageUrl, String originalUrl) throws IOException {
         try (InputStream inputStream = imageUrl.openStream();
              ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
 

--- a/src/main/java/com/meetup/server/global/util/ImageConverter.java
+++ b/src/main/java/com/meetup/server/global/util/ImageConverter.java
@@ -1,0 +1,47 @@
+package com.meetup.server.global.util;
+
+import com.meetup.server.global.support.error.GlobalErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+
+@Slf4j
+@Configuration
+public class ImageConverter {
+
+    private static final String IMAGE_FORMAT = "png";
+
+    public byte[] downloadImage(String url) {
+        try {
+            URL imageUrl = URI.create(url).toURL();
+            return convertUrlToBytes(imageUrl, url);
+
+        } catch (Exception e) {
+            log.error("이미지 변환 중 예외 발생: {}", e.getMessage(), e);
+            throw new GlobalException(GlobalErrorType.IMAGE_CONVERSION_ERROR);
+        }
+    }
+
+    private byte[] convertUrlToBytes(URL imageUrl, String originalUrl) throws IOException {
+        try (InputStream inputStream = imageUrl.openStream();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+
+            BufferedImage image = ImageIO.read(inputStream);
+            if (image == null) {
+                log.error("이미지 변환 중 URL 처리 실패: {}", originalUrl);
+                throw new GlobalException(GlobalErrorType.IMAGE_CONVERSION_ERROR);
+            }
+
+            ImageIO.write(image, IMAGE_FORMAT, outputStream);
+            return outputStream.toByteArray();
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/place/exception/PlaceErrorType.java
+++ b/src/main/java/com/meetup/server/place/exception/PlaceErrorType.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PlaceErrorType implements ErrorType {
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소를 찾을 수 없습니다."),
+    PLACE_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "장소 이미지 업로드에 실패했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/place/implement/PlaceImageUploader.java
+++ b/src/main/java/com/meetup/server/place/implement/PlaceImageUploader.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -15,9 +17,9 @@ public class PlaceImageUploader {
 
     public static final String CONTENT_TYPE_PNG = "image/png";
 
-    public String uploadImage(String imageUrl, String placeId) {
+    public String uploadImage(String imageUrl, UUID placeId) {
         byte[] imageData = ImageConverter.downloadImage(imageUrl);
-        String objectKey = simpleStorageUploader.generateObjectKey(placeId, 1, imageUrl);
+        String objectKey = simpleStorageUploader.generateObjectKey(placeId.toString(), 1, imageUrl);
         return simpleStorageUploader.uploadImage(imageData, objectKey, CONTENT_TYPE_PNG);
     }
 }

--- a/src/main/java/com/meetup/server/place/implement/PlaceImageUploader.java
+++ b/src/main/java/com/meetup/server/place/implement/PlaceImageUploader.java
@@ -1,0 +1,24 @@
+package com.meetup.server.place.implement;
+
+import com.meetup.server.global.clients.simplestorage.SimpleStorageUploader;
+import com.meetup.server.global.util.ImageConverter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class PlaceImageUploader {
+
+    private final SimpleStorageUploader simpleStorageUploader;
+    private final ImageConverter imageConverter;
+
+    public static final String CONTENT_TYPE_PNG = "image/png";
+
+    public String uploadImage(String imageUrl, String placeId) {
+        byte[] imageData = imageConverter.downloadImage(imageUrl);
+        String objectKey = simpleStorageUploader.generateObjectKey(placeId, 1, imageUrl);
+        return simpleStorageUploader.uploadImage(imageData, objectKey, CONTENT_TYPE_PNG);
+    }
+}

--- a/src/main/java/com/meetup/server/place/implement/PlaceImageUploader.java
+++ b/src/main/java/com/meetup/server/place/implement/PlaceImageUploader.java
@@ -12,12 +12,11 @@ import org.springframework.stereotype.Component;
 public class PlaceImageUploader {
 
     private final SimpleStorageUploader simpleStorageUploader;
-    private final ImageConverter imageConverter;
 
     public static final String CONTENT_TYPE_PNG = "image/png";
 
     public String uploadImage(String imageUrl, String placeId) {
-        byte[] imageData = imageConverter.downloadImage(imageUrl);
+        byte[] imageData = ImageConverter.downloadImage(imageUrl);
         String objectKey = simpleStorageUploader.generateObjectKey(placeId, 1, imageUrl);
         return simpleStorageUploader.uploadImage(imageData, objectKey, CONTENT_TYPE_PNG);
     }

--- a/src/test/java/com/meetup/server/fixture/PlaceFixture.java
+++ b/src/test/java/com/meetup/server/fixture/PlaceFixture.java
@@ -1,0 +1,29 @@
+package com.meetup.server.fixture;
+
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.domain.type.PlaceCategory;
+import com.meetup.server.startpoint.domain.type.Location;
+import org.locationtech.jts.geom.GeometryFactory;
+
+import java.util.List;
+
+public class PlaceFixture {
+
+    private static final GeometryFactory geometryFactory = new GeometryFactory();
+
+    public static Place getPlace() {
+        return Place.builder()
+                .kakaoPlaceId("1337065720")
+                .googlePlaceId("ChIJNazwn-mkfDUR-RHbyQEqj2c")
+                .category(PlaceCategory.CAFE)
+                .name("놀숲 건대점")
+                .googleRating(null)
+                .images(List.of())
+                .openingHours(List.of())
+                .googleReviews(List.of())
+                .location(Location.of(37.5406181573079, 127.06798560729))
+                .point(geometryFactory.createPoint(new org.locationtech.jts.geom.Coordinate(127.06798560729, 37.5406181573079)))
+                .rawJson(null)
+                .build();
+    }
+}

--- a/src/test/java/com/meetup/server/fixture/PlaceFixture.java
+++ b/src/test/java/com/meetup/server/fixture/PlaceFixture.java
@@ -1,5 +1,6 @@
 package com.meetup.server.fixture;
 
+import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.place.domain.type.PlaceCategory;
 import com.meetup.server.startpoint.domain.type.Location;
@@ -8,8 +9,6 @@ import org.locationtech.jts.geom.GeometryFactory;
 import java.util.List;
 
 public class PlaceFixture {
-
-    private static final GeometryFactory geometryFactory = new GeometryFactory();
 
     public static Place getPlace() {
         return Place.builder()
@@ -22,7 +21,7 @@ public class PlaceFixture {
                 .openingHours(List.of())
                 .googleReviews(List.of())
                 .location(Location.of(37.5406181573079, 127.06798560729))
-                .point(geometryFactory.createPoint(new org.locationtech.jts.geom.Coordinate(127.06798560729, 37.5406181573079)))
+                .point(CoordinateUtil.createPoint(127.06798560729, 37.5406181573079))
                 .rawJson(null)
                 .build();
     }

--- a/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
+++ b/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
@@ -1,0 +1,85 @@
+package com.meetup.server.place.implement;
+
+import com.meetup.server.fixture.PlaceFixture;
+import com.meetup.server.global.clients.google.place.photo.GooglePhotoClient;
+import com.meetup.server.global.clients.google.place.photo.GooglePhotoRequest;
+import com.meetup.server.global.clients.google.place.photo.GooglePhotoResponse;
+import com.meetup.server.global.clients.google.place.search.GoogleSearchTextClient;
+import com.meetup.server.global.clients.google.place.search.GoogleSearchTextRequest;
+import com.meetup.server.global.clients.google.place.search.GoogleSearchTextResponse;
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.exception.PlaceErrorType;
+import com.meetup.server.place.exception.PlaceException;
+import com.meetup.server.place.persistence.PlaceRepository;
+import com.meetup.server.support.IntegrationTestContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class PlaceImageUploaderTest extends IntegrationTestContainer {
+
+    @Autowired
+    private PlaceImageUploader placeImageUploader;
+
+    @Autowired
+    private GooglePhotoClient googlePhotoClient;
+
+    @Autowired
+    private GoogleSearchTextClient googleSearchTextClient;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @BeforeEach
+    void setUp() {
+        Place place = PlaceFixture.getPlace();
+        placeRepository.save(place);
+    }
+
+    public String uploadImageByPlaceName(Place place, Integer maxHeightPx, Integer maxWidthPx) {
+        GoogleSearchTextRequest searchRequest = GoogleSearchTextRequest.from(place.getName());
+        GoogleSearchTextResponse searchResponse = googleSearchTextClient.sendRequest(searchRequest);
+
+        if (searchResponse.places().isEmpty()) {
+            throw new PlaceException(PlaceErrorType.PLACE_NOT_FOUND);
+        }
+
+        GoogleSearchTextResponse.Place latestPlace = searchResponse.places().getFirst();
+
+        if (latestPlace.photos() == null || latestPlace.photos().isEmpty()) {
+            throw new PlaceException(PlaceErrorType.PLACE_IMAGE_UPLOAD_FAILED);
+        }
+
+        String latestPhotoName = latestPlace.photos().getFirst().name();
+
+        GooglePhotoRequest photoRequest = GooglePhotoRequest.builder()
+                .name(latestPhotoName)
+                .maxHeightPx(maxHeightPx)
+                .maxWidthPx(maxWidthPx)
+                .build();
+
+        GooglePhotoResponse photoResponse = googlePhotoClient.sendRequest(photoRequest);
+
+        if (photoResponse == null || photoResponse.photoUri() == null) {
+            throw new PlaceException(PlaceErrorType.PLACE_IMAGE_UPLOAD_FAILED);
+        }
+
+        return placeImageUploader.uploadImage(photoResponse.photoUri(), place.getId().toString());
+    }
+
+    //@Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
+    @Test
+    void 구글_장소_이름으로_이미지를_S3에_업로드한다() {
+        Place place = placeRepository.findAll().getFirst();
+
+        Integer maxHeightPx = 1200;
+        Integer maxWidthPx = 1200;
+
+        String imageUrl = uploadImageByPlaceName(place, maxHeightPx, maxWidthPx);
+
+        assert imageUrl != null : "이미지 업로드에 실패했습니다.";System.out.println("업로드된 이미지 URL: " + imageUrl);
+        assertThat(imageUrl).isNotNull().isNotBlank();
+    }
+}

--- a/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
+++ b/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
@@ -13,6 +13,7 @@ import com.meetup.server.place.exception.PlaceException;
 import com.meetup.server.place.persistence.PlaceRepository;
 import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -69,7 +70,7 @@ class PlaceImageUploaderTest extends IntegrationTestContainer {
         return placeImageUploader.uploadImage(photoResponse.photoUri(), place.getId());
     }
 
-    //@Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
+    @Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")
     @Test
     void 구글_장소_이름으로_이미지를_S3에_업로드한다() {
         Place place = placeRepository.findAll().getFirst();

--- a/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
+++ b/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
@@ -79,7 +79,9 @@ class PlaceImageUploaderTest extends IntegrationTestContainer {
 
         String imageUrl = uploadImageByPlaceName(place, maxHeightPx, maxWidthPx);
 
-        assert imageUrl != null : "이미지 업로드에 실패했습니다.";System.out.println("업로드된 이미지 URL: " + imageUrl);
+        assert imageUrl != null : "이미지 업로드에 실패했습니다.";
+
+        System.out.println("업로드된 이미지 URL: " + imageUrl);
         assertThat(imageUrl).isNotNull().isNotBlank();
     }
 }

--- a/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
+++ b/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
@@ -66,7 +66,7 @@ class PlaceImageUploaderTest extends IntegrationTestContainer {
             throw new PlaceException(PlaceErrorType.PLACE_IMAGE_UPLOAD_FAILED);
         }
 
-        return placeImageUploader.uploadImage(photoResponse.photoUri(), place.getId().toString());
+        return placeImageUploader.uploadImage(photoResponse.photoUri(), place.getId());
     }
 
     //@Disabled("API 호출 시, 과금 가능성으로 인한 테스트 비활성화")


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 이미지 URL의 만료를 방지하고, 안정적인 서버 운영을 위해 장소 이미지를 직접 다운로드 후 S3에 저장합니다.

## ✅ What - 무엇이 변경됐나요?

- S3 연동을 위한 Config 작성이 추가되었고, 
`ImageConverter` 에서 URL 을 바이너리 파일로 변경하는 과정을 진행했습니다.
- `SimpleStorageUploader`  에서 이미지를 S3 로 업로드 하고, `generateObjectKey` 를 통해 파일 저장 경로를 커스텀 진행했습니다.
- 장소 이미지에 대한 업로드를 진행하기 때문에 `PlaceUploader` 에 집합하여 `변환 -> 업로드  -> URL 반환` 일련의 과정으로 동작할 수 있도록 진행했습니다.
- test 를 통해 전체 과정을 확인하였습니다.

## 🛠️ How - 어떻게 해결했나요?

- `generateObjectKey` 테스트 진행 시 경우에 따라 places 가 중복되는 상황이 발생하여 1번만 붙이도록 normalize 했습니다.
- 현재는 장소 당 사진 1개로 진행하지만, 추후에 장소 당 N개로 늘어날 수 있을 것 같아서 index 를 통해 구분되도록 진행했습니다.

## 🖼️ Attachment

- URL 생성 확인
<img width="2628" height="734" alt="image" src="https://github.com/user-attachments/assets/d13051ee-24d3-4ac2-88d5-e631db074c30" />

## 💬 기타 코멘트

- S3 작업 진행한 AWS 계정 노션에 공유했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 장소 이미지를 AWS S3에 업로드하는 기능이 추가되었습니다.
  * 외부 이미지 URL을 다운로드하여 PNG로 변환하는 기능이 도입되었습니다.

* **버그 수정**
  * 이미지 변환 및 업로드 실패 시 사용자에게 명확한 에러 메시지가 제공됩니다.

* **테스트**
  * 장소 이미지 업로드 기능에 대한 통합 테스트가 추가되었습니다.

* **기타**
  * AWS S3 연동을 위한 설정 및 라이브러리가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->