### PR TITLE
[SPOT-165] 주기적으로 리뷰 작성 요청 메일 전송하기

### DIFF
--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -16,6 +16,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation "org.springframework.boot:spring-boot-starter-mail"
+    implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'

--- a/src/main/java/com/meetup/server/ServerApplication.java
+++ b/src/main/java/com/meetup/server/ServerApplication.java
@@ -3,9 +3,11 @@ package com.meetup.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableCaching
+@EnableScheduling
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/meetup/server/auth/presentation/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/meetup/server/auth/presentation/filter/JwtAuthenticationFilter.java
@@ -37,7 +37,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         String token = cookieUtil.getAccessTokenFromCookie(request);
-        log.info("Success Access Token With Cookie");
 
         if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
             authenticationUtil.setAuthenticationFromRequest(request, token);

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -80,7 +80,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     }
 
     private String buildDefaultCallbackUrl(String eventId, String to) {
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(successRedirectUri + "/oauth/kakao/callback");
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(successRedirectUri).pathSegment("oauth", "kakao", "callback");
         if (eventId != null && !eventId.isBlank()) {
             uriBuilder.queryParam("eventId", eventId);
         }

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -44,41 +44,63 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     }
 
     private String createRedirectUrlWithTokens(HttpServletRequest request) {
-        log.info("[Redirect URI] - {}", createRedirectUrl(request));
-        return UriComponentsBuilder.fromUriString(createRedirectUrl(request))
-                .build()
-                .toUriString();
+        StateParams stateParams = parseState(request.getParameter("state"));
+
+        String redirectUrl;
+        if ("visited".equals(stateParams.to) && stateParams.eventId != null && stateParams.placeId != null) {
+            redirectUrl = buildVisitedRedirectUrl(stateParams.eventId, stateParams.placeId);
+        } else if ("notvisited".equals(stateParams.to) && stateParams.eventId != null && stateParams.placeId != null) {
+            redirectUrl = buildNotVisitedRedirectUrl(stateParams.eventId, stateParams.placeId);
+        } else {
+            redirectUrl = buildDefaultCallbackUrl(stateParams.eventId, stateParams.to);
+        }
+
+        log.info("[Redirect URI] - {}", redirectUrl);
+        return redirectUrl;
     }
 
