### PR TITLE
[SPOT-160] HI 1명 조회 가능하게 변경하기

### DIFF
--- a/src/main/java/com/meetup/server/startpoint/persistence/StartPointCustomRepositoryImpl.java
+++ b/src/main/java/com/meetup/server/startpoint/persistence/StartPointCustomRepositoryImpl.java
@@ -49,7 +49,6 @@ public class StartPointCustomRepositoryImpl implements StartPointCustomRepositor
                                                         .select(startPoint.event.eventId)
                                                         .from(startPoint)
                                                         .groupBy(startPoint.event.eventId)
-                                                        .having(startPoint.count().goe(2))
                                         )
                                 )
                 )


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- QA 이후 변경 된 HI 의 기획 사항을 적용합니다

## ✅ What - 무엇이 변경됐나요?

- 2명 이상만 조회하도록 확인하던 having 절을 삭제했습니다

## 🛠️ How - 어떻게 해결했나요?

- 본래 having 절을 이용하여 모임에 2명 이상 있을 경우만 조회 가능하도록 했던 부분을 제거해서 1명 인 경우 포함 모든 event 가 조회 되도록 변경했습니다

## 🖼️ Attachment

- HI 조회 결과
<img width="2760" height="1140" alt="image" src="https://github.com/user-attachments/assets/1ebe2c4b-fcdb-4260-b2b2-a14efcc8708f" />


## 💬 기타 코멘트
