### PR TITLE
[MOISAM-201] 모임의 확정 장소를 취소한다

### DIFF
--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -3,6 +3,7 @@ package com.meetup.server.event.application;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.request.UpdateEventRequest;
+import com.meetup.server.event.dto.request.UpdatePlaceRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.dto.response.route.MeetingPointResult;
 import com.meetup.server.event.dto.response.route.MeetingPointRouteGroup;
@@ -12,9 +13,13 @@ import com.meetup.server.event.implement.EventReader;
 import com.meetup.server.event.implement.route.MeetingPointCalculator;
 import com.meetup.server.event.implement.route.RouteProcessor;
 import com.meetup.server.event.implement.route.RouteReader;
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.implement.PlaceReader;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.implement.StartPointProcessor;
 import com.meetup.server.startpoint.implement.StartPointReader;
+import com.meetup.server.subway.domain.Subway;
+import com.meetup.server.subway.implement.reader.SubwayReader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,6 +41,8 @@ public class EventService {
     private final RouteReader routeReader;
     private final RouteProcessor routeProcessor;
     private final StartPointReader startPointReader;
+    private final PlaceReader placeReader;
+    private final SubwayReader subwayReader;
 
     public EventStartPointResponse createEvent(Long userId, UUID guestId, EventRequest eventRequest) {
         Event event = eventProcessor.save(eventRequest);
@@ -82,8 +89,16 @@ public class EventService {
         eventProcessor.delete(event);
     }
 
-    public void cancelPlace(UUID eventId) {
+    public void updatePlace(UUID eventId, UpdatePlaceRequest updatePlaceRequest) {
         Event event = eventReader.read(eventId);
-        event.removePlace();
+        Place place = placeReader.read(updatePlaceRequest.placeId());
+        Subway subway = subwayReader.read(updatePlaceRequest.subwayId());
+
+        event.updateMeetingPlace(place, subway);
+    }
+
+    public void deletePlace(UUID eventId) {
+        Event event = eventReader.read(eventId);
+        event.deletePlace();
     }
 }

--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -81,4 +81,9 @@ public class EventService {
         routeProcessor.deleteCache(eventId);
         eventProcessor.delete(event);
     }
+
+    public void cancelPlace(UUID eventId) {
+        Event event = eventReader.read(eventId);
+        event.removePlace();
+    }
 }

--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -70,4 +70,8 @@ public class Event extends BaseEntity {
         this.place = place;
         this.subway = subway;
     }
+
+    public void removePlace() {
+        this.place = null;
+    }
 }

--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -71,7 +71,7 @@ public class Event extends BaseEntity {
         this.subway = subway;
     }
 
-    public void removePlace() {
+    public void deletePlace() {
         this.place = null;
     }
 }

--- a/src/main/java/com/meetup/server/event/dto/request/UpdatePlaceRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/UpdatePlaceRequest.java
@@ -1,0 +1,17 @@
+package com.meetup.server.event.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record UpdatePlaceRequest(
+
+        @NotNull
+        @Schema(description = "확정 장소 ID", example = "0196f346-5244-79b9-85b0-955d6328f09b")
+        UUID placeId,
+
+        @Schema(description = "지하철역 ID", example = "1")
+        int subwayId
+) {
+}

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -54,4 +54,11 @@ public class EventController {
             @RequestParam(required = false) UUID guestId) {
         return ApiResponse.success(eventService.getMeetingPointRoutes(eventId, userId, guestId));
     }
+
+    @Operation(summary = "확정된 모임 장소 취소 API", description = "모임 ID를 통해 확정된 모임 장소를 취소합니다.")
+    @DeleteMapping("/{eventId}/place")
+    public ApiResponse<?> cancelPlace(@PathVariable UUID eventId) {
+        eventService.cancelPlace(eventId);
+        return ApiResponse.success();
+    }
 }

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -57,7 +57,7 @@ public class EventController {
     }
 
     @Operation(summary = "모임 장소 확정/변경 API", description = "모임 ID와 장소 ID를 통해 모임 장소를 확정/변경합니다.")
