### PR TITLE
[SPOT-132] MP 조회 시, 확정 장소 데이터를 추가 반환하기

### DIFF
--- a/src/main/java/com/meetup/server/event/application/EventCacheService.java
+++ b/src/main/java/com/meetup/server/event/application/EventCacheService.java
@@ -3,10 +3,13 @@ package com.meetup.server.event.application;
 import com.meetup.server.event.dto.response.MeetingPointResult;
 import com.meetup.server.event.dto.response.MeetingPointRouteGroup;
 import com.meetup.server.event.dto.response.MeetingPointRoutesResponse;
+import com.meetup.server.event.implement.EventReader;
 import com.meetup.server.event.implement.MeetingPointCalculator;
 import com.meetup.server.event.implement.RouteAssembler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -18,8 +21,12 @@ import java.util.UUID;
 @Slf4j
 public class EventCacheService {
 
+    private final CacheManager cacheManager;
+
     private final MeetingPointCalculator meetingPointCalculator;
     private final RouteAssembler routeAssembler;
+    private final EventReader eventReader;
+
 
     @Cacheable(value = "routeDetails", key = "#eventId", unless = "#result == null")
     public MeetingPointRoutesResponse getCachedMeetingPointRoutes(UUID eventId) {
@@ -28,5 +35,15 @@ public class EventCacheService {
                 .map(resultResponse -> routeAssembler.assemble(resultResponse.startPoints(), resultResponse.subway()))
                 .toList();
         return MeetingPointRoutesResponse.of(meetingPointResults, meetingPointRouteGroups);
+    }
+
+    public void updateCachedPlaceName(UUID eventId, String placeName) {
+        Cache cache = cacheManager.getCache("routeDetails");
+        if (!eventReader.isEventCacheExists(eventId)) {
+            return;
+        }
+
+        MeetingPointRoutesResponse cachedData = (MeetingPointRoutesResponse) cache.get(eventId).get();
+        cache.put(eventId, cachedData.withPlaceName(placeName));
     }
 }

--- a/src/main/java/com/meetup/server/event/application/EventCacheService.java
+++ b/src/main/java/com/meetup/server/event/application/EventCacheService.java
@@ -42,8 +42,14 @@ public class EventCacheService {
         if (!eventReader.isEventCacheExists(eventId)) {
             return;
         }
+        Cache.ValueWrapper valueWrapper = cache.get(eventId);
+        if (valueWrapper == null) {
+            return;
+        }
 
-        MeetingPointRoutesResponse cachedData = (MeetingPointRoutesResponse) cache.get(eventId).get();
-        cache.put(eventId, cachedData.withPlaceName(placeName));
+        MeetingPointRoutesResponse cachedData = (MeetingPointRoutesResponse) valueWrapper.get();
+        if (cachedData != null) {
+            cache.put(eventId, cachedData.withPlaceName(placeName));
+        }
     }
 }

