### PR TITLE
[MOISAM-98] 외부 API 호출수에 근접한 경우, 디스코드에 알림 보내기

### DIFF
--- a/src/main/java/com/meetup/server/global/clients/exception/ClientErrorType.java
+++ b/src/main/java/com/meetup/server/global/clients/exception/ClientErrorType.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ClientErrorType implements ErrorType {
-    EXCEED_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "일일 제한 호출수를 초과하였습니다.")
+    EXCEED_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "일일 제한 호출수를 초과하였습니다."),
+    WARNING_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "일일 호출 한도에 임박했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/global/clients/util/RedisRateLimiter.java
+++ b/src/main/java/com/meetup/server/global/clients/util/RedisRateLimiter.java
@@ -2,6 +2,7 @@ package com.meetup.server.global.clients.util;
 
 import com.meetup.server.global.clients.exception.ClientErrorType;
 import com.meetup.server.global.clients.exception.ClientException;
+import com.meetup.server.global.support.error.discord.DiscordAlarmSender;
 import com.meetup.server.global.util.TimeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,9 @@ public class RedisRateLimiter implements RateLimiter {
 
     private final RedisTemplate<String, String> redisRateLimitTemplate;
     private final RedisScript<Long> redisRateLimitScript;
+    private final DiscordAlarmSender discordAlarmSender;
+
+    private static final String DISCORD_ALERT_SENT_KEY_PREFIX = "rate_limit_alert:";
 
     @Override
     public void tryApiCall(LimitRequestPerDay limitRequestPerDay) {
@@ -34,11 +38,16 @@ public class RedisRateLimiter implements RateLimiter {
         );
 
         if (result == -1) {
-            throw new ClientException(ClientErrorType.EXCEED_RATE_LIMIT_PER_DAY);
+            discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.EXCEED_RATE_LIMIT_PER_DAY));
+            return;
         }
 
         if (result >= limitCount - 50) {
-            log.warn("[RedisRateLimiter] Rate limit near threshold ({} / {}) for key: {}", result, limitCount, key);
+            String alertSentKey = DISCORD_ALERT_SENT_KEY_PREFIX + key;
+            Boolean isAlertSent = redisRateLimitTemplate.opsForValue().setIfAbsent(alertSentKey, "1", getTTL());
+            if (Boolean.TRUE.equals(isAlertSent)) {
+                discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.WARNING_RATE_LIMIT_PER_DAY));
+            }
         }
     }
 

--- a/src/main/java/com/meetup/server/global/presentation/ApiControllerAdvice.java
+++ b/src/main/java/com/meetup/server/global/presentation/ApiControllerAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -25,24 +26,26 @@ public class ApiControllerAdvice{
         return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.INTERNAL_ERROR), GlobalErrorType.INTERNAL_ERROR.getStatus());
     }
 
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleNoResourceFoundException(NoResourceFoundException e) {
+        return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.NOT_FOUND_RESOURCE), GlobalErrorType.NOT_FOUND_RESOURCE.getStatus());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException : {}", e.getMessage(), e);
-        discordAlarmSender.sendErrorAlert(e);
         return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.FAILED_REQUEST_VALIDATION), GlobalErrorType.FAILED_REQUEST_VALIDATION.getStatus());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
         log.error("IllegalArgumentException : {}", e.getMessage(), e);
-        discordAlarmSender.sendErrorAlert(e);
         return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.INVALID_REQUEST_ARGUMENT), GlobalErrorType.INVALID_REQUEST_ARGUMENT.getStatus());
     }
 
     @ExceptionHandler(GlobalException.class)
     public ResponseEntity<ApiResponse<?>> handleGlobalException(GlobalException e) {
         log.error("GlobalException : {}", e.getMessage(), e);
-        discordAlarmSender.sendErrorAlert(e);
         return new ResponseEntity<>(ApiResponse.error(e.getErrorType()), e.getErrorType().getStatus());
     }
 

--- a/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
+++ b/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum GlobalErrorType implements ErrorType {
 
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
+    NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, "존재하지 않는 자원입니다."),
     FAILED_REQUEST_VALIDATION(HttpStatus.BAD_REQUEST, "요청 데이터 검증에 실패하였습니다."),
     INVALID_REQUEST_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 요청 인자입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다."),

--- a/src/test/java/com/meetup/server/global/clients/util/RateLimiterTest.java
+++ b/src/test/java/com/meetup/server/global/clients/util/RateLimiterTest.java
@@ -1,6 +1,5 @@
 package com.meetup.server.global.clients.util;
 
