### PR TITLE
[SPOT-148] 모임 수정 및 삭제하기

### DIFF
--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -12,6 +12,7 @@ import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.implement.StartPointProcessor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,5 +51,11 @@ public class EventService {
 
         MeetingPointRoutesResponse cachedResponse = eventReader.readEventCache(eventId);
         return cachedResponse.withEvent(updateEventRequest.eventName(), updateEventRequest.toDateTime());
+    }
+
+    @CacheEvict(value = "routeDetails", key = "#eventId")
+    public void deleteEvent(UUID eventId) {
+        Event event = eventReader.read(eventId);
+        eventProcessor.delete(event);
     }
 }

--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -2,42 +2,53 @@ package com.meetup.server.event.application;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.dto.request.EventRequest;
+import com.meetup.server.event.dto.request.UpdateEventRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.dto.response.MeetingPointRouteGroup;
 import com.meetup.server.event.dto.response.MeetingPointRoutesResponse;
 import com.meetup.server.event.implement.EventProcessor;
+import com.meetup.server.event.implement.EventReader;
 import com.meetup.server.startpoint.domain.StartPoint;
-import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.startpoint.implement.StartPointProcessor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
-@Service
-@RequiredArgsConstructor
 @Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class EventService {
 
+    private final EventReader eventReader;
     private final EventProcessor eventProcessor;
     private final StartPointProcessor startPointProcessor;
     private final EventCacheService eventCacheService;
 
-    @Transactional
     public EventStartPointResponse createEvent(Long userId, UUID guestId, EventRequest eventRequest) {
         Event event = eventProcessor.save(eventRequest);
         StartPoint startPoint = startPointProcessor.save(event, userId, guestId, eventRequest.toStartPointRequest());
         return EventStartPointResponse.of(event, startPoint);
     }
 
-    @Transactional
     public MeetingPointRoutesResponse getMeetingPointRoutes(UUID eventId, Long userId, UUID guestId) {
         MeetingPointRoutesResponse meetingPointRoutesResponse = eventCacheService.getCachedMeetingPointRoutes(eventId);
         for (MeetingPointRouteGroup event : meetingPointRoutesResponse.meetingPointRouteGroups()) {
             eventProcessor.prioritizeMyRoute(userId, guestId, event.getRouteResponse());
         }
         return meetingPointRoutesResponse;
+    }
+
+    @CachePut(value = "routeDetails", key = "#eventId")
+    public MeetingPointRoutesResponse updateEvent(UUID eventId, UpdateEventRequest updateEventRequest) {
+        Event event = eventReader.read(eventId);
+        eventProcessor.update(event, updateEventRequest);
+
+        MeetingPointRoutesResponse cachedResponse = eventReader.readEventCache(eventId);
+        return cachedResponse.withEvent(updateEventRequest.eventName(), updateEventRequest.toDateTime());
     }
 }

--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -49,6 +49,11 @@ public class Event extends BaseEntity {
         this.eventDateTime = eventDateTime;
     }
 
+    public void update(String eventName, LocalDateTime eventDateTime) {
+        this.eventName = eventName;
+        this.eventDateTime = eventDateTime;
+    }
+
     public void updateSubway(Subway subway) {
         this.subway = subway;
     }

--- a/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
@@ -11,7 +11,7 @@ import java.time.LocalTime;
 public record EventRequest(
 
         @NotBlank
-        @Size(min = 1, max = 15)
+        @Size(min = 1, max = 50)
         @Schema(description = "모임명", example = "입력핑")
         String eventName,
 

--- a/src/main/java/com/meetup/server/event/dto/request/UpdateEventRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/UpdateEventRequest.java
@@ -1,0 +1,30 @@
+package com.meetup.server.event.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record UpdateEventRequest(
+
+        @NotBlank
+        @Size(min = 1, max = 50)
+        @Schema(description = "모임명", example = "입력핑")
+        String eventName,
+
+        @NotNull
+        @Schema(description = "모임 날짜", example = "2026-01-01")
+        LocalDate eventDate,
+
+        @NotNull
+        @Schema(description = "모임 시간", example = "15:30")
+        LocalTime eventTime
+) {
+    public LocalDateTime toDateTime() {
+        return LocalDateTime.of(eventDate, eventTime);
+    }
+}

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -42,4 +42,15 @@ public record MeetingPointRoutesResponse(
                 meetingPointRouteGroups
         );
     }
+
+    public MeetingPointRoutesResponse withEvent(String eventName, LocalDateTime eventDateTime) {
+        return new MeetingPointRoutesResponse(
+                eventName,
+                TimeUtil.formatAsDate(eventDateTime),
+                TimeUtil.formatAsTime(eventDateTime),
+                this.eventMaker(),
+                this.peopleCount(),
+                this.meetingPointRouteGroups()
+        );
+    }
 }