--- a/src/main/java/com/meetup/server/event/application/EventCacheService.java
+++ b/src/main/java/com/meetup/server/event/application/EventCacheService.java
@@ -38,18 +38,12 @@ public class EventCacheService {
     }
 
     public void updateCachedPlaceName(UUID eventId, String placeName) {
-        Cache cache = cacheManager.getCache("routeDetails");
-        if (!eventReader.isEventCacheExists(eventId)) {
-            return;
-        }
-        Cache.ValueWrapper valueWrapper = cache.get(eventId);
-        if (valueWrapper == null) {
+        MeetingPointRoutesResponse cachedData = eventReader.readEventCache(eventId);
+        if (cachedData == null) {
             return;
         }
 
-        MeetingPointRoutesResponse cachedData = (MeetingPointRoutesResponse) valueWrapper.get();
-        if (cachedData != null) {
-            cache.put(eventId, cachedData.withPlaceName(placeName));
-        }
+        Cache cache = cacheManager.getCache("routeDetails");
+        cache.put(eventId, cachedData.withPlaceName(placeName));
     }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -4,18 +4,32 @@ import com.meetup.server.event.domain.Event;
 import com.meetup.server.global.util.TimeUtil;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.util.UsernameExtractor;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 
 public record MeetingPointRoutesResponse(
+        @Schema(description = "모임명", example = "SPOT 정기회의")
         String eventName,
+
+        @Schema(description = "모임 날짜 (yyyy-MM-dd 형식)", example = "2025-07-09")
         String eventDate,
+
+        @Schema(description = "모임 시간 (HH:mm 형식)", example = "14:00")
         String eventTime,
+
+        @Schema(description = "모임 생성자", example = "홍길동")
         String eventMaker,
+
+        @Schema(description = "확정 장소명", example = "스타벅스 방배카페거리점")
         String placeName,
+
+        @Schema(description = "참여자 수", example = "5")
         int peopleCount,
+
+        @Schema(description = "모임 경로 관련 그룹 데이터")
         List<MeetingPointRouteGroup> meetingPointRouteGroups
 ) {
 

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -14,6 +14,7 @@ public record MeetingPointRoutesResponse(
         String eventDate,
         String eventTime,
         String eventMaker,
+        String placeName,
         int peopleCount,
         List<MeetingPointRouteGroup> meetingPointRouteGroups
 ) {
@@ -38,6 +39,7 @@ public record MeetingPointRoutesResponse(
                 TimeUtil.formatAsDate(eventDateTime),
                 TimeUtil.formatAsTime(eventDateTime),
                 eventMaker,
+                event.getPlace().getName(),
                 peopleCount,
                 meetingPointRouteGroups
         );

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -6,7 +6,6 @@ import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.util.UsernameExtractor;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 
@@ -35,27 +34,27 @@ public record MeetingPointRoutesResponse(
 
     public static MeetingPointRoutesResponse of(List<MeetingPointResult> meetingPointResults, List<MeetingPointRouteGroup> meetingPointRouteGroups) {
         MeetingPointResult meetingPointResult = meetingPointResults.getFirst();
-
         Event event = meetingPointResult.event();
-        LocalDateTime eventDateTime = event.getEventDateTime();
-
-        List<StartPoint> startPoints = meetingPointResult.startPoints();
-
-        String eventMaker = startPoints.stream()
-                .min(Comparator.comparing(StartPoint::getCreatedAt))
-                .map(UsernameExtractor::extractDisplayName)
-                .orElse(null);
-
-        int peopleCount = startPoints.size();
 
         return new MeetingPointRoutesResponse(
                 event.getEventName(),
-                TimeUtil.formatAsDate(eventDateTime),
-                TimeUtil.formatAsTime(eventDateTime),
-                eventMaker,
-                event.getPlace().getName(),
-                peopleCount,
+                TimeUtil.formatAsDate(event.getEventDateTime()),
+                TimeUtil.formatAsTime(event.getEventDateTime()),
+                extractEventMaker(meetingPointResult.startPoints()),
+                extractPlaceName(event),
+                meetingPointResult.startPoints().size(),
                 meetingPointRouteGroups
         );
+    }
+
+    private static String extractPlaceName(Event event) {
+        return event.getPlace() != null ? event.getPlace().getName() : null;
+    }
+
+    private static String extractEventMaker(List<StartPoint> startPoints) {
+        return startPoints.stream()
+                .min(Comparator.comparing(StartPoint::getCreatedAt))
+                .map(UsernameExtractor::extractDisplayName)
+                .orElse(null);
     }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -2,12 +2,14 @@ package com.meetup.server.event.dto.response;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.global.util.TimeUtil;
+import com.meetup.server.place.domain.Place;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.util.UsernameExtractor;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 public record MeetingPointRoutesResponse(
         @Schema(description = "모임명", example = "SPOT 정기회의")
@@ -48,7 +50,9 @@ public record MeetingPointRoutesResponse(
     }
 
     private static String extractPlaceName(Event event) {
-        return event.getPlace() != null ? event.getPlace().getName() : null;
+        return Optional.ofNullable(event.getPlace())
+                .map(Place::getName)
+                .orElse(null);
     }
 
     private static String extractEventMaker(List<StartPoint> startPoints) {

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -7,6 +7,7 @@ import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.util.UsernameExtractor;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -77,9 +78,10 @@ public record MeetingPointRoutesResponse(
     public MeetingPointRoutesResponse withEvent(String eventName, LocalDateTime eventDateTime) {
         return new MeetingPointRoutesResponse(
                 eventName,
-                TimeUtil.formatAsDate(eventDateTime),
+                TimeUtil.formatAsDashDate(eventDateTime),
                 TimeUtil.formatAsTime(eventDateTime),
                 this.eventMaker(),
+                this.placeName(),
                 this.peopleCount(),
                 this.meetingPointRouteGroups()
         );

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -57,4 +57,16 @@ public record MeetingPointRoutesResponse(
                 .map(UsernameExtractor::extractDisplayName)
                 .orElse(null);
     }
+
+    public MeetingPointRoutesResponse withPlaceName(String confirmedPlaceName) {
+        return new MeetingPointRoutesResponse(
+                this.eventName,
+                this.eventDate,
+                this.eventTime,
+                this.eventMaker,
+                confirmedPlaceName,
+                this.peopleCount,
+                this.meetingPointRouteGroups
+        );
+    }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/MeetingPointRoutesResponse.java
@@ -38,7 +38,7 @@ public record MeetingPointRoutesResponse(
 
         return new MeetingPointRoutesResponse(
                 event.getEventName(),
-                TimeUtil.formatAsDate(event.getEventDateTime()),
+                TimeUtil.formatAsDashDate(event.getEventDateTime()),
                 TimeUtil.formatAsTime(event.getEventDateTime()),
                 extractEventMaker(meetingPointResult.startPoints()),
                 extractPlaceName(event),

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -1,12 +1,10 @@
 package com.meetup.server.event.implement;
 
 import com.meetup.server.event.domain.Event;
-import com.meetup.server.event.dto.response.MeetingPointRoutesResponse;
 import com.meetup.server.event.exception.EventErrorType;
 import com.meetup.server.event.exception.EventException;
 import com.meetup.server.event.persistence.EventRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
@@ -23,13 +21,5 @@ public class EventReader {
     public Event read(UUID eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventException(EventErrorType.EVENT_NOT_FOUND));
-    }
-
-    public MeetingPointRoutesResponse readEventCache(UUID eventId) {
-        Cache cache = cacheManager.getCache("routeDetails");
-        Cache.ValueWrapper wrapper = cache.get(eventId);
-
-        eventValidator.validateEventCacheExist(wrapper);
-        return (MeetingPointRoutesResponse) wrapper.get();
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -1,10 +1,12 @@
 package com.meetup.server.event.implement;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.response.MeetingPointRoutesResponse;
 import com.meetup.server.event.exception.EventErrorType;
 import com.meetup.server.event.exception.EventException;
 import com.meetup.server.event.persistence.EventRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
@@ -21,5 +23,16 @@ public class EventReader {
     public Event read(UUID eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventException(EventErrorType.EVENT_NOT_FOUND));
+    }
+
+    /**
+     * #139 캐시 데이터 가져올 때 사용하는 메서드
+     */
+    public MeetingPointRoutesResponse readEventCache(UUID eventId) {
+        Cache cache = cacheManager.getCache("routeDetails");
+        Cache.ValueWrapper wrapper = cache.get(eventId);
+
+        eventValidator.validateEventCacheExist(wrapper);
+        return (MeetingPointRoutesResponse) wrapper.get();
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -25,9 +25,6 @@ public class EventReader {
                 .orElseThrow(() -> new EventException(EventErrorType.EVENT_NOT_FOUND));
     }
 
-    /**
-     *  캐시 데이터 가져올 때 사용하는 메서드 (#139)
-     */
     public MeetingPointRoutesResponse readEventCache(UUID eventId) {
         Cache cache = cacheManager.getCache("routeDetails");
         Cache.ValueWrapper wrapper = cache.get(eventId);

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -26,13 +26,27 @@ public class EventReader {
     }
 
     /**
-     * #139 캐시 데이터 가져올 때 사용하는 메서드
+     *  캐시 데이터 가져올 때 사용하는 메서드 (#139)
      */
     public MeetingPointRoutesResponse readEventCache(UUID eventId) {
         Cache cache = cacheManager.getCache("routeDetails");
         Cache.ValueWrapper wrapper = cache.get(eventId);
 
         eventValidator.validateEventCacheExist(wrapper);
+
         return (MeetingPointRoutesResponse) wrapper.get();
+    }
+
+    public boolean isEventCacheExists(UUID eventId) {
+        Cache cache = cacheManager.getCache("routeDetails");
+        if (cache == null) {
+            return false;
+        }
+        Cache.ValueWrapper wrapper = cache.get(eventId);
+
+        if (wrapper == null) {
+            return false;
+        }
+        return wrapper.get() instanceof MeetingPointRoutesResponse;
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 public class EventReader {
 
     private final EventRepository eventRepository;
-    private final EventValidator eventValidator;
     private final CacheManager cacheManager;
 
     public Event read(UUID eventId) {
@@ -27,23 +26,20 @@ public class EventReader {
 
     public MeetingPointRoutesResponse readEventCache(UUID eventId) {
         Cache cache = cacheManager.getCache("routeDetails");
-        Cache.ValueWrapper wrapper = cache.get(eventId);
-
-        eventValidator.validateEventCacheExist(wrapper);
-
-        return (MeetingPointRoutesResponse) wrapper.get();
-    }
-
-    public boolean isEventCacheExists(UUID eventId) {
-        Cache cache = cacheManager.getCache("routeDetails");
         if (cache == null) {
-            return false;
+            return null;
         }
-        Cache.ValueWrapper wrapper = cache.get(eventId);
 
+        Cache.ValueWrapper wrapper = cache.get(eventId);
         if (wrapper == null) {
-            return false;
+            return null;
         }
-        return wrapper.get() instanceof MeetingPointRoutesResponse;
+
+        Object cachedValue = wrapper.get();
+        if (!(cachedValue instanceof MeetingPointRoutesResponse)) {
+            return null;
+        }
+
+        return (MeetingPointRoutesResponse) cachedValue;
     }
 }

--- a/src/main/java/com/meetup/server/global/util/TimeUtil.java
+++ b/src/main/java/com/meetup/server/global/util/TimeUtil.java
@@ -17,6 +17,8 @@ public class TimeUtil {
 
     private static final DateTimeFormatter YYYY_MM_DD_DOT_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
+    private static final DateTimeFormatter YYYY_MM_DD_DASH_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
     private static final DateTimeFormatter HH_MM_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     public static int calculateDaysAgo(LocalDateTime createdAt) {
@@ -31,8 +33,12 @@ public class TimeUtil {
         return dateTime.format(YYYY_MM_DD_HH_MM_SS_FORMATTER);
     }
 
-    public static String formatAsDate(LocalDateTime dateTime) {
+    public static String formatAsDotDate(LocalDateTime dateTime) {
         return dateTime.format(YYYY_MM_DD_DOT_FORMATTER);
+    }
+
+    public static String formatAsDashDate(LocalDateTime dateTime) {
+        return dateTime.format(YYYY_MM_DD_DASH_FORMATTER);
     }
 
     public static String formatAsTime(LocalDateTime dateTime) {

--- a/src/main/java/com/meetup/server/global/util/TimeUtil.java
+++ b/src/main/java/com/meetup/server/global/util/TimeUtil.java
@@ -15,8 +15,6 @@ public class TimeUtil {
 
     private static final DateTimeFormatter YYYY_MM_DD_HH_MM_SS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-    private static final DateTimeFormatter YYYY_MM_DD_DOT_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
-
     private static final DateTimeFormatter YYYY_MM_DD_DASH_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     private static final DateTimeFormatter HH_MM_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
@@ -32,11 +30,6 @@ public class TimeUtil {
     public static String formatAsDateTime(LocalDateTime dateTime) {
         return dateTime.format(YYYY_MM_DD_HH_MM_SS_FORMATTER);
     }
-
-    public static String formatAsDotDate(LocalDateTime dateTime) {
-        return dateTime.format(YYYY_MM_DD_DOT_FORMATTER);
-    }
-
     public static String formatAsDashDate(LocalDateTime dateTime) {
         return dateTime.format(YYYY_MM_DD_DASH_FORMATTER);
     }

--- a/src/main/java/com/meetup/server/place/application/PlaceService.java
+++ b/src/main/java/com/meetup/server/place/application/PlaceService.java
@@ -46,9 +46,7 @@ public class PlaceService {
         Subway subway = subwayReader.read(subwayId);
 
         event.updateMeetingPlace(place, subway);
-
         eventCacheService.updateCachedPlaceName(eventId, place.getName());
-
     }
 
     public PlaceResponseList getAllPlaces(UUID eventId, int subwayId) {

--- a/src/main/java/com/meetup/server/place/application/PlaceService.java
+++ b/src/main/java/com/meetup/server/place/application/PlaceService.java
@@ -1,5 +1,6 @@
 package com.meetup.server.place.application;
 
+import com.meetup.server.event.application.EventCacheService;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.implement.EventReader;
 import com.meetup.server.place.domain.Place;
@@ -16,7 +17,6 @@ import com.meetup.server.subway.domain.Subway;
 import com.meetup.server.subway.implement.reader.SubwayReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,15 +37,18 @@ public class PlaceService {
     private final ReviewReader reviewReader;
     private final PlaceSorter placeSorter;
     private final SubwayReader subwayReader;
+    private final EventCacheService eventCacheService;
 
     @Transactional
-    @CacheEvict(value = "routeDetails", key = "#eventId")
     public void confirmPlace(UUID eventId, UUID placeId, int subwayId) {
         Event event = eventReader.read(eventId);
         Place place = placeReader.read(placeId);
         Subway subway = subwayReader.read(subwayId);
 
         event.updateMeetingPlace(place, subway);
+
+        eventCacheService.updateCachedPlaceName(eventId, place.getName());
+
     }
 
     public PlaceResponseList getAllPlaces(UUID eventId, int subwayId) {

--- a/src/main/java/com/meetup/server/place/application/PlaceService.java
+++ b/src/main/java/com/meetup/server/place/application/PlaceService.java
@@ -16,6 +16,7 @@ import com.meetup.server.subway.domain.Subway;
 import com.meetup.server.subway.implement.reader.SubwayReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +39,7 @@ public class PlaceService {
     private final SubwayReader subwayReader;
 
     @Transactional
+    @CacheEvict(value = "routeDetails", key = "#eventId")
     public void confirmPlace(UUID eventId, UUID placeId, int subwayId) {
         Event event = eventReader.read(eventId);
         Place place = placeReader.read(placeId);

--- a/src/main/java/com/meetup/server/user/dto/response/UserEventHistoryResponse.java
+++ b/src/main/java/com/meetup/server/user/dto/response/UserEventHistoryResponse.java
@@ -25,7 +25,7 @@ public record UserEventHistoryResponse(
         return UserEventHistoryResponse.builder()
                 .eventId(eventHistory.eventId())
                 .eventName(eventHistory.eventName())
-                .eventDate(TimeUtil.formatAsDotDate(eventHistory.eventDateTime()))
+                .eventDate(TimeUtil.formatAsDashDate(eventHistory.eventDateTime()))
                 .eventTime(TimeUtil.formatAsTime(eventHistory.eventDateTime()))
                 .middlePointName(eventHistory.subwayName())
                 .placeName(eventHistory.placeName())

--- a/src/main/java/com/meetup/server/user/dto/response/UserEventHistoryResponse.java
+++ b/src/main/java/com/meetup/server/user/dto/response/UserEventHistoryResponse.java
@@ -25,7 +25,7 @@ public record UserEventHistoryResponse(
         return UserEventHistoryResponse.builder()
                 .eventId(eventHistory.eventId())
                 .eventName(eventHistory.eventName())
-                .eventDate(TimeUtil.formatAsDate(eventHistory.eventDateTime()))
+                .eventDate(TimeUtil.formatAsDotDate(eventHistory.eventDateTime()))
                 .eventTime(TimeUtil.formatAsTime(eventHistory.eventDateTime()))
                 .middlePointName(eventHistory.subwayName())
                 .placeName(eventHistory.placeName())


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- [SPOT 3Q] 기반으로 변경된 화면 설계를 기반으로 장소 확정 데이터를 추가 반환합니다.

## ✅ What - 무엇이 변경됐나요?

- Meeting Point 조회 시, Event에서 장소 정보를 가져와 장소명을 응답에 포함시켰습니다.
- 장소가 확정되지 않은 경우 null을 반환하도록 처리했습니다.
- 장소 확정 또는 수정 시 캐시가 갱신되도록 @CacheEvict 를 적용했습니다.

## 🛠️ How - 어떻게 해결했나요?

- MeetingPointRoutesResponse DTO에 장소명 필드를 추가하고, null 처리 로직을 적용했습니다.

## 🖼️ Attachment

- MP 조회
<img width="2714" height="1121" alt="image" src="https://github.com/user-attachments/assets/02025604-c300-40fa-96f3-22bef38d79a7" />

- FI 장소 변경 이후 MP 조회
<img width="2763" height="1098" alt="image" src="https://github.com/user-attachments/assets/1fce5c9a-066a-4828-92ac-a0a8c1bed9ff" />


## 💬 기타 코멘트

-  모임 수정 및 삭제하기 pr 에서 가변 클래스로 관리하는 방식에서 불변으로 관리하고 재생성 하는 부분에 대해 현재 API 에서도 개선이 가능할 것 같아서 현재 task 는 merge 하고 추가로 pr 해서 수정하는 방향으로 진행해봐도 될까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * API 응답 필드에 Swagger 설명과 예시가 추가되어 API 문서가 개선되었습니다.

* **기능 개선**
  * 장소 확정 시 캐시에 저장된 장소명이 자동으로 업데이트되어 최신 정보가 반영됩니다.
  * 이벤트 캐시 조회 시 안전한 타입 검사와 null 체크가 추가되어 안정성이 향상되었습니다.

* **리팩터**
  * 내부 로직이 보완되어 코드 가독성과 유지보수성이 향상되었습니다.
  * 날짜 포맷팅 방식이 변경되어 일관된 대시(-) 구분 날짜 표시가 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->