### PR TITLE
[SPOT-123] 장소 이미지를 S3에 업로드 후 DB에 갱신하기

### DIFF
--- a/src/main/java/com/meetup/server/batch/place/job/PlaceImageUpdateJob.java
+++ b/src/main/java/com/meetup/server/batch/place/job/PlaceImageUpdateJob.java
@@ -1,0 +1,148 @@
+package com.meetup.server.batch.place.job;
+
+import com.meetup.server.global.clients.google.place.GoogleFieldMask;
+import com.meetup.server.global.clients.google.place.photo.GooglePhotoClient;
+import com.meetup.server.global.clients.google.place.photo.GooglePhotoRequest;
+import com.meetup.server.global.clients.google.place.photo.GooglePhotoResponse;
+import com.meetup.server.global.clients.google.place.search.GoogleSearchTextClient;
+import com.meetup.server.global.clients.google.place.search.GoogleSearchTextRequest;
+import com.meetup.server.global.clients.google.place.search.GoogleSearchTextResponse;
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.exception.PlaceErrorType;
+import com.meetup.server.place.exception.PlaceException;
+import com.meetup.server.place.implement.PlaceImageUploader;
+import com.meetup.server.place.persistence.PlaceRepository;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.Date;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class PlaceImageUpdateJob {
+
+    private final String JOB_NAME = this.getClass().getSimpleName();
+
+    private final JobLauncher jobLauncher;
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager platformTransactionManager;
+    private final EntityManagerFactory entityManagerFactory;
+    private final PlaceRepository placeRepository;
+    private final GoogleSearchTextClient googleSearchTextClient;
+    private final GooglePhotoClient googlePhotoClient;
+    private final PlaceImageUploader placeImageUploader;
+
+    //    @Scheduled(cron = "0 0 3 1 * ?")
+    public void updatePlaceImageJobScheduler() {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addDate("time", new Date())
+                .toJobParameters();
+        try {
+            jobLauncher.run(updatePlaceImageJob(), jobParameters);
+        } catch (Exception e) {
+            log.error(JOB_NAME, e);
+        }
+    }
+
+    @Bean
+    public Job updatePlaceImageJob() {
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .start(updatePlaceImageStep())
+                .build();
+    }
+
+    @Bean
+    @JobScope
+    public Step updatePlaceImageStep() {
+        return new StepBuilder("updatePlaceImageStep", jobRepository)
+                .<Place, Place>chunk(5, platformTransactionManager)
+                .reader(placeReader())
+                .processor(updatePlaceImage())
+                .writer(updatePlaceImageWriter())
+                .build();
+    }
+
+    private ItemReader<Place> placeReader() {
+        return new JpaPagingItemReaderBuilder<Place>()
+                .name("placeReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT p FROM Place p")
+                .pageSize(5)
+                .build();
+    }
+
+    private ItemProcessor<Place, Place> updatePlaceImage() {
+        return place -> {
+            String imageUrl = uploadImageByPlace(place);
+            place.updateImage(imageUrl);
+            return place;
+        };
+    }
+
+    private ItemWriter<Place> updatePlaceImageWriter() {
+        return new RepositoryItemWriterBuilder<Place>()
+                .repository(placeRepository)
+                .build();
+    }
+
+    private String uploadImageByPlace(Place place) {
+        GoogleSearchTextResponse.Place googlePlace = fetchGooglePlace(place);
+
+        String googlePhotoName = googlePlace.photos().getFirst().name();
+        GooglePhotoResponse photoResponse = fetchGooglePhoto(googlePhotoName);
+
+        return placeImageUploader.uploadImage(photoResponse.photoUri(), place.getId());
+    }
+
+    private GoogleSearchTextResponse.Place fetchGooglePlace(Place place) {
+        GoogleSearchTextRequest googleSearchTextRequest = GoogleSearchTextRequest.from(place.getName());
+        GoogleSearchTextResponse googleSearchTextResponse = googleSearchTextClient.sendRequest(googleSearchTextRequest, GoogleFieldMask.PHOTOS);
+
+        if (googleSearchTextResponse == null || googleSearchTextResponse.places().isEmpty()) {
+            throw new PlaceException(PlaceErrorType.PLACE_NOT_FOUND);
+        }
+
+        GoogleSearchTextResponse.Place googlePlace = googleSearchTextResponse.places().getFirst();
+
+        if (googlePlace.photos() == null || googlePlace.photos().isEmpty()) {
+            throw new PlaceException(PlaceErrorType.PLACE_IMAGE_UPLOAD_FAILED);
+        }
+
+        return googlePlace;
+    }
+
+    private GooglePhotoResponse fetchGooglePhoto(String photoName) {
+        GooglePhotoRequest googlePhotoRequest = GooglePhotoRequest.builder()
+                .name(photoName)
+                .maxHeightPx(1200)
+                .maxWidthPx(1200)
+                .build();
+
+        GooglePhotoResponse googlePhotoResponse = googlePhotoClient.sendRequest(googlePhotoRequest);
+
+        if (googlePhotoResponse == null || googlePhotoResponse.photoUri() == null) {
+            throw new PlaceException(PlaceErrorType.PLACE_IMAGE_UPLOAD_FAILED);
+        }
+
+        return googlePhotoResponse;
+    }
+}