-    private String createRedirectUrl(HttpServletRequest request) {
-        String state = request.getParameter("state");
-        String to = null;
-        String eventId = null;
+    private StateParams parseState(String state) {
+        StateParams params = new StateParams();
 
-        if (state != null && !state.isBlank()) {
-            String decodedState = java.net.URLDecoder.decode(state, java.nio.charset.StandardCharsets.UTF_8);
+        if (state == null || state.isBlank()) return params;
 
-            for (String param : decodedState.split("&")) {
-                String[] keyValue = param.split("=", 2);
-                if (keyValue.length == 2) {
-                    if ("to".equals(keyValue[0])) {
-                        to = keyValue[1];
-                    } else if ("eventId".equals(keyValue[0])) {
-                        eventId = keyValue[1];
-                    }
+        String decodedState = java.net.URLDecoder.decode(state, java.nio.charset.StandardCharsets.UTF_8);
+
+        for (String param : decodedState.split("&")) {
+            String[] keyValue = param.split("=", 2);
+            if (keyValue.length == 2) {
+                switch (keyValue[0]) {
+                    case "to" -> params.to = keyValue[1];
+                    case "eventId" -> params.eventId = keyValue[1];
+                    case "placeId" -> params.placeId = keyValue[1];
                 }
             }
         }
+        return params;
+    }
 
-        String redirectBase = successRedirectUri + "/oauth/kakao/callback";
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(redirectBase);
-
-
+    private String buildDefaultCallbackUrl(String eventId, String to) {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(successRedirectUri + "/oauth/kakao/callback");
         if (eventId != null && !eventId.isBlank()) {
-            uriBuilder.queryParam("to", to);
             uriBuilder.queryParam("eventId", eventId);
         }
-
+        if (to != null && !to.isBlank()) {
+            uriBuilder.queryParam("to", to);
+        }
         return uriBuilder.build().toUriString();
+    }
+
+    private String buildVisitedRedirectUrl(String eventId, String placeId) {
+        return String.format("%s/visited/%s/%s", successRedirectUri, eventId, placeId);
+    }
+
+    private String buildNotVisitedRedirectUrl(String eventId, String placeId) {
+        return String.format("%s/notvisited/%s/%s", successRedirectUri, eventId, placeId);
+    }
+
+    private static class StateParams {
+        String to;
+        String eventId;
+        String placeId;
     }
 }

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -91,11 +91,17 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     }
 
     private String buildVisitedRedirectUrl(String eventId, String placeId) {
-        return String.format("%s/visited/%s/%s", successRedirectUri, eventId, placeId);
+        return UriComponentsBuilder.fromUriString(successRedirectUri)
+                .pathSegment("visited", eventId, placeId)
+                .build()
+                .toUriString();
     }
 
     private String buildNotVisitedRedirectUrl(String eventId, String placeId) {
-        return String.format("%s/notvisited/%s/%s", successRedirectUri, eventId, placeId);
+        return UriComponentsBuilder.fromUriString(successRedirectUri)
+                .pathSegment("notvisited", eventId, placeId)
+                .build()
+                .toUriString();
     }
 
     private static class StateParams {

--- a/src/main/java/com/meetup/server/auth/support/resolver/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/meetup/server/auth/support/resolver/CustomAuthorizationRequestResolver.java
@@ -36,12 +36,13 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
 
         String to = request.getParameter("to");
         String eventId = request.getParameter("eventId");
+        String placeId = request.getParameter("placeId");
 
-        if (to == null && eventId == null) {
+        if (to == null && eventId == null && placeId == null) {
             return req;
         }
 
-        String stateValue = "to=" + to + "&eventId=" + eventId;
+        String stateValue = "to=" + to + "&eventId=" + eventId + "&placeId=" + placeId;
         stateValue = URLEncoder.encode(stateValue, StandardCharsets.UTF_8);
 
         return OAuth2AuthorizationRequest.from(req)

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -22,7 +22,7 @@ public class EventReader {
                 .orElseThrow(() -> new EventException(EventErrorType.EVENT_NOT_FOUND));
     }
 
-    public List<Event> readEventsAtWithPlace(int hour) {
+    public List<Event> readEventsWithPlaceAtHour(int hour) {
         LocalDateTime targetTime = LocalDateTime.now()
                 .plusHours(hour)
                 .withSecond(0)

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -7,6 +7,8 @@ import com.meetup.server.event.infrastructure.jpa.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -18,5 +20,13 @@ public class EventReader {
     public Event read(UUID eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventException(EventErrorType.EVENT_NOT_FOUND));
+    }
+
+    public List<Event> readEventsAtWithPlace(int hour) {
+        LocalDateTime targetTime = LocalDateTime.now()
+                .plusHours(hour)
+                .withSecond(0)
+                .withNano(0);
+        return eventRepository.findAllByEventDateTimeWithPlace(targetTime);
     }
 }

--- a/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
+++ b/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public interface EventRepository extends JpaRepository<Event, UUID> {
@@ -19,4 +21,7 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
     @Query("UPDATE Event e SET e.routes = :routes WHERE e.eventId = :eventId")
     void saveRoutesByEventId(@Param("eventId") UUID eventId,
                              @Param("routes") MeetingPointRouteGroups routes);
+
+    @Query("SELECT e FROM Event e JOIN FETCH e.place WHERE e.eventDateTime = :eventDateTime")
+    List<Event> findAllByEventDateTimeWithPlace(@Param("eventDateTime") LocalDateTime eventDateTime);
 }

--- a/src/main/java/com/meetup/server/global/config/JpaConfig.java
+++ b/src/main/java/com/meetup/server/global/config/JpaConfig.java
@@ -2,10 +2,8 @@ package com.meetup.server.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableJpaAuditing
-@EnableJpaRepositories(basePackages = "com.meetup.server.*.infrastructure")
 @Configuration
 public class JpaConfig {
 }

--- a/src/main/java/com/meetup/server/global/email/EmailSender.java
+++ b/src/main/java/com/meetup/server/global/email/EmailSender.java
@@ -1,0 +1,27 @@
+package com.meetup.server.global.email;
+
+import com.meetup.server.global.email.dto.EmailSendRequest;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailSender {
+
+    private final JavaMailSender mailSender;
+
+    public void send(EmailSendRequest emailSendRequest) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setTo(emailSendRequest.emailAddress());
+        helper.setSubject(emailSendRequest.subject());
+        helper.setText(emailSendRequest.content(), true);
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/meetup/server/global/email/domain/EmailSendHistory.java
+++ b/src/main/java/com/meetup/server/global/email/domain/EmailSendHistory.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "email_send_history", uniqueConstraints = @UniqueConstraint(columnNames = {"event_id", "user_id"}))
+@Table(name = "email_send_history", uniqueConstraints = @UniqueConstraint(columnNames = {"event_id", "user_id", "email_type"}))
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Getter
 public class EmailSendHistory {

--- a/src/main/java/com/meetup/server/global/email/domain/EmailSendHistory.java
+++ b/src/main/java/com/meetup/server/global/email/domain/EmailSendHistory.java
@@ -1,0 +1,53 @@
+package com.meetup.server.global.email.domain;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_send_history", uniqueConstraints = @UniqueConstraint(columnNames = {"event_id", "user_id"}))
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
+public class EmailSendHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "email_type", nullable = false)
+    private EmailType emailType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "email_send_status", nullable = false)
+    private EmailSendStatus emailSendStatus;
+
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt;
+
+    @Column(name = "error_message")
+    private String errorMessage;
+
+    @Builder
+    public EmailSendHistory(Event event, User user, EmailType emailType, EmailSendStatus emailSendStatus, LocalDateTime sentAt, String errorMessage) {
+        this.event = event;
+        this.user = user;
+        this.emailType = emailType;
+        this.emailSendStatus = emailSendStatus;
+        this.sentAt = sentAt;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/meetup/server/global/email/domain/EmailSendStatus.java
+++ b/src/main/java/com/meetup/server/global/email/domain/EmailSendStatus.java
@@ -1,0 +1,6 @@
+package com.meetup.server.global.email.domain;
+
+public enum EmailSendStatus {
+    SUCCESS,
+    FAILURE,
+}

--- a/src/main/java/com/meetup/server/global/email/domain/EmailType.java
+++ b/src/main/java/com/meetup/server/global/email/domain/EmailType.java
@@ -1,0 +1,5 @@
+package com.meetup.server.global.email.domain;
+
+public enum EmailType {
+    REVIEW_REQUEST,
+}

--- a/src/main/java/com/meetup/server/global/email/dto/EmailSendRequest.java
+++ b/src/main/java/com/meetup/server/global/email/dto/EmailSendRequest.java
@@ -1,0 +1,11 @@
+package com.meetup.server.global.email.dto;
+
+public record EmailSendRequest(
+        String emailAddress,
+        String subject,
+        String content
+) {
+    public static EmailSendRequest of(String emailAddress, String subject, String content) {
+        return new EmailSendRequest(emailAddress, subject, content);
+    }
+}

--- a/src/main/java/com/meetup/server/global/email/infrastructure/jpa/EmailSendHistoryRepository.java
+++ b/src/main/java/com/meetup/server/global/email/infrastructure/jpa/EmailSendHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.meetup.server.global.email.infrastructure.jpa;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.global.email.domain.EmailSendHistory;
+import com.meetup.server.global.email.domain.EmailType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EmailSendHistoryRepository extends JpaRepository<EmailSendHistory, Long> {
+
+    List<EmailSendHistory> findAllByEventInAndEmailType(List<Event> events, EmailType emailType);
+}

--- a/src/main/java/com/meetup/server/review/application/ReviewRequestSchedule.java
+++ b/src/main/java/com/meetup/server/review/application/ReviewRequestSchedule.java
@@ -1,0 +1,142 @@
+package com.meetup.server.review.application;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.implement.EventReader;
+import com.meetup.server.global.email.EmailSender;
+import com.meetup.server.global.email.domain.EmailSendHistory;
+import com.meetup.server.global.email.domain.EmailSendStatus;
+import com.meetup.server.global.email.domain.EmailType;
+import com.meetup.server.global.email.dto.EmailSendRequest;
+import com.meetup.server.global.email.infrastructure.jpa.EmailSendHistoryRepository;
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.domain.value.OpeningHour;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.implement.StartPointReader;
+import com.meetup.server.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.meetup.server.global.util.TimeUtil.KST_ZONE_ID;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewRequestSchedule {
+
+    @Value("${server-url}")
+    private String serverUrl;
+
+    private static final String EVERY_30_MINUTES = "0 0,30 * * * *";
+    private static final int REVIEW_REQUEST_HOURS_AHEAD = 4;
+    private static final String TEMPLATE_REVIEW_REQUEST = "review_request_email";
+    private static final String SUBJECT_FORMAT = "[모이삼] 오늘 ‘%s’은 어떠셨나요?";
+
+    private final EmailSender emailSender;
+    private final EventReader eventReader;
+    private final StartPointReader startPointReader;
+    private final EmailSendHistoryRepository emailSendHistoryRepository;
+    private final TemplateEngine templateEngine;
+
+    @Scheduled(cron = EVERY_30_MINUTES, zone = "Asia/Seoul")
+    public void sendReviewRequestEmail() {
+        List<Event> events = eventReader.readEventsAtWithPlace(REVIEW_REQUEST_HOURS_AHEAD);
+        if (events.isEmpty()) return;
+
+        List<EmailSendHistory> eventSendHistories = emailSendHistoryRepository.findAllByEventInAndEmailType(events, EmailType.REVIEW_REQUEST);
+
+        Map<String, EmailSendHistory> emailHistoryByEventAndUser = eventSendHistories.stream()
+                .collect(Collectors.toMap(
+                        history -> history.getEvent().getEventId() + "_" + history.getUser().getUserId(),
+                        Function.identity()
+                ));
+
+        List<EmailSendHistory> historiesToSave = new ArrayList<>();
+
+        for (Event event : events) {
+            if (event.getPlace() == null) continue;
+
+            List<StartPoint> participants = startPointReader.readAllWithUserByEvent(event);
+
+            for (StartPoint participant : participants) {
+                User user = participant.getUser();
+                if (user == null) continue;
+
+                String key = event.getEventId() + "_" + user.getUserId();
+                if (emailHistoryByEventAndUser.containsKey(key)) continue;
+
+                Context context = buildContext(event, participant, participants);
+                String html = templateEngine.process(TEMPLATE_REVIEW_REQUEST, context);
+
+                EmailSendRequest request = new EmailSendRequest(
+                        user.getEmail(),
+                        String.format(SUBJECT_FORMAT, event.getEventName()),
+                        html
+                );
+
+                EmailSendHistory.EmailSendHistoryBuilder emailSendHistoryBuilder = EmailSendHistory.builder()
+                        .event(event)
+                        .user(user)
+                        .emailType(EmailType.REVIEW_REQUEST)
+                        .sentAt(LocalDateTime.now());
+
+                try {
+                    emailSender.send(request);
+                    emailSendHistoryBuilder.emailSendStatus(EmailSendStatus.SUCCESS);
+                } catch (Exception e) {
+                    emailSendHistoryBuilder.emailSendStatus(EmailSendStatus.FAILURE);
+                    emailSendHistoryBuilder.errorMessage(e.getMessage());
+                }
+
+                historiesToSave.add(emailSendHistoryBuilder.build());
+            }
+        }
+
+        emailSendHistoryRepository.saveAll(historiesToSave);
+    }
+
+    private Context buildContext(Event event, StartPoint participant, List<StartPoint> participants) {
+        Place place = event.getPlace();
+        User currentUser = participant.getUser();
+
+        List<String> otherParticipants = participants.stream()
+                .filter(startPoint -> !participant.getStartPointId().equals(startPoint.getStartPointId()))
+                .map(StartPoint::getNonUserName)
+                .toList();
+
+        Context context = new Context();
+        context.setVariable("eventName", event.getEventName());
+        context.setVariable("participantName", currentUser.getNickname());
+        context.setVariable("otherParticipantName", otherParticipants.getFirst());
+        context.setVariable("otherParticipantCount", otherParticipants.size());
+        context.setVariable("placeName", place.getName());
+        context.setVariable("placeRating", place.getGoogleRating());
+        context.setVariable("placeImage", Optional.ofNullable(place.getImages())
+                .filter(images -> !images.isEmpty())
+                .map(images -> images.getFirst().photoUri())
+                .orElse(null));
+        context.setVariable("serverUrl", serverUrl);
+        context.setVariable("eventId", event.getEventId());
+        context.setVariable("placeId", place.getId());
+
+        Optional<OpeningHour> todayOpeningHour = Optional.ofNullable(place.getOpeningHours())
+                .orElse(List.of())
+                .stream()
+                .filter(openingHour -> openingHour.isToday(LocalDateTime.now(KST_ZONE_ID)))
+                .findFirst();
+
+        context.setVariable("openTime", todayOpeningHour.map(OpeningHour::openTime).orElse(null));
+        context.setVariable("closeTime", todayOpeningHour.map(OpeningHour::closeTime).orElse(null));
+        return context;
+    }
+}

--- a/src/main/java/com/meetup/server/review/application/ReviewRequestSchedule.java
+++ b/src/main/java/com/meetup/server/review/application/ReviewRequestSchedule.java
@@ -2,6 +2,7 @@ package com.meetup.server.review.application;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.implement.EventReader;
+import com.meetup.server.event.util.UsernameExtractor;
 import com.meetup.server.global.email.EmailSender;
 import com.meetup.server.global.email.domain.EmailSendHistory;
 import com.meetup.server.global.email.domain.EmailSendStatus;
@@ -111,7 +112,7 @@ public class ReviewRequestSchedule {
 
         List<String> otherParticipants = participants.stream()
                 .filter(startPoint -> !participant.getStartPointId().equals(startPoint.getStartPointId()))
-                .map(StartPoint::getNonUserName)
+                .map(UsernameExtractor::extractDisplayName)
                 .toList();
 
         Context context = new Context();

--- a/src/main/java/com/meetup/server/review/application/ReviewRequestSchedule.java
+++ b/src/main/java/com/meetup/server/review/application/ReviewRequestSchedule.java
@@ -50,7 +50,7 @@ public class ReviewRequestSchedule {
 
     @Scheduled(cron = EVERY_30_MINUTES, zone = "Asia/Seoul")
     public void sendReviewRequestEmail() {
-        List<Event> events = eventReader.readEventsAtWithPlace(REVIEW_REQUEST_HOURS_AHEAD);
+        List<Event> events = eventReader.readEventsWithPlaceAtHour(REVIEW_REQUEST_HOURS_AHEAD);
         if (events.isEmpty()) return;
 
         List<EmailSendHistory> eventSendHistories = emailSendHistoryRepository.findAllByEventInAndEmailType(events, EmailType.REVIEW_REQUEST);

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
@@ -40,4 +40,8 @@ public class StartPointReader {
     public List<ParticipantCount> readParticipantCounts(List<UUID> eventIds) {
         return startPointRepository.findParticipantsCounts(eventIds);
     }
+
+    public List<StartPoint> readAllWithUserByEvent(Event event) {
+        return startPointRepository.findAllWithUserByEvent(event);
+    }
 }

--- a/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/StartPointRepository.java
+++ b/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/StartPointRepository.java
@@ -19,6 +19,9 @@ public interface StartPointRepository extends JpaRepository<StartPoint, UUID>, S
     @Query("SELECT DISTINCT sp FROM StartPoint sp JOIN FETCH sp.event WHERE sp.event = :event")
     List<StartPoint> findAllByEvent(@Param("event") Event event);
 
+    @Query("SELECT DISTINCT sp FROM StartPoint sp LEFT JOIN FETCH sp.user WHERE sp.event = :event")
+    List<StartPoint> findAllWithUserByEvent(@Param("event") Event event);
+
     @Modifying
     @Query("DELETE FROM StartPoint sp WHERE sp.event = :event")
     void deleteAllByEvent(@Param("event") Event event);

--- a/src/main/resources/templates/review_request_email.html
+++ b/src/main/resources/templates/review_request_email.html
@@ -1,0 +1,457 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <title th:text="'[모이삼] 오늘 ' + ${eventName} + '는 어떠셨나요?'"></title>
+    <!-- 모바일 확대/재배치 방지 -->
+    <meta name="viewport" content="width=device-width,initial-scale=1"/>
+    <meta name="x-apple-disable-message-reformatting"/>
+    <meta
+            name="format-detection"
+            content="telephone=no,address=no,email=no,date=no,url=no"
+    />
+    <!-- 외부 폰트는 일부 메일앱에서 폴백될 수 있음 -->
+    <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/pretendard/dist/web/static/pretendard.css"
+    />
+</head>
+<body style="margin: 0; padding: 0; background: #ffffff">
+<!-- 풀폭 래퍼 -->
+<table
+        role="presentation"
+        width="100%"
+        cellpadding="0"
+        cellspacing="0"
+        border="0"
+        style="
+        border-collapse: collapse;
+        mso-table-lspace: 0;
+        mso-table-rspace: 0;
+      "
+>
+    <tr>
+        <td align="center" valign="top" style="padding: 0">
+            <table
+                    role="presentation"
+                    cellpadding="0"
+                    cellspacing="0"
+                    border="0"
+                    style="
+              width: 100%;
+              max-width: 600px;
+              border-collapse: collapse;
+              font-family: Pretendard, -apple-system, BlinkMacSystemFont,
+                'Segoe UI', Roboto, 'Noto Sans KR', Arial, sans-serif;
+            "
+            >
+                <!-- 헤더 -->
+                <tr>
+                    <td style="padding: 0; background: #007aff">
+                        <table
+                                role="presentation"
+                                width="100%"
+                                cellpadding="0"
+                                cellspacing="0"
+                                border="0"
+                                style="border-collapse: collapse"
+                        >
+                            <tr>
+                                <td align="center" style="padding: 0 24px; height: 74px">
+                                    <table
+                                            role="presentation"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            border="0"
+                                    >
+                                        <tr>
+                                            <td align="center" style="padding-right: 268px">
+                                                <img
+                                                        src="https://moisam-server.s3.ap-northeast-2.amazonaws.com/moisam_white_logo.png"
+                                                        alt="모이삼"
+                                                        width="121"
+                                                        height="28"
+                                                        style="display: block; border: 0; outline: 0"
+                                                />
+                                            </td>
+                                            <td align="center">
+                                                <img
+                                                        src="https://moisam-server.s3.ap-northeast-2.amazonaws.com/moisam_graphic.png"
+                                                        alt=""
+                                                        width="171"
+                                                        height="74"
+                                                        style="display: block; border: 0; outline: 0"
+                                                />
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+
+                <!-- 본문: 타이틀 -->
+                <tr>
+                    <td style="padding: 32px 40px 0 40px">
+                        <h2
+                                style="
+                    margin: 0;
+                    font-size: 24px;
+                    line-height: 120%;
+                    font-weight: 700;
+                    letter-spacing: -0.48px;
+                    color: #1c1c22;
+                  "
+                        >
+                            오늘
+                            <span style="color: #007aff" th:text="${eventName}"></span>는
+                        </h2>
+                        <h2
+                                style="
+                    margin: 0;
+                    font-size: 24px;
+                    line-height: 120%;
+                    font-weight: 700;
+                    letter-spacing: -0.48px;
+                    color: #1c1c22;
+                  "
+                        >
+                            어떠셨나요?
+                        </h2>
+                    </td>
+                </tr>
+
+                <!-- 본문: 인사/설명 -->
+                <tr>
+                    <td style="padding: 24px 40px 0 40px">
+                        <p
+                                style="
+                    margin: 0;
+                    font-size: 16px;
+                    font-weight: 600;
+                    line-height: 150%;
+                    letter-spacing: -0.28px;
+                    color: #49495a;
+                  "
+                        >
+                            안녕하세요, <span th:text="${participantName}"></span>님
+                        </p>
+                        <p
+                                style="
+                    margin: 8px 0 0 0;
+                    font-size: 16px;
+                    font-weight: 400;
+                    line-height: 150%;
+                    letter-spacing: -0.28px;
+                    color: #787891;
+                  "
+                        >
+                            오늘 <span th:text="${otherParticipantName}"></span>님 외
+                            <span th:text="${otherParticipantCount}"></span>명과 함께한 시간은
+                            어떠셨나요? <br/>
+                            모이삼과 함께한 약속이 즐겁고 행복했기를 바랍니다.
+                        </p>
+                        <p
+                                style="
+                    margin: 8px 0 0 0;
+                    font-size: 16px;
+                    font-weight: 400;
+                    line-height: 150%;
+                    letter-spacing: -0.28px;
+                    color: #787891;
+                  "
+                        >
+                            오늘 방문한
+                            <span
+                                    style="color: #49495a; font-weight: 600"
+                                    th:text="${placeName}"
+                            ></span
+                            >의 후기를 남겨주시면 <br/>
+                            <span th:text="${participantName}"></span>님의 다음 약속 장소
+                            추천에 반영됩니다.
+                        </p>
+                    </td>
+                </tr>
+
+                <!-- 카드 -->
+                <tr>
+                    <td style="padding: 24px 40px 0 40px">
+                        <table
+                                role="presentation"
+                                cellpadding="0"
+                                cellspacing="0"
+                                border="0"
+                                style="
+                    width: 100%;
+                    max-width: 320px;
+                    border-collapse: separate;
+                    border-spacing: 0;
+                  "
+                        >
+                            <!-- 장소 이미지 -->
+                            <tr th:if="${placeImage != null}">
+                                <td
+                                        style="
+                        padding: 0;
+                        border-radius: 10px 10px 0 0;
+                        overflow: hidden;
+                        box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+                      "
+                                >
+                                    <img
+                                            th:src="${placeImage}"
+                                            alt=""
+                                            width="320"
+                                            style="
+                          width: 100%;
+                          height: auto;
+                          display: block;
+                          border: 0;
+                          outline: 0;
+                        "
+                                    />
+                                </td>
+                            </tr>
+                            <!-- 카드 바디 -->
+                            <tr>
+                                <td
+                                        style="
+                        padding: 14px;
+                        border-radius: 0 0 10px 10px;
+                        background: #ffffff;
+                        box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+                      "
+                                >
+                                    <div
+                                            style="
+                          margin: 0;
+                          color: #1c1c22;
+                          font-size: 16px;
+                          font-weight: 600;
+                          line-height: 150%;
+                        "
+                                            th:text="${placeName}"
+                                    ></div>
+
+                                    <!-- 평점 -->
+                                    <table
+                                            role="presentation"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            border="0"
+                                            style="margin-top: 4px"
+                                            th:if="${placeRating != null}"
+                                    >
+                                        <tr>
+                                            <td style="padding: 0 4px 0 0">
+                                                <img
+                                                        src="https://moisam-server.s3.ap-northeast-2.amazonaws.com/star_icon.png"
+                                                        alt="★"
+                                                        width="14"
+                                                        height="14"
+                                                        style="display: block"
+                                                />
+                                            </td>
+                                            <td style="padding: 0">
+                                                <div
+                                                        style="
+                                margin: 0;
+                                color: #32323e;
+                                font-size: 12px;
+                                font-weight: 600;
+                                line-height: 150%;
+                              "
+                                                >
+                                                    <span th:text="${placeRating}"></span>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+
+                                    <!-- 영업시간 -->
+                                    <table
+                                            role="presentation"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            border="0"
+                                            style="margin-top: 4px"
+                                            th:if="${openTime != null and closeTime != null}"
+                                    >
+                                        <tr>
+                                            <td style="padding: 0 4px 0 0">
+                                                <img
+                                                        src="https://moisam-server.s3.ap-northeast-2.amazonaws.com/clock_icon.png"
+                                                        alt=""
+                                                        width="14"
+                                                        height="14"
+                                                        style="display: block"
+                                                />
+                                            </td>
+                                            <td
+                                                    style="
+                              padding: 0 6px 0 0;
+                              white-space: nowrap;
+                              color: #787891;
+                              font-size: 12px;
+                              font-weight: 500;
+                              line-height: 150%;
+                            "
+                                            >
+                                                영업시간
+                                            </td>
+                                            <td
+                                                    style="
+                              padding: 0;
+                              white-space: nowrap;
+                              color: #32323e;
+                              font-size: 12px;
+                              font-weight: 500;
+                              line-height: 150%;
+                            "
+                                            >
+                                                <span th:text="${openTime} + ' ~ ' + ${closeTime}"></span>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+
+                <!-- 버튼 두 개 -->
+                <!-- 버튼 두 개 -->
+                <tr>
+                    <td style="padding: 24px 40px 64px 40px">
+                        <table
+                                role="presentation"
+                                cellpadding="0"
+                                cellspacing="0"
+                                border="0"
+                                width="320"
+                        >
+                            <tr>
+                                <!-- 다른 곳에 갔어요 -->
+                                <td align="center" width="126" style="padding-right: 8px">
+                                    <table
+                                            role="presentation"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            border="0"
+                                            width="100%"
+                                    >
+                                        <tr>
+                                            <td
+                                                    align="center"
+                                                    bgcolor="#E9E9ED"
+                                                    style="border-radius: 10px"
+                                            >
+                                                <a
+                                                        th:href="${serverUrl + '/oauth2/authorization/kakao?to=notvisited' + '&eventId=' + eventId + '&placeId=' + placeId}"
+                                                        style="
+                                display: block;
+                                text-align: center;
+                                text-decoration: none;
+                                color: #606076;
+                                font-size: 16px;
+                                font-weight: 500;
+                                letter-spacing: -0.32px;
+                                line-height: 120%;
+                                padding: 12px 0;
+                                border-radius: 10px;
+                              "
+                                                >
+                                                    다른 곳에 갔어요
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+
+                                <!-- 리뷰 남기기 -->
+                                <td align="center" width="126" style="padding-right: 0">
+                                    <!-- 마지막은 0으로 -->
+                                    <table
+                                            role="presentation"
+                                            cellpadding="0"
+                                            cellspacing="0"
+                                            border="0"
+                                            width="100%"
+                                    >
+                                        <tr>
+                                            <td
+                                                    align="center"
+                                                    bgcolor="#1C1C22"
+                                                    style="border-radius: 10px"
+                                            >
+                                                <a
+                                                        th:href="${serverUrl + '/oauth2/authorization/kakao?to=visited' + '&eventId=' + eventId + '&placeId=' + placeId}"
+                                                        style="
+                                display: block;
+                                text-align: center;
+                                text-decoration: none;
+                                color: #ffffff;
+                                font-size: 16px;
+                                font-weight: 500;
+                                letter-spacing: -0.32px;
+                                line-height: 120%;
+                                padding: 12px 0;
+                                border-radius: 10px;
+                              "
+                                                >
+                                                    리뷰 남기기
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+
+                <!-- 푸터 -->
+                <tr>
+                    <td style="padding: 32px 40px; border-top: 1px solid #e9e9ed">
+                        <img
+                                src="https://moisam-server.s3.ap-northeast-2.amazonaws.com/moisam_dark_logo.png"
+                                alt="모이삼"
+                                width="78"
+                                height="18"
+                                style="display: block"
+                        />
+                        <div
+                                style="
+                    margin: 10px 0 0 0;
+                    font-size: 14px;
+                    font-weight: 500;
+                    line-height: 150%;
+                    letter-spacing: -0.28px;
+                    color: #9494a8;
+                  "
+                        >
+                            클릭 한 번으로 찾는 약속의 중간장소
+                        </div>
+                        <div style="margin-top: 6px">
+                            <a
+                                    href="https://forms.gle/Z5FB9f7JwXgKdc6G7"
+                                    style="
+                      font-size: 14px;
+                      font-weight: 500;
+                      line-height: 150%;
+                      letter-spacing: -0.28px;
+                      color: #606076;
+                    "
+                            >
+                                문의하기
+                            </a>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 리뷰 작성 요청 메일을 30분 주기로 전송해야하는 기능입니다.

## ✅ What - 무엇이 변경됐나요?

- 메일 전송 기능을 구현했습니다. (config 파일에 메일 관련 값 추가되었습니다.)
- 메일 전송 이력을 관리하기 위해 EmailSendHistory 테이블을 추가했습니다.
- 메일 전송 템플릿이 추가되었습니다.
- 리뷰 작성은 가입한 유저에 한해 가능하므로, 리뷰 작성 페이지 접근 시 로그인 페이지로 이동하며 이때 placeId와 eventId, to를 가진 state를 통해 서버에서 리뷰 작성 페이지로 리다이렉트 하였습니다.

## 🛠️ How - 어떻게 해결했나요?

1. 30분 주기로, 4시간 뒤의 이벤트 날짜가 있는 이벤트를 조회합니다.
2. 이벤트에 속한 출발지를 조회한 후, 출발지를 순회하며 user일 경우 메일을 전송합니다.
3. 이벤트 + 유저 ID를 키값으로 하여 만약 메일 전송이 된 경우, 추가로 메일을 보내지 않습니다. (동일한 이벤트 한정)

## 🖼️ Attachment
<img width="464" height="809" alt="스크린샷 2025-08-21 오후 6 54 31" src="https://github.com/user-attachments/assets/4d1d4037-8d56-4534-862b-48f6649ed0f1" />

## 💬 기타 코멘트

- 스테이징 서버에서 스케줄러 동작 확인 해봐야할 것 같습니다! 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 카카오 OAuth 로그인 성공 시 상태값(to/eventId/placeId)에 따라 방문/미방문 페이지로 정확히 리다이렉트.
  - 리뷰 요청 메일 자동 발송(30분 단위): 이벤트 4시간 전 참가자에게 개인화된 HTML 이메일(장소 이미지·평점·영업시간 포함)과 액션 버튼 제공.
  - 애플리케이션에서 스케줄러 활성화로 자동 발송 기능 운영.

- Chores
  - 이메일 전송 및 템플릿 렌더링을 위한 의존성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->