-    @PutMapping("/{eventId}/place")
+    @PatchMapping("/{eventId}/place")
     public ApiResponse<?> updatePlace(
             @PathVariable UUID eventId,
             @Valid @RequestBody UpdatePlaceRequest updatePlaceRequest

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -3,6 +3,7 @@ package com.meetup.server.event.presentation;
 import com.meetup.server.event.application.EventService;
 import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.request.UpdateEventRequest;
+import com.meetup.server.event.dto.request.UpdatePlaceRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.dto.response.route.MeetingPointRoutesResponse;
 import com.meetup.server.global.support.response.ApiResponse;
@@ -55,10 +56,20 @@ public class EventController {
         return ApiResponse.success(eventService.getMeetingPointRoutes(eventId, userId, guestId));
     }
 
+    @Operation(summary = "모임 장소 확정/변경 API", description = "모임 ID와 장소 ID를 통해 모임 장소를 확정/변경합니다.")
+    @PutMapping("/{eventId}/place")
+    public ApiResponse<?> updatePlace(
+            @PathVariable UUID eventId,
+            @Valid @RequestBody UpdatePlaceRequest updatePlaceRequest
+    ) {
+        eventService.updatePlace(eventId, updatePlaceRequest);
+        return ApiResponse.success();
+    }
+
     @Operation(summary = "확정된 모임 장소 취소 API", description = "모임 ID를 통해 확정된 모임 장소를 취소합니다.")
     @DeleteMapping("/{eventId}/place")
-    public ApiResponse<?> cancelPlace(@PathVariable UUID eventId) {
-        eventService.cancelPlace(eventId);
+    public ApiResponse<?> deletePlace(@PathVariable UUID eventId) {
+        eventService.deletePlace(eventId);
         return ApiResponse.success();
     }
 }

--- a/src/main/java/com/meetup/server/place/application/PlaceService.java
+++ b/src/main/java/com/meetup/server/place/application/PlaceService.java
@@ -37,15 +37,6 @@ public class PlaceService {
     private final PlaceSorter placeSorter;
     private final SubwayReader subwayReader;
 
-    @Transactional
-    public void confirmPlace(UUID eventId, UUID placeId, int subwayId) {
-        Event event = eventReader.read(eventId);
-        Place place = placeReader.read(placeId);
-        Subway subway = subwayReader.read(subwayId);
-
-        event.updateMeetingPlace(place, subway);
-    }
-
     public PlaceResponseList getAllPlaces(UUID eventId, int subwayId) {
         Event event = eventReader.read(eventId);
         Subway subway = subwayReader.read(subwayId);

--- a/src/main/java/com/meetup/server/place/presentation/PlaceController.java
+++ b/src/main/java/com/meetup/server/place/presentation/PlaceController.java
@@ -21,17 +21,6 @@ public class PlaceController {
 
     private final PlaceService placeService;
 
-    @Operation(summary = "모임 장소 확정 및 변경 API", description = "모임 ID와 장소 ID를 통해 모임 장소를 확정/변경합니다.")
-    @PostMapping("/{placeId}")
-    public ApiResponse<?> confirmPlace(
-            @PathVariable UUID placeId,
-            @RequestParam UUID eventId,
-            @RequestParam int subwayId
-    ) {
-        placeService.confirmPlace(eventId, placeId, subwayId);
-        return ApiResponse.success();
-    }
-
     @Operation(summary = "장소 추천 리스트 조회 API", description = "역 주변의 장소 추천 리스트를 조회합니다")
     @GetMapping
     public ApiResponse<PlaceResponseList> getAllPlaces(


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 모임의 확정 장소를 취소하는 API 구현하였습니다.
- 모임 확정/변경 API 요청 방식을 변경하였습니다.

## ✅ What - 무엇이 변경됐나요?

- 모임 ID를 통해 모임의 place를 null로 설정하여 연관관계를 끊어주었습니다.

- 모임 확정/변경 API에서 쿼리스트링 대신 RequestBody를 통해 요청 값을 받도록 변경하였고, URI도 변경하였습니다.

## 🛠️ How - 어떻게 해결했나요?

- What 내용 참고바랍니다.

## 🖼️ Attachment

<img width="595" height="446" alt="스크린샷 2025-09-12 오후 2 19 32" src="https://github.com/user-attachments/assets/b4b91c81-95d7-4471-a06b-1e7391689ae6" />

<img width="621" height="386" alt="스크린샷 2025-09-11 오후 8 19 06" src="https://github.com/user-attachments/assets/4854647d-55ff-42f3-9144-81718e6c8391" />

## 💬 기타 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 이벤트 모임 장소를 설정/변경하는 API 추가: PATCH /events/{eventId}/place (요청 본문: placeId, subwayId).
  - 이벤트 모임 장소를 취소하는 API 추가: DELETE /events/{eventId}/place (성공 응답 반환).

- **Chores**
  - 기존 장소 확인/확정용 API 및 관련 서비스 메서드 제거(더 이상 제공되지 않음).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->