-import com.meetup.server.global.clients.exception.ClientException;
 import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,7 +11,6 @@ import java.lang.annotation.Annotation;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 
 class RateLimiterTest extends IntegrationTestContainer {
 
@@ -47,26 +45,16 @@ class RateLimiterTest extends IntegrationTestContainer {
             }
         };
 
-        AtomicInteger successCount = new AtomicInteger();
-        AtomicInteger failCount = new AtomicInteger();
-
         for (int i = 0; i < 10; i++) {
-            try {
-                rateLimiter.tryApiCall(annotation);
-                successCount.incrementAndGet();
-            } catch (ClientException e) {
-                failCount.incrementAndGet();
-            }
+            rateLimiter.tryApiCall(annotation);
         }
 
-        Assertions.assertEquals(5, successCount.get());
-        Assertions.assertEquals(5, failCount.get());
-
+        Long count = Long.valueOf(redisRateLimitTemplate.opsForValue().get("test"));
+        Assertions.assertEquals(5L, count);
     }
 
     @Test
-    void 동시_요청_상황에서도_요청제한을_원자적으로_보장한다() throws InterruptedException {
-        // given
+    void 동시_요청_상황에서도_요청제한을_보장한다() throws InterruptedException {
         LimitRequestPerDay annotation = new LimitRequestPerDay() {
             @Override
             public String key() {
@@ -88,17 +76,9 @@ class RateLimiterTest extends IntegrationTestContainer {
         ExecutorService executorService = Executors.newFixedThreadPool(totalThreads);
         CountDownLatch latch = new CountDownLatch(totalThreads);
 
-        AtomicInteger successCount = new AtomicInteger();
-        AtomicInteger failCount = new AtomicInteger();
-
         for (int i = 0; i < totalThreads; i++) {
             executorService.submit(() -> {
-                try {
-                    rateLimiter.tryApiCall(annotation);
-                    successCount.incrementAndGet();
-                } catch (ClientException e) {
-                    failCount.incrementAndGet();
-                }
+                rateLimiter.tryApiCall(annotation);
                 latch.countDown();
             });
         }
@@ -106,7 +86,8 @@ class RateLimiterTest extends IntegrationTestContainer {
         latch.await();
         executorService.shutdown();
 
-        Assertions.assertEquals(10, successCount.get());
+        Long count = Long.valueOf(redisRateLimitTemplate.opsForValue().get("test"));
+        Assertions.assertEquals(10L, count);
     }
 
 }


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 외부 API 호출 수가 임박하거나 초과할 경우, 기존에는 로깅만 하여 즉각 대응하기 어려운 문제가 있었습니다.
-> 디스코드 알림 기능을 사용해 호출수에 근접할 경우 알림을 전송합니다.

- 외부에서 특정 주소 ("/robot.txt", "/") 등으로 접속할 경우, 디스코드에 알림이 전송되는 문제가 있었습니다.
-> NoResourceFoundException일 경우, 예외 처리만 진행하였고 우리가 제어할 수 없는 예외인 Exception만 디스코드 알림 전송을 하도록 변경하여 중요한 에러만 확인할 수 있도록 변경하였습니다.

## ✅ What - 무엇이 변경됐나요?

- 기존에는 호출수가 초과되면 예외 처리를 하였으나, 단순 호출수 계산 기능이기 때문에 디스코드 알림 전송만 하고 예외 처리는 하지 않았습니다.
- 호출수에 임박할 경우, `rate_limit_alert:` 접두사를 사용한 Key를 만들어 하루 한 번만 임박 알림을 전송하도록 구현하였습니다.
- Exception 예외만 디스코드 알림 전송하여 무분별한 예외 전송을 막았습니다.

## 🛠️ How - 어떻게 해결했나요?

ExceptionHandler에서 Exception 예외만 디스코드 알림 전송하도록 변경하였고 호출수 임박, 초과 분기에 따라 디스코드 알림에 필요한 예외를 생성하여 사용하였습니다.

## 🖼️ Attachment

<img width="414" height="295" alt="스크린샷 2025-09-10 오후 5 36 09" src="https://github.com/user-attachments/assets/3f74530f-009f-4f9c-8611-d4ba16b85903" />

<img width="298" height="265" alt="스크린샷 2025-09-10 오후 5 36 18" src="https://github.com/user-attachments/assets/3651ab41-e8a2-4219-a5b8-38036fd26f1d" />

## 💬 기타 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 존재하지 않는 자원 요청 시 404 응답 유형 추가.
  - 일일 호출 한도 임박 시 경고 상태를 도입해 사전 안내 강화.
- 리팩터링
  - 레이트 리미트 초과/임박 시 알림 처리 로직 정비로 중복 알림 감소 및 안정성 향상.
- 테스트
  - 레이트 리미터 동작 검증 방식을 개선하고 테스트 명명을 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->