### PR TITLE
[SPOT-164] 중간 지점 지하철역 후보군에서 역명 중복 지하철역 제거하기

### DIFF
--- a/src/main/java/com/meetup/server/event/implement/MeetingPointCalculator.java
+++ b/src/main/java/com/meetup/server/event/implement/MeetingPointCalculator.java
@@ -17,9 +17,12 @@ import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -51,13 +54,23 @@ public class MeetingPointCalculator {
         if (topFairSubwayIds.isEmpty()) {
             throw new EventException(EventErrorType.PATH_CALCULATION_FAILED);
         }
-
         List<Subway> topFairSubways = subwayReader.readAllByIdIn(topFairSubwayIds);
 
-        Subway firstSubway = topFairSubways.getFirst();
+        List<Subway> filteredSubways = topFairSubways.stream()
+                .collect(Collectors.toMap(
+                        Subway::getName,
+                        Function.identity(),
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new
+                ))
+                .values()
+                .stream()
+                .toList();
+
+        Subway firstSubway = filteredSubways.getFirst();
         event.updateSubway(firstSubway);
 
-        return topFairSubways.stream()
+        return filteredSubways.stream()
                 .map(subway -> MeetingPointResult.of(event, startPoints, subway))
                 .toList();
     }

--- a/src/main/java/com/meetup/server/event/implement/MeetingPointCalculator.java
+++ b/src/main/java/com/meetup/server/event/implement/MeetingPointCalculator.java
@@ -54,7 +54,7 @@ public class MeetingPointCalculator {
         if (topFairSubwayIds.isEmpty()) {
             throw new EventException(EventErrorType.PATH_CALCULATION_FAILED);
         }
-        List<Subway> topFairSubways = subwayReader.readAllByIdIn(topFairSubwayIds);
+        List<Subway> topFairSubways = subwayReader.readAllOrderByIds(topFairSubwayIds);
 
         List<Subway> filteredSubways = topFairSubways.stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/com/meetup/server/subway/implement/reader/SubwayReader.java
+++ b/src/main/java/com/meetup/server/subway/implement/reader/SubwayReader.java
@@ -25,8 +25,8 @@ public class SubwayReader {
         return subwayRepository.findById(subwayId).orElseThrow(() -> new SubwayException(SubwayErrorType.SUBWAY_NOT_FOUND));
     }
 
-    public List<Subway> readAllByIdIn(List<Integer> subwayIds) {
-        return subwayRepository.findAllBySubwayIdIn(subwayIds);
+    public List<Subway> readAllOrderByIds(List<Integer> subwayIds) {
+        return subwayRepository.findAllBySubwayIdInOrderByIds(subwayIds.toArray(new Integer[0]));
     }
 
     public Subway readClosestSubway(Point startPoint) {

--- a/src/main/java/com/meetup/server/subway/persistence/SubwayRepository.java
+++ b/src/main/java/com/meetup/server/subway/persistence/SubwayRepository.java
@@ -33,5 +33,6 @@ public interface SubwayRepository extends JpaRepository<Subway, Integer> {
             """)
     List<Subway> findAllWithinRadius(@Param("centerPoint") Point centerPoint, @Param("radius") double radius);
 
-    List<Subway> findAllBySubwayIdIn(List<Integer> subwayIds);
+    @Query(value = "SELECT s.* FROM subway s WHERE subway_id IN (:subwayIds) ORDER BY array_position(:subwayIds, subway_id)", nativeQuery = true)
+    List<Subway> findAllBySubwayIdInOrderByIds(@Param("subwayIds") Integer[] subwayIds);
 }


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- QA 진행 시, 지하철역명이 동일한 지하철역이 중간지점에 2개 이상 뜨는 문제가 발생했습니다.

## ✅ What - 무엇이 변경됐나요?

- 중간지점 지하철 후보군 계산 이후에 역명이 중복된 지하철역을 제거하도록 변경하였습니다.
- in절로 들어오는 매개변수 배열 요소 순서와 조회 결과의 순서가 다르기 때문에 이를 맞추기 위해 jpql을 native query로 변경하였습니다.

## 🛠️ How - 어떻게 해결했나요?

- topFairSubways는 표준편차 오름차순으로 정렬되어 있어 LinkedHashMap을 이용하여 정렬 기준을 유지하여 중복을 제거했습니다.

## 🖼️ Attachment

- 로컬 및 스테이징 서버에서 테스트 완료했습니다.
<img width="610" height="931" alt="스크린샷 2025-08-12 오후 9 04 43" src="https://github.com/user-attachments/assets/ba9e9ddb-1ebe-40ac-9a54-1babbabfd1b1" />

## 💬 기타 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 결과 목록에서 동일한 지하철역 이름이 중복으로 표시되던 문제를 해결하여 각 이름의 첫 번째 항목만 유지하고 원래 입력 순서를 보존합니다.
  * 추천 모임 지점 선택과 표시 로직을 중복 제거된 목록 기준으로 개선해 더 일관된 결과를 제공합니다.
  * 화면 전반과 목록에서 중복 제거된 데이터가 적용되어 사용자 혼란을 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->