--- a/src/main/java/com/meetup/server/event/implement/EventProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/EventProcessor.java
@@ -2,6 +2,7 @@ package com.meetup.server.event.implement;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.dto.request.EventRequest;
+import com.meetup.server.event.dto.request.UpdateEventRequest;
 import com.meetup.server.event.dto.response.RouteResponse;
 import com.meetup.server.event.persistence.EventRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +39,9 @@ public class EventProcessor {
                     routeList.remove(route);
                     routeList.addFirst(route);
                 });
+    }
+
+    public void update(Event event, UpdateEventRequest updateEventRequest) {
+        event.update(updateEventRequest.eventName(), updateEventRequest.toDateTime());
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/EventProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/EventProcessor.java
@@ -5,6 +5,8 @@ import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.request.UpdateEventRequest;
 import com.meetup.server.event.dto.response.RouteResponse;
 import com.meetup.server.event.persistence.EventRepository;
+import com.meetup.server.review.implement.ReviewWriter;
+import com.meetup.server.startpoint.implement.StartPointProcessor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +19,8 @@ import java.util.function.Predicate;
 public class EventProcessor {
 
     private final EventRepository eventRepository;
+    private final StartPointProcessor startPointProcessor;
+    private final ReviewWriter reviewWriter;
 
     public Event save(EventRequest eventRequest) {
         Event event = Event.builder()
@@ -43,5 +47,11 @@ public class EventProcessor {
 
     public void update(Event event, UpdateEventRequest updateEventRequest) {
         event.update(updateEventRequest.eventName(), updateEventRequest.toDateTime());
+    }
+
+    public void delete(Event event) {
+        startPointProcessor.deleteAllByEvent(event);
+        reviewWriter.unlinkFromEvent(event);
+        eventRepository.delete(event);
     }
 }

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -2,6 +2,7 @@ package com.meetup.server.event.presentation;
 
 import com.meetup.server.event.application.EventService;
 import com.meetup.server.event.dto.request.EventRequest;
+import com.meetup.server.event.dto.request.UpdateEventRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.dto.response.MeetingPointRoutesResponse;
 import com.meetup.server.global.support.response.ApiResponse;
@@ -29,6 +30,13 @@ public class EventController {
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) UUID guestId) {
         return ApiResponse.success(eventService.createEvent(userId, guestId, eventRequest));
+    }
+
+    @Operation(summary = "모임 수정 API", description = "모임명과 시간을 입력받아 모임을 수정합니다")
+    @PatchMapping("/{eventId}")
+    public ApiResponse<?> updateEvent(@PathVariable UUID eventId, @Valid @RequestBody UpdateEventRequest updateEventRequest) {
+        eventService.updateEvent(eventId, updateEventRequest);
+        return ApiResponse.success();
     }
 
     @Operation(summary = "지도 조회 API", description = "모임의 중간 지점 계산 및 모임 참여자의 경로 조회를 진행합니다")

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -39,6 +39,13 @@ public class EventController {
         return ApiResponse.success();
     }
 
+    @Operation(summary = "모임 삭제 API", description = "모임을 삭제합니다")
+    @DeleteMapping("/{eventId}")
+    public ApiResponse<?> deleteEvent(@PathVariable UUID eventId) {
+        eventService.deleteEvent(eventId);
+        return ApiResponse.success();
+    }
+
     @Operation(summary = "지도 조회 API", description = "모임의 중간 지점 계산 및 모임 참여자의 경로 조회를 진행합니다")
     @GetMapping("/{eventId}")
     public ApiResponse<MeetingPointRoutesResponse> getMeetingPointRoutes(

--- a/src/main/java/com/meetup/server/review/domain/Review.java
+++ b/src/main/java/com/meetup/server/review/domain/Review.java
@@ -25,7 +25,7 @@ public class Review extends BaseEntity {
     private Place place;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_id", nullable = false)
+    @JoinColumn(name = "event_id", nullable = true)
     private Event event;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/meetup/server/review/domain/Review.java
+++ b/src/main/java/com/meetup/server/review/domain/Review.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Entity
 @Table(name = "review")
@@ -42,7 +43,7 @@ public class Review extends BaseEntity {
     private NonVisitedReview nonVisitedReview;
 
     @Builder
-    public Review(Place place, User user, boolean isVisited, VisitedReview visitedReview, NonVisitedReview nonVisitedReview, Event event) {
+    public Review(Place place, User user, boolean isVisited, VisitedReview visitedReview, NonVisitedReview nonVisitedReview, @NonNull Event event) {
         this.place = place;
         this.user = user;
         this.isVisited = isVisited;

--- a/src/main/java/com/meetup/server/review/implement/ReviewWriter.java
+++ b/src/main/java/com/meetup/server/review/implement/ReviewWriter.java
@@ -75,4 +75,8 @@ public class ReviewWriter {
                 .isVisited(isVisited)
                 .build();
     }
+
+    public void unlinkFromEvent(Event event) {
+        reviewRepository.updateEventToNull(event);
+    }
 }

--- a/src/main/java/com/meetup/server/review/persistence/ReviewRepository.java
+++ b/src/main/java/com/meetup/server/review/persistence/ReviewRepository.java
@@ -5,6 +5,9 @@ import com.meetup.server.place.domain.Place;
 import com.meetup.server.review.domain.Review;
 import com.meetup.server.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,4 +16,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewCus
     List<Review> findAllByPlace(Place place);
 
     boolean existsByEventAndPlaceAndUser(Event event, Place place, User user);
+
+    @Modifying
+    @Query("UPDATE Review r SET r.event = null WHERE r.event = :event")
+    void updateEventToNull(@Param("event") Event event);
 }

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointProcessor.java
@@ -81,4 +81,8 @@ public class StartPointProcessor {
     public void delete(StartPoint startPoint) {
         startPointRepository.delete(startPoint);
     }
+
+    public void deleteAllByEvent(Event event) {
+        startPointRepository.deleteAllByEvent(event);
+    }
 }

--- a/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
+++ b/src/main/java/com/meetup/server/startpoint/persistence/StartPointRepository.java
@@ -3,6 +3,7 @@ package com.meetup.server.startpoint.persistence;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.startpoint.domain.StartPoint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,6 +14,10 @@ public interface StartPointRepository extends JpaRepository<StartPoint, UUID>, S
 
     int countByEvent(Event event);
 
-    @Query("SELECT DISTINCT s FROM StartPoint s JOIN FETCH s.event WHERE s.event = :event")
+    @Query("SELECT DISTINCT sp FROM StartPoint sp JOIN FETCH sp.event WHERE sp.event = :event")
     List<StartPoint> findAllByEvent(@Param("event") Event event);
+
+    @Modifying
+    @Query("DELETE FROM StartPoint sp WHERE sp.event = :event")
+    void deleteAllByEvent(@Param("event") Event event);
 }


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 변경된 화면 설계를 기반으로 추가된 모임 수정 및 삭제 기능을 구현합니다.

## ✅ What - 무엇이 변경됐나요?

### 모임 수정 API
- 모임 수정 시, DB에 모임명과 모임 날짜 및 시간을 업데이트합니다.
- 캐싱된 데이터를 변경된 모임명과 날짜 및 시간으로 동기화합니다. (`CachePut`)

### 모임 삭제 API
- 모임 삭제 시 Event 엔티티와 연관된 Review와 StartPoint를 같이 제거해야 합니다.
  - Review는 Place, User에게 귀속됨으로 연관관계만 끊도록 하였습니다.
- 캐싱된 데이터 존재시 제거합니다. (`CacheEvict`)

## 🛠️ How - 어떻게 해결했나요?

### 모임 수정 API
- 모임 수정 시 캐싱된 데이터를 이전처럼 Class로 가변적으로 관리하지 않도록 했습니다.
  - 생각해보니, 앞서 성능적인 이슈때문에 객체를 재생성하는 비용보다 가변 클래스로 관리하는게 낫겠다고 논의했었습니다.
  - 다만, 수정이 잦지 않고 캐싱된 데이터는 가변적으로 관리할 경우 동시성 문제가 발생할 수 있습니다.
  - 따라서 객체를 불변으로 관리하고 매번 수정될 때마다 재생성하는게 맞다고 판단했습니다.
  - 추후, 성능 테스트를 통해서 확인해봐야할 것 같습니다. 만약 괜찮다면 앞서 가변으로 관리하던 클래스도 불변 객체로 변경하면 좋을 거 같아요.

### 모임 삭제 API
- 벌크 연산을 통해 최적화

**개선 전**
```java
// 이벤트 조회
Hibernate: 
    select
        e1_0.event_id,
        e1_0.created_at,
        e1_0.event_date_time,
        e1_0.event_name,
        e1_0.is_deleted,
        e1_0.modified_at,
        e1_0.place_id,
        e1_0.subway_id 
    from
        event e1_0 
    where
        e1_0.event_id=?

// 이벤트와 연관된 출발지 조회
Hibernate: 
    select
        sp1_0.start_point_id,
        sp1_0.address,
        sp1_0.road_address,
        sp1_0.created_at,
        sp1_0.event_id,
        sp1_0.guest_id,
        sp1_0.is_deleted,
        sp1_0.is_transit,
        sp1_0.is_user,
        sp1_0.road_latitude,
        sp1_0.road_longitude,
        sp1_0.modified_at,
        sp1_0.start_point_name,
        sp1_0.non_user_name,
        sp1_0.point,
        sp1_0.user_id 
    from
        start_point sp1_0 
    where
        sp1_0.event_id=?

// 이벤트와 연관된 리뷰 조회
Hibernate: 
    select
        r1_0.review_id,
        r1_0.created_at,
        r1_0.event_id,
        r1_0.is_deleted,
        r1_0.is_visited,
        r1_0.modified_at,
        r1_0.place_id,
        r1_0.user_id 
    from
        review r1_0 
    where
        r1_0.event_id=?

// 리뷰 - 미방문 조회
Hibernate: 
    select
        nvr1_0.review_id,
        nvr1_0.address,
        nvr1_0.road_address,
        nvr1_0.road_latitude,
        nvr1_0.road_longitude,
        nvr1_0.actual_visited_place_name,
        nvr1_0.point,
        nvr1_0.categories,
        nvr1_0.created_at,
        nvr1_0.etc_reason,
        nvr1_0.is_deleted,
        nvr1_0.modified_at 
    from
        non_visited_review nvr1_0 
    where
        nvr1_0.review_id=?

// 리뷰 - 방문 조회
Hibernate: 
    select
        vr1_0.review_id,
        vr1_0.content,
        vr1_0.created_at,
        vr1_0.is_deleted,
        vr1_0.modified_at,
        vr1_0.quiet,
        vr1_0.seat,
        vr1_0.socket,
        vr1_0.visited_time 
    from
        visited_review vr1_0 
    where
        vr1_0.review_id=?

// 리뷰 연관관계 제거 (null)
Hibernate: 
    update
        review 
    set
        event_id=?,
        is_deleted=?,
        is_visited=?,
        modified_at=?,
        place_id=?,
        user_id=? 
    where
        review_id=?

// 출발지 삭제 (출발지 수만큼)
Hibernate: 
    delete 
    from
        start_point 
    where
        start_point_id=?
Hibernate: 
    delete 
    from
        start_point 
    where
        start_point_id=?

// 이벤트 삭제
Hibernate: 
    delete 
    from
        event 
    where
        event_id=?
```
- 출발지, 리뷰 개수만큼 쿼리 발생

**개선 후**
<img width="1369" height="815" alt="스크린샷 2025-08-01 오전 5 00 25" src="https://github.com/user-attachments/assets/fba8c6df-fe43-47bf-8020-beeb4b85d1c8" />

1. 이벤트 조회
2. 출발지 삭제 (벌크 연산)
3. 리뷰 연관관계 제거 (벌크 연산)
4. 이벤트 삭제

-> 총 4개의 쿼리로 최적화

## 🖼️ Attachment

### 모임 수정 API
<img width="1431" height="667" alt="스크린샷 2025-08-01 오전 3 47 48" src="https://github.com/user-attachments/assets/9ed503f5-dc12-4252-99ed-bbe7b1f0d411" />
<img width="1241" height="265" alt="스크린샷 2025-08-01 오전 3 48 06" src="https://github.com/user-attachments/assets/456fb32a-b85f-480e-bd4a-3def24a89815" />

### 모임 삭제 API
<img width="560" height="274" alt="스크린샷 2025-08-01 오전 5 00 17" src="https://github.com/user-attachments/assets/50a67da5-dd7d-4d77-b4f6-1d2413529eb7" />

## 💬 기타 코멘트

- review 테이블의 event_id가 nullable로 변경되었습니다. ddl-auto로 자동 업데이트 될 거 같은데 배포 후 확인해봐야 합니다.

만약 반영 안된다면 하기 쿼리를 적용하면 됩니다. (제약조건은 DDL 확인 후 변경 요망)
```sql
-- 외래키 제약조건 삭제
ALTER TABLE review DROP CONSTRAINT fkqhtk2kbsx9ga87m7xr21b3ggr;

-- 컬럼 null 허용으로 변경
ALTER TABLE review ALTER COLUMN event_id DROP NOT NULL;

-- 외래키 제약조건 재생성
ALTER TABLE review
    ADD CONSTRAINT fkqhtk2kbsx9ga87m7xr21b3ggr FOREIGN KEY (event_id) REFERENCES event(event_id);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 수정 및 삭제 기능이 추가되었습니다. 기존 이벤트의 이름과 날짜/시간을 변경하거나 이벤트를 삭제할 수 있습니다.
  * 관련 API 엔드포인트(PATCH, DELETE)가 제공되어 클라이언트에서 직접 이벤트를 수정 및 삭제할 수 있습니다.

* **버그 수정**
  * 이벤트 삭제 시 관련된 시작 지점과 리뷰 데이터가 함께 정리되어 데이터 일관성이 향상되었습니다.

* **문서화**
  * 이벤트 수정 요청에 대한 입력값 유효성 검사 및 예시가 API 문서에 추가되었습니다.

* **기타 개선**
  * 이벤트명 최대 길이가 15자에서 50자로 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->