### PR TITLE
[SPOT-163] 도로명 주소 Null 허용하기

### DIFF
--- a/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
@@ -37,7 +37,7 @@ public record EventRequest(
         String address,
 
         @NotNull
-        @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580")
+        @Schema(description = "도로명주소 (빈 문자열 허용)", example = "서울특별시 강남구 선릉로 지하580")
         String roadAddress,
 
         @DecimalMin(value = "-180.0", message = "경도는 -180.0보다 크거나 같아야 합니다.")

--- a/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
@@ -36,7 +36,7 @@ public record EventRequest(
         @Schema(description = "지번주소", example = "서울특별시 강남구 삼성동 111-114")
         String address,
 
-        @NotBlank(message = "도로명주소는 필수 값입니다.")
+        @NotNull
         @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580")
         String roadAddress,
 

--- a/src/main/java/com/meetup/server/startpoint/domain/type/Address.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/type/Address.java
@@ -13,13 +13,16 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Address {
 
-    @Column(name = "address", length = 255, nullable = false)
-    private String address;    //지번주소
+    @Column(name = "address", nullable = false)
+    private String address;
 
-    @Column(name = "road_address", length = 255, nullable = false)
-    private String roadAddress; //도로명주소
+    @Column(name = "road_address", nullable = true)
+    private String roadAddress;
 
     public static Address of(String address, String roadAddress) {
-        return new Address(address, roadAddress);
+        return new Address(
+                address,
+                (roadAddress == null || roadAddress.isBlank()) ? null : roadAddress
+        );
     }
 }

--- a/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
+++ b/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
@@ -18,7 +18,7 @@ public record StartPointRequest(
         @Schema(description = "지번주소", example = "서울특별시 강남구 삼성동 111-114")
         String address,
 
-        @NotBlank(message = "도로명주소는 필수 값입니다.")
+        @NotNull
         @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580")
         String roadAddress,
 

--- a/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
+++ b/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
@@ -19,7 +19,7 @@ public record StartPointRequest(
         String address,
 
         @NotNull
-        @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580")
+        @Schema(description = "도로명주소 (빈 문자열 허용)", example = "서울특별시 강남구 선릉로 지하580")
         String roadAddress,
 
         @DecimalMin(value = "-180.0", message = "경도는 -180.0보다 크거나 같아야 합니다.")


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- QA 진행 시, 카카오 API에서 지번 주소는 제공하지만 도로명 주소는 제공하지 않는 경우가 종종 있었습니다. 
- 서버에서 요청값 검증에서 `@NotBlank` 사용해 공백 허용을 하지 않기 때문에 출발지 생성이 되지 않는 문제가 발생했습니다.

## ✅ What - 무엇이 변경됐나요?

- 요청값 검증에서 `@NotNull`로 변경했습니다. 검증을 아예 제거하려고 했지만, 프론트에서 값이 없을 경우 공백으로 전달해주기 때문입니다.
- DB road_address 컬럼의 null을 허용하도록 변경하였습니다.

## 🛠️ How - 어떻게 해결했나요?

- 프론트에서 빈 문자열을 전달해주지만, db에 null로 저장하기 위해서 Address 값객체 생성시 변환 로직을 추가했습니다.

## 🖼️ Attachment
### 생성
<img width="549" height="636" alt="스크린샷 2025-08-12 오후 4 25 20" src="https://github.com/user-attachments/assets/f9f6b257-7b9f-42bb-93a2-7c5cd9234d1e" />

### 수정
<img width="895" height="605" alt="스크린샷 2025-08-12 오후 4 27 48" src="https://github.com/user-attachments/assets/82612b7b-c497-4c15-acd6-f18c6d45b833" />

### 결과
<img width="785" height="224" alt="스크린샷 2025-08-12 오후 4 25 46" src="https://github.com/user-attachments/assets/d3abc200-98d0-4ca9-93e0-ade67b0ec864" />

## 💬 기타 코멘트

- road_address가 nullable하도록 변경되어, 운영/스테이징 서버에 ALTER 쿼리로 직접 수정해야할 수 있습니다.
```sql
alter table start_point
    alter column road_address drop not null;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 도로명주소 입력 규칙 완화: 값은 필수(Null 불허)이나 빈 문자열 허용으로 변경되었습니다.
* 버그 수정
  * 빈 문자열 관련 검증으로 제출이 실패하던 사례 해소.
* 리팩터링
  * 주소 저장 규칙 조정: 도로명주소는 선택 저장으로 변경되고 내부적으로 빈 값은 null로 정리되며 기본 길이 제한이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->