--- a/src/main/java/com/meetup/server/batch/place/job/PlaceImageUpdateJob.java
+++ b/src/main/java/com/meetup/server/batch/place/job/PlaceImageUpdateJob.java
@@ -76,7 +76,7 @@ public class PlaceImageUpdateJob {
         return new StepBuilder("updatePlaceImageStep", jobRepository)
                 .<Place, Place>chunk(5, platformTransactionManager)
                 .reader(placeReader())
-                .processor(updatePlaceImage())
+                .processor(updatePlaceImageProcessor())
                 .writer(updatePlaceImageWriter())
                 .build();
     }
@@ -90,10 +90,14 @@ public class PlaceImageUpdateJob {
                 .build();
     }
 
-    private ItemProcessor<Place, Place> updatePlaceImage() {
+    private ItemProcessor<Place, Place> updatePlaceImageProcessor() {
         return place -> {
-            String imageUrl = uploadImageByPlace(place);
-            place.updateImage(imageUrl);
+            try {
+                String imageUrl = uploadImageByPlace(place);
+                place.updateImage(imageUrl);
+            } catch (Exception e) {
+                log.warn("[PlaceImageUpdateJob] 장소 이미지 업데이트 실패 {}: {}", place.getId(), e.getMessage());
+            }
             return place;
         };
     }

--- a/src/main/java/com/meetup/server/batch/place/job/PlaceSaveJob.java
+++ b/src/main/java/com/meetup/server/batch/place/job/PlaceSaveJob.java
@@ -21,6 +21,8 @@ import com.meetup.server.place.domain.type.PlaceCategory;
 import com.meetup.server.place.domain.value.GoogleReview;
 import com.meetup.server.place.domain.value.Image;
 import com.meetup.server.place.domain.value.OpeningHour;
+import com.meetup.server.place.exception.PlaceErrorType;
+import com.meetup.server.place.exception.PlaceException;
 import com.meetup.server.place.implement.PlaceImageUploader;
 import com.meetup.server.place.persistence.PlaceRepository;
 import com.meetup.server.startpoint.domain.type.Location;
@@ -150,19 +152,43 @@ public class PlaceSaveJob {
     }
 
     private Place createPlace(KakaoSearchResponse kakaoSearchResponse) throws JsonProcessingException {
-        GoogleSearchTextResponse googleSearchTextResponse =
-                googleSearchTextClient.sendRequest(GoogleSearchTextRequest.from(kakaoSearchResponse.getPlaceName()), GoogleFieldMask.ALL);
-
-        GoogleSearchTextResponse.Place googlePlace = googleSearchTextResponse.places().getFirst();
-
-        String photoName = googlePlace.photos().getFirst().name();
-        GooglePhotoResponse googlePhotoResponse = fetchGooglePhoto(photoName);
         UUID placeId = UuidCreator.getTimeOrderedEpoch();
-        String photoUri = placeImageUploader.uploadImage(googlePhotoResponse.photoUri(), placeId);
+
+        GoogleSearchTextResponse.Place googlePlace = fetchGooglePlace(kakaoSearchResponse.getPlaceName());
+        String photoUri = uploadPlaceImage(googlePlace, placeId);
 
         double longitude = Double.parseDouble(kakaoSearchResponse.getX());
         double latitude = Double.parseDouble(kakaoSearchResponse.getY());
 
+        return buildPlace(placeId, kakaoSearchResponse, googlePlace, photoUri, longitude, latitude);
+    }
+
+    private GoogleSearchTextResponse.Place fetchGooglePlace(String placeName) {
+        GoogleSearchTextResponse googleSearchTextResponse = googleSearchTextClient.sendRequest(
+                GoogleSearchTextRequest.from(placeName),
+                GoogleFieldMask.ALL
+        );
+
+        return googleSearchTextResponse.places().getFirst();
+    }
+
+    private String uploadPlaceImage(GoogleSearchTextResponse.Place googlePlace, UUID placeId) {
+        String photoName = googlePlace.photos().getFirst().name();
+
+        GooglePhotoResponse googlePhotoResponse = fetchGooglePhoto(photoName);
+        if (googlePhotoResponse == null || googlePhotoResponse.photoUri() == null) {
+            throw new PlaceException(PlaceErrorType.PLACE_IMAGE_UPLOAD_FAILED);
+        }
+
+        return placeImageUploader.uploadImage(googlePhotoResponse.photoUri(), placeId);
+    }
+
+    private Place buildPlace(UUID placeId,
+                             KakaoSearchResponse kakaoSearchResponse,
+                             GoogleSearchTextResponse.Place googlePlace,
+                             String photoUri,
+                             double longitude,
+                             double latitude) throws JsonProcessingException {
         return Place.builder()
                 .id(placeId)
                 .kakaoPlaceId(kakaoSearchResponse.getId())
@@ -173,21 +199,17 @@ public class PlaceSaveJob {
                 .images(List.of(Image.from(photoUri)))
                 .openingHours(
                         Optional.ofNullable(googlePlace.regularOpeningHours())
-                                .map(openingHours -> openingHours.periods().stream()
-                                        .map(OpeningHour::from)
-                                        .toList())
+                                .map(openingHours -> openingHours.periods().stream().map(OpeningHour::from).toList())
                                 .orElseGet(List::of)
                 )
                 .googleReviews(
                         Optional.ofNullable(googlePlace.reviews())
-                                .map(reviews -> reviews.stream()
-                                        .map(GoogleReview::from)
-                                        .toList())
+                                .map(reviews -> reviews.stream().map(GoogleReview::from).toList())
                                 .orElseGet(List::of)
                 )
                 .location(Location.of(longitude, latitude))
                 .point(CoordinateUtil.createPoint(longitude, latitude))
-                .rawJson(objectMapper.writeValueAsString(googleSearchTextResponse))
+                .rawJson(objectMapper.writeValueAsString(googlePlace))
                 .build();
     }
 

--- a/src/main/java/com/meetup/server/batch/place/job/PlaceSaveJob.java
+++ b/src/main/java/com/meetup/server/batch/place/job/PlaceSaveJob.java
@@ -2,6 +2,8 @@ package com.meetup.server.batch.place.job;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.f4b6a3.uuid.UuidCreator;
+import com.meetup.server.global.clients.google.place.GoogleFieldMask;
 import com.meetup.server.global.clients.google.place.photo.GooglePhotoClient;
 import com.meetup.server.global.clients.google.place.photo.GooglePhotoRequest;
 import com.meetup.server.global.clients.google.place.photo.GooglePhotoResponse;
@@ -19,6 +21,7 @@ import com.meetup.server.place.domain.type.PlaceCategory;
 import com.meetup.server.place.domain.value.GoogleReview;
 import com.meetup.server.place.domain.value.Image;
 import com.meetup.server.place.domain.value.OpeningHour;
+import com.meetup.server.place.implement.PlaceImageUploader;
 import com.meetup.server.place.persistence.PlaceRepository;
 import com.meetup.server.startpoint.domain.type.Location;
 import com.meetup.server.subway.domain.Subway;
@@ -43,10 +46,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Configuration
 @RequiredArgsConstructor
@@ -64,6 +64,7 @@ public class PlaceSaveJob {
     private final GoogleSearchTextClient googleSearchTextClient;
     private final GooglePhotoClient googlePhotoClient;
     private final ObjectMapper objectMapper;
+    private final PlaceImageUploader placeImageUploader;
 
     //    @Scheduled(cron = "0 0 3 1 * ?")
     public void savePlaceJobScheduler(int page) {
@@ -150,23 +151,26 @@ public class PlaceSaveJob {
 
     private Place createPlace(KakaoSearchResponse kakaoSearchResponse) throws JsonProcessingException {
         GoogleSearchTextResponse googleSearchTextResponse =
-                googleSearchTextClient.sendRequest(GoogleSearchTextRequest.from(kakaoSearchResponse.getPlaceName()));
+                googleSearchTextClient.sendRequest(GoogleSearchTextRequest.from(kakaoSearchResponse.getPlaceName()), GoogleFieldMask.ALL);
 
         GoogleSearchTextResponse.Place googlePlace = googleSearchTextResponse.places().getFirst();
 
         String photoName = googlePlace.photos().getFirst().name();
         GooglePhotoResponse googlePhotoResponse = fetchGooglePhoto(photoName);
+        UUID placeId = UuidCreator.getTimeOrderedEpoch();
+        String photoUri = placeImageUploader.uploadImage(googlePhotoResponse.photoUri(), placeId);
 
         double longitude = Double.parseDouble(kakaoSearchResponse.getX());
         double latitude = Double.parseDouble(kakaoSearchResponse.getY());
 
         return Place.builder()
+                .id(placeId)
                 .kakaoPlaceId(kakaoSearchResponse.getId())
                 .googlePlaceId(googlePlace.id())
                 .category(PlaceCategory.CAFE)
                 .name(kakaoSearchResponse.getPlaceName())
                 .googleRating(googlePlace.rating())
-                .images(List.of(Image.from(googlePhotoResponse)))
+                .images(List.of(Image.from(photoUri)))
                 .openingHours(
                         Optional.ofNullable(googlePlace.regularOpeningHours())
                                 .map(openingHours -> openingHours.periods().stream()

--- a/src/main/java/com/meetup/server/batch/presentation/BatchJobController.java
+++ b/src/main/java/com/meetup/server/batch/presentation/BatchJobController.java
@@ -1,5 +1,6 @@
 package com.meetup.server.batch.presentation;
 
+import com.meetup.server.batch.place.job.PlaceImageUpdateJob;
 import com.meetup.server.batch.place.job.PlaceSaveJob;
 import com.meetup.server.global.support.error.GlobalErrorType;
 import com.meetup.server.global.support.response.ApiResponse;
@@ -17,6 +18,7 @@ public class BatchJobController {
     private String batchSecretKey;
 
     private final PlaceSaveJob placeSaveJob;
+    private final PlaceImageUpdateJob placeImageUpdateJob;
 
     @Hidden
     @PostMapping("/place")
@@ -26,6 +28,17 @@ public class BatchJobController {
         }
 
         placeSaveJob.savePlaceJobScheduler(page);
+        return ApiResponse.success();
+    }
+
+    @Hidden
+    @PostMapping("/place/image")
+    public ApiResponse<?> runPlaceImageUpdateJob(@RequestHeader String secretKey) {
+        if (!batchSecretKey.equals(secretKey)) {
+            return ApiResponse.error(GlobalErrorType.UNAUTHORIZED);
+        }
+
+        placeImageUpdateJob.updatePlaceImageJobScheduler();
         return ApiResponse.success();
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/google/place/GoogleFieldMask.java
+++ b/src/main/java/com/meetup/server/global/clients/google/place/GoogleFieldMask.java
@@ -1,0 +1,15 @@
+package com.meetup.server.global.clients.google.place;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GoogleFieldMask {
+
+    ALL("*"),
+    PHOTOS("places.photos"),
+    ;
+
+    private final String mask;
+}

--- a/src/main/java/com/meetup/server/global/clients/google/place/search/GoogleSearchTextClient.java
+++ b/src/main/java/com/meetup/server/global/clients/google/place/search/GoogleSearchTextClient.java
@@ -1,5 +1,6 @@
 package com.meetup.server.global.clients.google.place.search;
 
+import com.meetup.server.global.clients.google.place.GoogleFieldMask;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -10,10 +11,10 @@ public class GoogleSearchTextClient {
 
     private final WebClient googlePlaceWebClient;
 
-    public GoogleSearchTextResponse sendRequest(GoogleSearchTextRequest request) {
+    public GoogleSearchTextResponse sendRequest(GoogleSearchTextRequest request, GoogleFieldMask googleFieldMask) {
         return googlePlaceWebClient.post()
                 .uri("/places:searchText")
-                .header("X-Goog-FieldMask", "*")
+                .header("X-Goog-FieldMask", googleFieldMask.getMask())
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(GoogleSearchTextResponse.class)

--- a/src/main/java/com/meetup/server/place/domain/Place.java
+++ b/src/main/java/com/meetup/server/place/domain/Place.java
@@ -68,7 +68,9 @@ public class Place extends BaseEntity {
 
     @PrePersist
     public void prePersist() {
-        this.id = UuidCreator.getTimeOrderedEpoch();
+        if (this.id == null) {
+            this.id = UuidCreator.getTimeOrderedEpoch();
+        }
     }
 
     @Builder
@@ -95,5 +97,10 @@ public class Place extends BaseEntity {
             return;
         }
         this.googleReviews = googleReviews;
+    }
+
+    public void updateImage(String imageUri) {
+        Image image = Image.from(imageUri);
+        this.images = List.of(image);
     }
 }

--- a/src/main/java/com/meetup/server/place/domain/Place.java
+++ b/src/main/java/com/meetup/server/place/domain/Place.java
@@ -74,7 +74,8 @@ public class Place extends BaseEntity {
     }
 
     @Builder
-    public Place(String kakaoPlaceId, String googlePlaceId, PlaceCategory category, String name, Double googleRating, List<Image> images, List<OpeningHour> openingHours, List<GoogleReview> googleReviews, Location location, Point point, String rawJson) {
+    public Place(UUID id, String kakaoPlaceId, String googlePlaceId, PlaceCategory category, String name, Double googleRating, List<Image> images, List<OpeningHour> openingHours, List<GoogleReview> googleReviews, Location location, Point point, String rawJson) {
+        this.id = id;
         this.kakaoPlaceId = kakaoPlaceId;
         this.googlePlaceId = googlePlaceId;
         this.category = category;

--- a/src/main/java/com/meetup/server/place/domain/value/Image.java
+++ b/src/main/java/com/meetup/server/place/domain/value/Image.java
@@ -1,17 +1,9 @@
 package com.meetup.server.place.domain.value;
 
-import com.meetup.server.global.clients.google.place.photo.GooglePhotoResponse;
-import lombok.Builder;
-
-@Builder
 public record Image(
-        String name,
         String photoUri
 ) {
-    public static Image from(GooglePhotoResponse googlePhotoResponse) {
-        return Image.builder()
-                .name(googlePhotoResponse.name())
-                .photoUri(googlePhotoResponse.photoUri())
-                .build();
+    public static Image from(String photoUri) {
+        return new Image(photoUri);
     }
 }

--- a/src/test/java/com/meetup/server/global/clients/google/place/GooglePlaceClientTest.java
+++ b/src/test/java/com/meetup/server/global/clients/google/place/GooglePlaceClientTest.java
@@ -25,7 +25,7 @@ class GooglePlaceClientTest extends IntegrationTestContainer {
     @Test
     void 구글_텍스트_검색_요청에_성공하고_장소_사진_조회에_성공한다() {
         GoogleSearchTextRequest request = GoogleSearchTextRequest.from("스타벅스 방배점");
-        GoogleSearchTextResponse response = googleSearchTextClient.sendRequest(request);
+        GoogleSearchTextResponse response = googleSearchTextClient.sendRequest(request, GoogleFieldMask.ALL);
 
         assertNotNull(response);
         assertNotNull(response.places().getFirst().id());

--- a/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
+++ b/src/test/java/com/meetup/server/place/implement/PlaceImageUploaderTest.java
@@ -1,6 +1,7 @@
 package com.meetup.server.place.implement;
 
 import com.meetup.server.fixture.PlaceFixture;
+import com.meetup.server.global.clients.google.place.GoogleFieldMask;
 import com.meetup.server.global.clients.google.place.photo.GooglePhotoClient;
 import com.meetup.server.global.clients.google.place.photo.GooglePhotoRequest;
 import com.meetup.server.global.clients.google.place.photo.GooglePhotoResponse;
@@ -41,7 +42,7 @@ class PlaceImageUploaderTest extends IntegrationTestContainer {
 
     public String uploadImageByPlaceName(Place place, Integer maxHeightPx, Integer maxWidthPx) {
         GoogleSearchTextRequest searchRequest = GoogleSearchTextRequest.from(place.getName());
-        GoogleSearchTextResponse searchResponse = googleSearchTextClient.sendRequest(searchRequest);
+        GoogleSearchTextResponse searchResponse = googleSearchTextClient.sendRequest(searchRequest, GoogleFieldMask.PHOTOS);
 
         if (searchResponse.places().isEmpty()) {
             throw new PlaceException(PlaceErrorType.PLACE_NOT_FOUND);


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- #136 작업에서 이미지 변환 메소드를 기반으로 장소 이미지를 새로 가져와서 변환 후 db에 업데이트합니다.

## ✅ What - 무엇이 변경됐나요?

- 장소 이름 기반으로 장소 이미지를 가져와서 S3 업로드 -> DB 업데이트 하도록 Job 생성하였습니다.
- GoogleFieldMask가 하드코딩 되어있었는데, 이를 Enum으로 관리하도록 변경하였습니다. 추후 FieldMask 변경 후, Enum에 추가해서 관리하면 될 거 같습니다.
- S3에 업로드할 때, PlaceId를 사용하는데 신규 장소 저장 시 flush 전까지 id가 할당되지 않는 문제 발생
  - id를 미리 생성하고 builder에서 적용하였습니다.
- Image 밸류 객체 필드에서 name 필드가 필요하지 않아서 uri만 저장하도록 변경하였습니다.

## 🛠️ How - 어떻게 해결했나요?

- #136 테스트코드에서 유진님이 로직을 잘만들어두셨어서 로직 그대로 사용했습니다!

## 🖼️ Attachment
### 업데이트 전
<img width="942" height="321" alt="스크린샷 2025-07-29 오후 8 26 55" src="https://github.com/user-attachments/assets/1e6e8561-2d9d-4e16-bcbc-a3973f1570b7" />

### 업데이트 후
<img width="929" height="315" alt="스크린샷 2025-07-29 오후 8 27 46" src="https://github.com/user-attachments/assets/91acf106-3a36-42f1-a816-e8c1ec8ca3c3" />



## 💬 기타 코멘트
- 해당 Job 실행 시 Prod, Stg DB의 Image 필드를 null로 설정하고 진행해야 합니다. (cause. Image 필드 변경)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 장소 이미지 일괄 업데이트를 위한 배치 작업이 추가되었습니다.
  * 관리자가 비밀키를 통해 장소 이미지 업데이트 배치 작업을 수동으로 실행할 수 있는 엔드포인트가 추가되었습니다.

* **기능 개선**
  * 구글 플레이스 API 요청 시 반환 필드를 유연하게 지정할 수 있도록 개선되었습니다.
  * 장소 이미지 업로드 및 저장 로직이 개선되어, 이미지 정보가 보다 명확하게 관리됩니다.

* **버그 수정**
  * 장소 ID가 이미 존재하는 경우, 새로 생성하지 않도록 수정되었습니다.

* **테스트**
  * 구글 플레이스 API 및 이미지 업로더 관련 테스트가 필드 마스크 지정 방식에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->