### PR TITLE
[MOISAM-228] Timeout, Retry, CircuitBreaker를 사용하여 외부 API 장애에 대처하기

### DIFF
--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation "org.springframework.boot:spring-boot-starter-mail"

--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -17,6 +17,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation "org.springframework.boot:spring-boot-starter-mail"
     implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'

--- a/src/main/java/com/meetup/server/ServerApplication.java
+++ b/src/main/java/com/meetup/server/ServerApplication.java
@@ -1,11 +1,12 @@
 package com.meetup.server;
 
+import io.github.resilience4j.springboot3.ratelimiter.autoconfigure.RateLimiterAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = { RateLimiterAutoConfiguration.class })
 @EnableCaching
 @EnableScheduling
 public class ServerApplication {

--- a/src/main/java/com/meetup/server/event/implement/route/RouteApiCaller.java
+++ b/src/main/java/com/meetup/server/event/implement/route/RouteApiCaller.java
@@ -38,7 +38,6 @@ public class RouteApiCaller {
                         .origin(startX + "," + startY)
                         .destination(endX + "," + endY)
                         .build()
-
         );
 
         if (response.routes() != null) {

--- a/src/main/java/com/meetup/server/global/clients/clova/ClovaClient.java
+++ b/src/main/java/com/meetup/server/global/clients/clova/ClovaClient.java
@@ -3,23 +3,22 @@ package com.meetup.server.global.clients.clova;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 @Component
 @RequiredArgsConstructor
 public class ClovaClient {
 
     private final ClovaProperties clovaProperties;
-    private final WebClient clovaWebClient;
+    private final RestClient clovaRestClient;
 
     public ClovaResponse sendRequest(ClovaRequest request) {
-        return clovaWebClient
+        return clovaRestClient
                 .post()
                 .uri(clovaProperties.basePath())
                 .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(request)
+                .body(request)
                 .retrieve()
-                .bodyToMono(ClovaResponse.class)
-            .block();
+                .body(ClovaResponse.class);
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/exception/ClientErrorType.java
+++ b/src/main/java/com/meetup/server/global/clients/exception/ClientErrorType.java
@@ -8,8 +8,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ClientErrorType implements ErrorType {
-    EXCEED_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "일일 제한 호출수를 초과하였습니다."),
-    WARNING_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "일일 호출 한도에 임박했습니다."),
+    ODSAY_EXCEED_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "Odsay API 일일 제한 호출수를 초과하였습니다."),
+    KAKAO_MOBILITY_EXCEED_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "카카오 모빌리티 API 일일 제한 호출수를 초과하였습니다."),
+
+    ODSAY_WARNING_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "Odsay API 일일 호출 한도에 임박했습니다."),
+    KAKAO_MOBILITY_WARNING_RATE_LIMIT_PER_DAY(HttpStatus.TOO_MANY_REQUESTS, "카카오 모빌리티 API 일일 호출 한도에 임박했습니다."),
+
+    ODSAY_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "Odsay API 서버가 일시적으로 사용 불가능합니다."),
+    KAKAO_MOBILITY_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "카카오 모빌리티 API 서버가 일시적으로 사용 불가능합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/global/clients/google/place/photo/GooglePhotoClient.java
+++ b/src/main/java/com/meetup/server/global/clients/google/place/photo/GooglePhotoClient.java
@@ -3,7 +3,7 @@ package com.meetup.server.global.clients.google.place.photo;
 import com.meetup.server.global.clients.google.place.GooglePlaceProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 import java.util.Optional;
 
@@ -11,11 +11,11 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class GooglePhotoClient {
 
-    private final WebClient googlePlaceWebClient;
+    private final RestClient googlePlaceRestClient;
     private final GooglePlaceProperties googlePlaceProperties;
 
     public GooglePhotoResponse sendRequest(GooglePhotoRequest request) {
-        return googlePlaceWebClient.get()
+        return googlePlaceRestClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/" + request.name() + "/media")
                         .queryParam("key", googlePlaceProperties.secretKey())
@@ -24,7 +24,6 @@ public class GooglePhotoClient {
                         .build()
                 )
                 .retrieve()
-                .bodyToMono(GooglePhotoResponse.class)
-                .block();
+                .body(GooglePhotoResponse.class);
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/google/place/search/GoogleSearchTextClient.java
+++ b/src/main/java/com/meetup/server/global/clients/google/place/search/GoogleSearchTextClient.java
@@ -3,21 +3,20 @@ package com.meetup.server.global.clients.google.place.search;
 import com.meetup.server.global.clients.google.place.GoogleFieldMask;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 @Component
 @RequiredArgsConstructor
 public class GoogleSearchTextClient {
 
-    private final WebClient googlePlaceWebClient;
+    private final RestClient googlePlaceRestClient;
 
     public GoogleSearchTextResponse sendRequest(GoogleSearchTextRequest request, GoogleFieldMask googleFieldMask) {
-        return googlePlaceWebClient.post()
+        return googlePlaceRestClient.post()
                 .uri("/places:searchText")
                 .header("X-Goog-FieldMask", googleFieldMask.getMask())
-                .bodyValue(request)
+                .body(request)
                 .retrieve()
-                .bodyToMono(GoogleSearchTextResponse.class)
-                .block();
+                .body(GoogleSearchTextResponse.class);
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/kakao/local/KakaoLocalCategoryClient.java
+++ b/src/main/java/com/meetup/server/global/clients/kakao/local/KakaoLocalCategoryClient.java
@@ -2,7 +2,7 @@ package com.meetup.server.global.clients.kakao.local;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 import java.util.Optional;
 
@@ -10,10 +10,10 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class KakaoLocalCategoryClient {
 
-    private final WebClient kakaoLocalWebClient;
+    private final RestClient kakaoLocalRestClient;
 
     public KakaoLocalResponse sendRequest(KakaoLocalRequest request) {
-        return kakaoLocalWebClient
+        return kakaoLocalRestClient
                 .get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/category.json")
@@ -27,7 +27,6 @@ public class KakaoLocalCategoryClient {
                         .queryParamIfPresent("sort", Optional.ofNullable(request.sort()))
                         .build())
                 .retrieve()
-                .bodyToMono(KakaoLocalResponse.class)
-                .block();
+                .body(KakaoLocalResponse.class);
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/kakao/local/KakaoLocalKeywordClient.java
+++ b/src/main/java/com/meetup/server/global/clients/kakao/local/KakaoLocalKeywordClient.java
@@ -2,7 +2,7 @@ package com.meetup.server.global.clients.kakao.local;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 import java.util.Optional;
 
@@ -10,10 +10,10 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class KakaoLocalKeywordClient {
 
-    private final WebClient kakaoLocalWebClient;
+    private final RestClient kakaoLocalRestClient;
 
     public KakaoLocalResponse sendRequest(KakaoLocalRequest request) {
-        return kakaoLocalWebClient
+        return kakaoLocalRestClient
                 .get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/keyword.json")
@@ -28,7 +28,6 @@ public class KakaoLocalKeywordClient {
                         .queryParamIfPresent("sort", Optional.ofNullable(request.sort()))
                         .build())
                 .retrieve()
-                .bodyToMono(KakaoLocalResponse.class)
-                .block();
+                .body(KakaoLocalResponse.class);
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
+++ b/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
@@ -3,7 +3,7 @@ package com.meetup.server.global.clients.kakao.mobility;
 import com.meetup.server.global.clients.util.LimitRequestPerDay;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 import java.util.Optional;
 
@@ -11,14 +11,14 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class KakaoMobilityClient {
 
-    private final WebClient kakaoMobilityWebClient;
+    private final RestClient kakaoMobilityRestClient;
 
     @LimitRequestPerDay(
             key = "kakao-mobility",
             count = 10000
     )
     public KakaoMobilityResponse sendRequest(KakaoMobilityRequest request) {
-        return kakaoMobilityWebClient
+        return kakaoMobilityRestClient
                 .get()
                 .uri(uriBuilder -> uriBuilder
                         .queryParam("origin", request.origin())
@@ -35,7 +35,6 @@ public class KakaoMobilityClient {
                         .queryParamIfPresent("summary", Optional.ofNullable(request.summary()))
                         .build())
                 .retrieve()
-                .bodyToMono(KakaoMobilityResponse.class)
-                .block();
+                .body(KakaoMobilityResponse.class);
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
+++ b/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
@@ -48,8 +48,8 @@ public class KakaoMobilityClient {
                 .body(KakaoMobilityResponse.class);
     }
 
-    private KakaoMobilityResponse circuitBreakerFallback(Throwable t) {
-        log.warn("[CircuitBreaker: OPEN] Fallback method executed. Reason: {}", t.getMessage());
+    private KakaoMobilityResponse circuitBreakerFallback(KakaoMobilityRequest request, Exception e) {
+        log.warn("[CircuitBreaker: OPEN] Fallback method executed. Reason: {}", e.getMessage());
         discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE));
         throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
     }

--- a/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
+++ b/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
@@ -2,7 +2,7 @@ package com.meetup.server.global.clients.kakao.mobility;
 
 import com.meetup.server.global.clients.exception.ClientErrorType;
 import com.meetup.server.global.clients.exception.ClientException;
-import com.meetup.server.global.clients.util.LimitRequestPerDay;
+import com.meetup.server.global.clients.ratelimit.LimitRequestPerDay;
 import com.meetup.server.global.support.error.discord.DiscordAlarmSender;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;

--- a/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
+++ b/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
@@ -25,7 +25,7 @@ public class KakaoMobilityClient {
             key = "kakao-mobility",
             count = 10000
     )
-    @Retry(name = "routeApi", fallbackMethod = "retryFallback")
+    @Retry(name = "routeApi")
     @CircuitBreaker(name = "routeApi", fallbackMethod = "circuitBreakerFallback")
     public KakaoMobilityResponse sendRequest(KakaoMobilityRequest request) {
         return kakaoMobilityRestClient
@@ -46,12 +46,6 @@ public class KakaoMobilityClient {
                         .build())
                 .retrieve()
                 .body(KakaoMobilityResponse.class);
-    }
-
-    private KakaoMobilityResponse retryFallback(Throwable t) {
-        log.warn("[Failed Retry] Fallback method executed. Reason: {}", t.getMessage());
-        discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE));
-        throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
     }
 
     private KakaoMobilityResponse circuitBreakerFallback(Throwable t) {

--- a/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
+++ b/src/main/java/com/meetup/server/global/clients/kakao/mobility/KakaoMobilityClient.java
@@ -1,22 +1,32 @@
 package com.meetup.server.global.clients.kakao.mobility;
 
+import com.meetup.server.global.clients.exception.ClientErrorType;
+import com.meetup.server.global.clients.exception.ClientException;
 import com.meetup.server.global.clients.util.LimitRequestPerDay;
+import com.meetup.server.global.support.error.discord.DiscordAlarmSender;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import java.util.Optional;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KakaoMobilityClient {
 
     private final RestClient kakaoMobilityRestClient;
+    private final DiscordAlarmSender discordAlarmSender;
 
     @LimitRequestPerDay(
             key = "kakao-mobility",
             count = 10000
     )
+    @Retry(name = "routeApi", fallbackMethod = "retryFallback")
+    @CircuitBreaker(name = "routeApi", fallbackMethod = "circuitBreakerFallback")
     public KakaoMobilityResponse sendRequest(KakaoMobilityRequest request) {
         return kakaoMobilityRestClient
                 .get()
@@ -36,5 +46,17 @@ public class KakaoMobilityClient {
                         .build())
                 .retrieve()
                 .body(KakaoMobilityResponse.class);
+    }
+
+    private KakaoMobilityResponse retryFallback(Throwable t) {
+        log.warn("[Failed Retry] Fallback method executed. Reason: {}", t.getMessage());
+        discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE));
+        throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
+    }
+
+    private KakaoMobilityResponse circuitBreakerFallback(Throwable t) {
+        log.warn("[CircuitBreaker: OPEN] Fallback method executed. Reason: {}", t.getMessage());
+        discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE));
+        throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
+++ b/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
@@ -2,7 +2,7 @@ package com.meetup.server.global.clients.odsay;
 
 import com.meetup.server.global.clients.exception.ClientErrorType;
 import com.meetup.server.global.clients.exception.ClientException;
-import com.meetup.server.global.clients.util.LimitRequestPerDay;
+import com.meetup.server.global.clients.ratelimit.LimitRequestPerDay;
 import com.meetup.server.global.support.error.discord.DiscordAlarmSender;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;

--- a/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
+++ b/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
@@ -1,7 +1,13 @@
 package com.meetup.server.global.clients.odsay;
 
+import com.meetup.server.global.clients.exception.ClientErrorType;
+import com.meetup.server.global.clients.exception.ClientException;
 import com.meetup.server.global.clients.util.LimitRequestPerDay;
+import com.meetup.server.global.support.error.discord.DiscordAlarmSender;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -9,17 +15,21 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.util.Optional;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OdsayTransitRouteSearchClient {
 
     private final RestClient odsayRestClient;
     private final OdsayProperties odsayProperties;
+    private final DiscordAlarmSender discordAlarmSender;
 
     @LimitRequestPerDay(
             key = "odsay-transit",
             count = 1000
     )
+    @Retry(name = "routeApi", fallbackMethod = "retryFallback")
+    @CircuitBreaker(name = "routeApi", fallbackMethod = "circuitBreakerFallback")
     public OdsayTransitRouteSearchResponse sendRequest(OdsayTransitRouteSearchRequest request) {
         URI uri = UriComponentsBuilder.fromUriString(odsayProperties.baseUrl() + "/searchPubTransPathT")
                 .queryParam("apiKey", odsayProperties.secretKey())
@@ -38,5 +48,17 @@ public class OdsayTransitRouteSearchClient {
                 .uri(uri)
                 .retrieve()
                 .body(OdsayTransitRouteSearchResponse.class);
+    }
+
+    private OdsayTransitRouteSearchResponse retryFallback(Throwable t) {
+        log.warn("[Failed Retry] Fallback method executed. Reason: {}", t.getMessage());
+        discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE));
+        throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
+    }
+
+    private OdsayTransitRouteSearchResponse circuitBreakerFallback(Throwable t) {
+        log.warn("[CircuitBreaker: OPEN] Fallback method executed. Reason: {}", t.getMessage());
+        discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE));
+        throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
+++ b/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
@@ -3,7 +3,7 @@ package com.meetup.server.global.clients.odsay;
 import com.meetup.server.global.clients.util.LimitRequestPerDay;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -13,7 +13,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class OdsayTransitRouteSearchClient {
 
-    private final WebClient webClient;
+    private final RestClient restClient;
     private final OdsayProperties odsayProperties;
 
     @LimitRequestPerDay(
@@ -33,11 +33,10 @@ public class OdsayTransitRouteSearchClient {
                 .build(true)
                 .toUri();
 
-        return webClient
+        return restClient
                 .get()
                 .uri(uri)
                 .retrieve()
-                .bodyToMono(OdsayTransitRouteSearchResponse.class)
-                .block();
+                .body(OdsayTransitRouteSearchResponse.class);
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
+++ b/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class OdsayTransitRouteSearchClient {
 
-    private final RestClient restClient;
+    private final RestClient odsayRestClient;
     private final OdsayProperties odsayProperties;
 
     @LimitRequestPerDay(
@@ -33,7 +33,7 @@ public class OdsayTransitRouteSearchClient {
                 .build(true)
                 .toUri();
 
-        return restClient
+        return odsayRestClient
                 .get()
                 .uri(uri)
                 .retrieve()

--- a/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
+++ b/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
@@ -50,8 +50,8 @@ public class OdsayTransitRouteSearchClient {
                 .body(OdsayTransitRouteSearchResponse.class);
     }
 
-    private OdsayTransitRouteSearchResponse circuitBreakerFallback(Throwable t) {
-        log.warn("[CircuitBreaker: OPEN] Fallback method executed. Reason: {}", t.getMessage());
+    private OdsayTransitRouteSearchResponse circuitBreakerFallback(OdsayTransitRouteSearchRequest request, Exception e) {
+        log.warn("[CircuitBreaker: OPEN] Fallback method executed. Reason: {}", e.getMessage());
         discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE));
         throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
     }

--- a/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
+++ b/src/main/java/com/meetup/server/global/clients/odsay/OdsayTransitRouteSearchClient.java
@@ -28,7 +28,7 @@ public class OdsayTransitRouteSearchClient {
             key = "odsay-transit",
             count = 1000
     )
-    @Retry(name = "routeApi", fallbackMethod = "retryFallback")
+    @Retry(name = "routeApi")
     @CircuitBreaker(name = "routeApi", fallbackMethod = "circuitBreakerFallback")
     public OdsayTransitRouteSearchResponse sendRequest(OdsayTransitRouteSearchRequest request) {
         URI uri = UriComponentsBuilder.fromUriString(odsayProperties.baseUrl() + "/searchPubTransPathT")
@@ -48,12 +48,6 @@ public class OdsayTransitRouteSearchClient {
                 .uri(uri)
                 .retrieve()
                 .body(OdsayTransitRouteSearchResponse.class);
-    }
-
-    private OdsayTransitRouteSearchResponse retryFallback(Throwable t) {
-        log.warn("[Failed Retry] Fallback method executed. Reason: {}", t.getMessage());
-        discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE));
-        throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
     }
 
     private OdsayTransitRouteSearchResponse circuitBreakerFallback(Throwable t) {

--- a/src/main/java/com/meetup/server/global/clients/ratelimit/LimitRequestPerDay.java
+++ b/src/main/java/com/meetup/server/global/clients/ratelimit/LimitRequestPerDay.java
@@ -1,4 +1,4 @@
-package com.meetup.server.global.clients.util;
+package com.meetup.server.global.clients.ratelimit;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/meetup/server/global/clients/ratelimit/RateLimiter.java
+++ b/src/main/java/com/meetup/server/global/clients/ratelimit/RateLimiter.java
@@ -1,4 +1,4 @@
-package com.meetup.server.global.clients.util;
+package com.meetup.server.global.clients.ratelimit;
 
 public interface RateLimiter {
 

--- a/src/main/java/com/meetup/server/global/clients/ratelimit/RateLimiterAspect.java
+++ b/src/main/java/com/meetup/server/global/clients/ratelimit/RateLimiterAspect.java
@@ -1,4 +1,4 @@
-package com.meetup.server.global.clients.util;
+package com.meetup.server.global.clients.ratelimit;
 
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -21,7 +21,7 @@ public class RateLimiterAspect {
         this.rateLimiter = rateLimiter;
     }
 
-    @Around("@annotation(com.meetup.server.global.clients.util.LimitRequestPerDay)")
+    @Around("@annotation(com.meetup.server.global.clients.ratelimit.LimitRequestPerDay)")
     public Object applyRateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
         LimitRequestPerDay limitRequestPerDay = getLimitRequestPerDayAnnotationFromMethod(joinPoint);
         rateLimiter.tryApiCall(limitRequestPerDay);

--- a/src/main/java/com/meetup/server/global/clients/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/com/meetup/server/global/clients/ratelimit/RedisRateLimiter.java
@@ -1,4 +1,4 @@
-package com.meetup.server.global.clients.util;
+package com.meetup.server.global.clients.ratelimit;
 
 import com.meetup.server.global.clients.exception.ClientErrorType;
 import com.meetup.server.global.clients.exception.ClientException;

--- a/src/main/java/com/meetup/server/global/clients/resilience4j/CircuitBreakerEventConsumer.java
+++ b/src/main/java/com/meetup/server/global/clients/resilience4j/CircuitBreakerEventConsumer.java
@@ -1,0 +1,42 @@
+package com.meetup.server.global.clients.resilience4j;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.core.registry.EntryAddedEvent;
+import io.github.resilience4j.core.registry.EntryRemovedEvent;
+import io.github.resilience4j.core.registry.EntryReplacedEvent;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CircuitBreakerEventConsumer implements RegistryEventConsumer<CircuitBreaker> {
+
+    @Override
+    public void onEntryAddedEvent(EntryAddedEvent<CircuitBreaker> entryAddedEvent) {
+        entryAddedEvent.getAddedEntry().getEventPublisher()
+                .onFailureRateExceeded(event -> log.warn("{} failure rate {}% on {}",
+                        event.getCircuitBreakerName(),
+                        event.getFailureRate(),
+                        event.getCreationTime())
+                )
+                .onError(event -> log.error("{} error with duration {}ms",
+                        event.getCircuitBreakerName(),
+                        event.getElapsedDuration().toMillis())
+                )
+                .onStateTransition(event -> log.info("{} state transition from {} to {} on {}",
+                        event.getCircuitBreakerName(),
+                        event.getStateTransition().getFromState(),
+                        event.getStateTransition().getToState(),
+                        event.getCreationTime())
+                );
+    }
+
+    @Override
+    public void onEntryRemovedEvent(EntryRemovedEvent<CircuitBreaker> entryRemoveEvent) {
+    }
+
+    @Override
+    public void onEntryReplacedEvent(EntryReplacedEvent<CircuitBreaker> entryReplacedEvent) {
+    }
+}

--- a/src/main/java/com/meetup/server/global/clients/resilience4j/CircuitBreakerEventConsumer.java
+++ b/src/main/java/com/meetup/server/global/clients/resilience4j/CircuitBreakerEventConsumer.java
@@ -8,6 +8,8 @@ import io.github.resilience4j.core.registry.RegistryEventConsumer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Slf4j
 @Component
 public class CircuitBreakerEventConsumer implements RegistryEventConsumer<CircuitBreaker> {
@@ -20,9 +22,11 @@ public class CircuitBreakerEventConsumer implements RegistryEventConsumer<Circui
                         event.getFailureRate(),
                         event.getCreationTime())
                 )
-                .onError(event -> log.error("{} error with duration {}ms",
+                .onError(event -> log.error("{} error with duration {}ms. failure reason: {} on {}",
                         event.getCircuitBreakerName(),
-                        event.getElapsedDuration().toMillis())
+                        event.getElapsedDuration().toMillis(),
+                        Optional.ofNullable(event.getThrowable()).map(Throwable::getMessage).orElse(null),
+                        event.getCreationTime())
                 )
                 .onStateTransition(event -> log.info("{} state transition from {} to {} on {}",
                         event.getCircuitBreakerName(),

--- a/src/main/java/com/meetup/server/global/clients/resilience4j/RetryEventConsumer.java
+++ b/src/main/java/com/meetup/server/global/clients/resilience4j/RetryEventConsumer.java
@@ -1,0 +1,48 @@
+package com.meetup.server.global.clients.resilience4j;
+
+import io.github.resilience4j.core.registry.EntryAddedEvent;
+import io.github.resilience4j.core.registry.EntryRemovedEvent;
+import io.github.resilience4j.core.registry.EntryReplacedEvent;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import io.github.resilience4j.retry.Retry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class RetryEventConsumer implements RegistryEventConsumer<Retry> {
+
+    @Override
+    public void onEntryAddedEvent(EntryAddedEvent<Retry> entryAddedEvent) {
+        entryAddedEvent.getAddedEntry().getEventPublisher()
+                .onRetry(event -> log.warn("[Attempt: {}] {} retrying. failure reason: {} on {}",
+                        event.getNumberOfRetryAttempts(),
+                        event.getName(),
+                        Optional.ofNullable(event.getLastThrowable()).map(Throwable::getMessage).orElse(null),
+                        event.getCreationTime())
+                )
+                .onSuccess(event -> log.info("[Attempt: {}] {} retry successful on {}",
+                        event.getNumberOfRetryAttempts(),
+                        event.getName(),
+                        event.getCreationTime())
+                )
+                .onError(event -> log.error("[Attempt: {}] {} retries failed. failure reason: {} on {}",
+                        event.getNumberOfRetryAttempts(),
+                        event.getName(),
+                        Optional.ofNullable(event.getLastThrowable()).map(Throwable::getMessage).orElse(null),
+                        event.getCreationTime())
+                );
+    }
+
+    @Override
+    public void onEntryRemovedEvent(EntryRemovedEvent<Retry> entryRemoveEvent) {
+
+    }
+
+    @Override
+    public void onEntryReplacedEvent(EntryReplacedEvent<Retry> entryReplacedEvent) {
+
+    }
+}

--- a/src/main/java/com/meetup/server/global/clients/resilience4j/RetryEventConsumer.java
+++ b/src/main/java/com/meetup/server/global/clients/resilience4j/RetryEventConsumer.java
@@ -38,11 +38,9 @@ public class RetryEventConsumer implements RegistryEventConsumer<Retry> {
 
     @Override
     public void onEntryRemovedEvent(EntryRemovedEvent<Retry> entryRemoveEvent) {
-
     }
 
     @Override
     public void onEntryReplacedEvent(EntryReplacedEvent<Retry> entryReplacedEvent) {
-
     }
 }

--- a/src/main/java/com/meetup/server/global/clients/util/RedisRateLimiter.java
+++ b/src/main/java/com/meetup/server/global/clients/util/RedisRateLimiter.java
@@ -24,6 +24,8 @@ public class RedisRateLimiter implements RateLimiter {
     private final DiscordAlarmSender discordAlarmSender;
 
     private static final String DISCORD_ALERT_SENT_KEY_PREFIX = "rate_limit_alert:";
+    private static final String ODSAY_TRANSIT = "odsay-transit";
+    private static final String KAKAO_MOBILITY = "kakao-mobility";
 
     @Override
     public void tryApiCall(LimitRequestPerDay limitRequestPerDay) {
@@ -38,7 +40,7 @@ public class RedisRateLimiter implements RateLimiter {
         );
 
         if (result == -1) {
-            discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.EXCEED_RATE_LIMIT_PER_DAY));
+            sendRateLimitExceedAlert(key);
             return;
         }
 
@@ -46,7 +48,7 @@ public class RedisRateLimiter implements RateLimiter {
             String alertSentKey = DISCORD_ALERT_SENT_KEY_PREFIX + key;
             Boolean isAlertSent = redisRateLimitTemplate.opsForValue().setIfAbsent(alertSentKey, "1", getTTL());
             if (Boolean.TRUE.equals(isAlertSent)) {
-                discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.WARNING_RATE_LIMIT_PER_DAY));
+                sendRateLimitWarningAlert(key);
             }
         }
     }
@@ -55,5 +57,23 @@ public class RedisRateLimiter implements RateLimiter {
         ZonedDateTime now = ZonedDateTime.now(TimeUtil.KST_ZONE_ID);
         ZonedDateTime midnight = now.plusDays(1).toLocalDate().atStartOfDay(TimeUtil.KST_ZONE_ID);
         return Duration.between(now, midnight);
+    }
+
+    private void sendRateLimitExceedAlert(String key) {
+        switch (key) {
+            case ODSAY_TRANSIT ->
+                    discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.ODSAY_EXCEED_RATE_LIMIT_PER_DAY));
+            case KAKAO_MOBILITY ->
+                    discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.KAKAO_MOBILITY_EXCEED_RATE_LIMIT_PER_DAY));
+        }
+    }
+
+    private void sendRateLimitWarningAlert(String key) {
+        switch (key) {
+            case ODSAY_TRANSIT ->
+                    discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.ODSAY_WARNING_RATE_LIMIT_PER_DAY));
+            case KAKAO_MOBILITY ->
+                    discordAlarmSender.sendErrorAlert(new ClientException(ClientErrorType.KAKAO_MOBILITY_WARNING_RATE_LIMIT_PER_DAY));
+        }
     }
 }

--- a/src/main/java/com/meetup/server/global/config/RestClientConfig.java
+++ b/src/main/java/com/meetup/server/global/config/RestClientConfig.java
@@ -7,6 +7,7 @@ import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
@@ -19,22 +20,37 @@ public class RestClientConfig {
     private final ClovaProperties clovaProperties;
 
     @Bean
-    public RestClient restClient() {
-        return RestClient.builder()
-                .build();
-    }
-
-    @Bean
     public RestClient kakaoLocalRestClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(1500);
+        requestFactory.setReadTimeout(1500);
+
         return RestClient.builder()
+                .requestFactory(requestFactory)
                 .defaultHeader("Authorization", "KakaoAK " + kakaoLocalProperties.secretKey())
                 .baseUrl(kakaoLocalProperties.baseUrl())
                 .build();
     }
 
     @Bean
-    public RestClient kakaoMobilityRestClient() {
+    public RestClient odsayRestClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(1500);
+        requestFactory.setReadTimeout(2000);
+
         return RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
+
+    @Bean
+    public RestClient kakaoMobilityRestClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(1500);
+        requestFactory.setReadTimeout(2000);
+
+        return RestClient.builder()
+                .requestFactory(requestFactory)
                 .defaultHeader("Authorization", "KakaoAK " + kakaoMobilityProperties.secretKey())
                 .baseUrl(kakaoMobilityProperties.url())
                 .build();

--- a/src/main/java/com/meetup/server/global/config/RestClientConfig.java
+++ b/src/main/java/com/meetup/server/global/config/RestClientConfig.java
@@ -14,6 +14,13 @@ import org.springframework.web.client.RestClient;
 @RequiredArgsConstructor
 public class RestClientConfig {
 
+    private static final int KAKAO_LOCAL_CONNECT_TIMEOUT = 1500;
+    private static final int KAKAO_LOCAL_READ_TIMEOUT = 1500;
+    private static final int ODSAY_CONNECT_TIMEOUT = 1500;
+    private static final int ODSAY_READ_TIMEOUT = 2000;
+    private static final int KAKAO_MOBILITY_CONNECT_TIMEOUT = 1500;
+    private static final int KAKAO_MOBILITY_READ_TIMEOUT = 2000;
+
     private final KakaoLocalProperties kakaoLocalProperties;
     private final KakaoMobilityProperties kakaoMobilityProperties;
     private final GooglePlaceProperties googlePlaceProperties;
@@ -22,8 +29,8 @@ public class RestClientConfig {
     @Bean
     public RestClient kakaoLocalRestClient() {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(1500);
-        requestFactory.setReadTimeout(1500);
+        requestFactory.setConnectTimeout(KAKAO_LOCAL_CONNECT_TIMEOUT);
+        requestFactory.setReadTimeout(KAKAO_LOCAL_READ_TIMEOUT);
 
         return RestClient.builder()
                 .requestFactory(requestFactory)
@@ -35,8 +42,8 @@ public class RestClientConfig {
     @Bean
     public RestClient odsayRestClient() {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(1500);
-        requestFactory.setReadTimeout(2000);
+        requestFactory.setConnectTimeout(ODSAY_CONNECT_TIMEOUT);
+        requestFactory.setReadTimeout(ODSAY_READ_TIMEOUT);
 
         return RestClient.builder()
                 .requestFactory(requestFactory)
@@ -46,8 +53,8 @@ public class RestClientConfig {
     @Bean
     public RestClient kakaoMobilityRestClient() {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(1500);
-        requestFactory.setReadTimeout(2000);
+        requestFactory.setConnectTimeout(KAKAO_MOBILITY_CONNECT_TIMEOUT);
+        requestFactory.setReadTimeout(KAKAO_MOBILITY_READ_TIMEOUT);
 
         return RestClient.builder()
                 .requestFactory(requestFactory)

--- a/src/main/java/com/meetup/server/global/config/RestClientConfig.java
+++ b/src/main/java/com/meetup/server/global/config/RestClientConfig.java
@@ -7,11 +7,11 @@ import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 @RequiredArgsConstructor
-public class WebClientConfig {
+public class RestClientConfig {
 
     private final KakaoLocalProperties kakaoLocalProperties;
     private final KakaoMobilityProperties kakaoMobilityProperties;
@@ -19,38 +19,38 @@ public class WebClientConfig {
     private final ClovaProperties clovaProperties;
 
     @Bean
-    public WebClient webClient() {
-        return WebClient.builder()
+    public RestClient restClient() {
+        return RestClient.builder()
                 .build();
     }
 
     @Bean
-    public WebClient kakaoLocalWebClient() {
-        return WebClient.builder()
+    public RestClient kakaoLocalRestClient() {
+        return RestClient.builder()
                 .defaultHeader("Authorization", "KakaoAK " + kakaoLocalProperties.secretKey())
                 .baseUrl(kakaoLocalProperties.baseUrl())
                 .build();
     }
 
     @Bean
-    public WebClient kakaoMobilityWebClient() {
-        return WebClient.builder()
+    public RestClient kakaoMobilityRestClient() {
+        return RestClient.builder()
                 .defaultHeader("Authorization", "KakaoAK " + kakaoMobilityProperties.secretKey())
                 .baseUrl(kakaoMobilityProperties.url())
                 .build();
     }
 
     @Bean
-    public WebClient googlePlaceWebClient() {
-        return WebClient.builder()
+    public RestClient googlePlaceRestClient() {
+        return RestClient.builder()
                 .defaultHeader("X-Goog-Api-Key", googlePlaceProperties.secretKey())
                 .baseUrl(googlePlaceProperties.baseUrl())
                 .build();
     }
 
     @Bean
-    public WebClient clovaWebClient() {
-        return WebClient.builder()
+    public RestClient clovaRestClient() {
+        return RestClient.builder()
                 .defaultHeader("Authorization", "Bearer " + clovaProperties.studioApiKey())
                 .defaultHeader("X-NCP-CLOVASTUDIO-REQUEST-ID", clovaProperties.requestId())
                 .baseUrl(clovaProperties.baseUrl())

--- a/src/test/java/com/meetup/server/global/clients/ratelimit/RateLimiterTest.java
+++ b/src/test/java/com/meetup/server/global/clients/ratelimit/RateLimiterTest.java
@@ -1,4 +1,4 @@
-package com.meetup.server.global.clients.util;
+package com.meetup.server.global.clients.ratelimit;
 
 import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/com/meetup/server/global/clients/resilience4j/Resilience4jTest.java
+++ b/src/test/java/com/meetup/server/global/clients/resilience4j/Resilience4jTest.java
@@ -15,6 +15,7 @@ import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.client.ResourceAccessException;
@@ -34,8 +35,18 @@ public class Resilience4jTest extends IntegrationTestContainer {
     @MockitoBean
     private OdsayTransitRouteSearchClient odsayTransitRouteSearchClient;
 
-    private KakaoMobilityRequest kakaoMobilityRequest;
-    private OdsayTransitRouteSearchRequest odsayTransitRouteSearchRequest;
+    private static final KakaoMobilityRequest kakaoMobilityRequest = KakaoMobilityRequest.builder()
+            .origin("127.10764191124568,37.402464820205246")
+            .destination("127.11056336672839,37.39419693653072")
+            .build();
+
+    private static final OdsayTransitRouteSearchRequest odsayTransitRouteSearchRequest = OdsayTransitRouteSearchRequest.builder()
+            .sx("127.10764191124568")
+            .sy("37.402464820205246")
+            .ex("127.11056336672839")
+            .ey("37.39419693653072")
+            .build();
+
     private CircuitBreaker circuitBreaker;
     private Retry retry;
 
@@ -55,141 +66,139 @@ public class Resilience4jTest extends IntegrationTestContainer {
                 .build();
         retry = Retry.of("testRetry", retryConfig);
 
-        kakaoMobilityRequest = KakaoMobilityRequest.builder()
-                .origin("127.10764191124568,37.402464820205246")
-                .destination("127.11056336672839,37.39419693653072")
-                .build();
-
-        odsayTransitRouteSearchRequest = OdsayTransitRouteSearchRequest.builder()
-                .sx("127.10764191124568")
-                .sy("37.402464820205246")
-                .ex("127.11056336672839")
-                .ey("37.39419693653072")
-                .build();
-
         circuitBreaker.reset();
     }
 
-    @Test
-    @DisplayName("카카오 모빌리티: 호출 성공 시 서킷 브레이커는 닫힌 상태를 유지한다")
-    void shouldStayWhenCircuitIsClosedOnSuccessForKakaoMobility() {
-        // given
-        circuitBreaker.transitionToClosedState();
-        when(kakaoMobilityClient.sendRequest(kakaoMobilityRequest))
-                .thenReturn(new KakaoMobilityResponse("transId", new ArrayList<>()));
+    @Nested
+    @DisplayName("Kakao Mobility Client")
+    class KakaoMobilityClientTest {
 
-        // when
-        assertDoesNotThrow(() -> kakaoMobilityClient.sendRequest(kakaoMobilityRequest));
+        @Test
+        @DisplayName("호출 성공 시 서킷 브레이커는 닫힌 상태를 유지한다")
+        void shouldStayWhenCircuitIsClosedOnSuccessForKakaoMobility() {
+            // given
+            circuitBreaker.transitionToClosedState();
+            when(kakaoMobilityClient.sendRequest(kakaoMobilityRequest))
+                    .thenReturn(new KakaoMobilityResponse("transId", new ArrayList<>()));
 
-        // then
-        assertEquals(circuitBreaker.getState(), CircuitBreaker.State.CLOSED);
-        verify(kakaoMobilityClient, times(1)).sendRequest(kakaoMobilityRequest);
+            // when
+            assertDoesNotThrow(() -> circuitBreaker.executeSupplier(() -> kakaoMobilityClient.sendRequest(kakaoMobilityRequest)));
+
+            // then
+            assertEquals(circuitBreaker.getState(), CircuitBreaker.State.CLOSED);
+            verify(kakaoMobilityClient, times(1)).sendRequest(kakaoMobilityRequest);
+        }
+
+        @Test
+        @DisplayName("타임아웃 발생 시, 재시도 로직이 실행된 후 실패한다")
+        void shouldRetryOnTimeoutAndFailForKakaoMobility() {
+            // given
+            when(kakaoMobilityClient.sendRequest(kakaoMobilityRequest))
+                    .thenThrow(new ResourceAccessException("Read timed out"));
+
+            // when
+            Supplier<KakaoMobilityResponse> supplierWithFallback = () -> {
+                try {
+                    return retry.executeSupplier(() -> kakaoMobilityClient.sendRequest(kakaoMobilityRequest));
+                } catch (Throwable t) {
+                    throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
+                }
+            };
+
+            // then
+            assertThrows(ClientException.class, supplierWithFallback::get);
+            verify(kakaoMobilityClient, times(3)).sendRequest(kakaoMobilityRequest);
+        }
+
+        @Test
+        @DisplayName("서킷 브레이커가 열린 상태일 때 호출은 즉시 실패한다")
+        void shouldFailImmediatelyWhenCircuitIsOpenForKakaoMobility() {
+            // given
+            circuitBreaker.transitionToOpenState();
+            when(kakaoMobilityClient.sendRequest(kakaoMobilityRequest))
+                    .thenThrow(new ResourceAccessException("Read timed out"));
+
+            // when
+            Supplier<KakaoMobilityResponse> supplierWithFallback = () -> {
+                try {
+                    return circuitBreaker.executeSupplier(() -> kakaoMobilityClient.sendRequest(kakaoMobilityRequest));
+                } catch (Throwable t) {
+                    throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
+                }
+            };
+
+            // then
+            assertThrows(ClientException.class, supplierWithFallback::get);
+            assertEquals(circuitBreaker.getState(), CircuitBreaker.State.OPEN);
+            verify(kakaoMobilityClient, never()).sendRequest(kakaoMobilityRequest);
+        }
     }
 
-    @Test
-    @DisplayName("Odsay: 호출 성공 시 서킷 브레이커는 닫힌 상태를 유지한다")
-    void shouldStayWhenCircuitIsClosedOnSuccessForOdsay() {
-        // given
-        circuitBreaker.transitionToClosedState();
-        when(odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest))
-                .thenReturn(new OdsayTransitRouteSearchResponse(
-                        new OdsayTransitRouteSearchResponse.TransitData(
-                                0, 0, 0, 0, 0, 0, 0, 0, new ArrayList<>()
-                        )));
+    @Nested
+    @DisplayName("Odsay Client")
+    class OdsayClientTest {
 
-        // when
-        assertDoesNotThrow(() -> odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest));
+        @Test
+        @DisplayName("호출 성공 시 서킷 브레이커는 닫힌 상태를 유지한다")
+        void shouldStayWhenCircuitIsClosedOnSuccessForOdsay() {
+            // given
+            circuitBreaker.transitionToClosedState();
+            when(odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest))
+                    .thenReturn(new OdsayTransitRouteSearchResponse(
+                            new OdsayTransitRouteSearchResponse.TransitData(
+                                    0, 0, 0, 0, 0, 0, 0, 0, new ArrayList<>()
+                            )));
 
-        // then
-        assertEquals(circuitBreaker.getState(), CircuitBreaker.State.CLOSED);
-        verify(odsayTransitRouteSearchClient, times(1)).sendRequest(odsayTransitRouteSearchRequest);
-    }
+            // when
+            assertDoesNotThrow(() -> circuitBreaker.executeSupplier(() -> odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest)));
 
-    @Test
-    @DisplayName("카카오 모빌리티: 타임아웃 발생 시, 재시도 로직이 실행된 후 실패한다")
-    void shouldRetryOnTimeoutAndFailForKakaoMobility() {
-        // given
-        when(kakaoMobilityClient.sendRequest(kakaoMobilityRequest))
-                .thenThrow(new ResourceAccessException("Read timed out"));
+            // then
+            assertEquals(circuitBreaker.getState(), CircuitBreaker.State.CLOSED);
+            verify(odsayTransitRouteSearchClient, times(1)).sendRequest(odsayTransitRouteSearchRequest);
+        }
 
-        // when
-        Supplier<KakaoMobilityResponse> supplierWithFallback = () -> {
-            try {
-                return retry.executeSupplier(() -> kakaoMobilityClient.sendRequest(kakaoMobilityRequest));
-            } catch (Throwable t) {
-                throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
-            }
-        };
+        @Test
+        @DisplayName("타임아웃 발생 시, 재시도 로직이 실행된 후 실패한다")
+        void shouldRetryOnTimeoutAndFailForOdsay() {
+            // given
+            when(odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest))
+                    .thenThrow(new ResourceAccessException("Read timed out"));
 
-        // then
-        assertThrows(ClientException.class, supplierWithFallback::get);
-        verify(kakaoMobilityClient, times(3)).sendRequest(kakaoMobilityRequest);
-    }
+            // when
+            Supplier<OdsayTransitRouteSearchResponse> supplierWithFallback = () -> {
+                try {
+                    return retry.executeSupplier(() -> odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest));
+                } catch (Throwable t) {
+                    throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
+                }
+            };
 
-    @Test
-    @DisplayName("Odsay: 타임아웃 발생 시, 재시도 로직이 실행된 후 실패한다")
-    void shouldRetryOnTimeoutAndFailForOdsay() {
-        // given
-        when(odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest))
-                .thenThrow(new ResourceAccessException("Read timed out"));
+            // then
+            assertThrows(ClientException.class, supplierWithFallback::get);
+            verify(odsayTransitRouteSearchClient, times(3)).sendRequest(odsayTransitRouteSearchRequest);
+        }
 
-        // when
-        Supplier<OdsayTransitRouteSearchResponse> supplierWithFallback = () -> {
-            try {
-                return retry.executeSupplier(() -> odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest));
-            } catch (Throwable t) {
-                throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
-            }
-        };
+        @Test
+        @DisplayName("서킷 브레이커가 열린 상태일 때 호출은 즉시 실패한다")
+        void shouldFailImmediatelyWhenCircuitIsOpenForOdsay() {
+            // given
+            circuitBreaker.transitionToOpenState();
+            when(odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest))
+                    .thenThrow(new ResourceAccessException("Read timed out"));
 
-        // then
-        assertThrows(ClientException.class, supplierWithFallback::get);
-        verify(odsayTransitRouteSearchClient, times(3)).sendRequest(odsayTransitRouteSearchRequest);
-    }
+            // when
+            Supplier<OdsayTransitRouteSearchResponse> supplierWithFallback = () -> {
+                try {
+                    return circuitBreaker.executeSupplier(() -> odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest));
+                } catch (Throwable t) {
+                    throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
+                }
+            };
 
-    @Test
-    @DisplayName("카카오 모빌리티: 서킷 브레이커가 열린 상태일 때 호출은 즉시 실패한다")
-    void shouldFailImmediatelyWhenCircuitIsOpenForKakaoMobility() {
-        // given
-        circuitBreaker.transitionToOpenState();
-        when(kakaoMobilityClient.sendRequest(kakaoMobilityRequest))
-                .thenThrow(new ResourceAccessException("Read timed out"));
-
-        // when
-        Supplier<KakaoMobilityResponse> supplierWithFallback = () -> {
-            try {
-                return circuitBreaker.executeSupplier(() -> kakaoMobilityClient.sendRequest(kakaoMobilityRequest));
-            } catch (Throwable t) {
-                throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
-            }
-        };
-
-        // then
-        assertThrows(ClientException.class, supplierWithFallback::get);
-        assertEquals(circuitBreaker.getState(), CircuitBreaker.State.OPEN);
-        verify(kakaoMobilityClient, never()).sendRequest(kakaoMobilityRequest);
-    }
-
-    @Test
-    @DisplayName("Odsay: 서킷 브레이커가 열린 상태일 때 호출은 즉시 실패한다")
-    void shouldFailImmediatelyWhenCircuitIsOpenForOdsay() {
-        // given
-        circuitBreaker.transitionToOpenState();
-        when(odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest))
-                .thenThrow(new ResourceAccessException("Read timed out"));
-
-        // when
-        Supplier<OdsayTransitRouteSearchResponse> supplierWithFallback = () -> {
-            try {
-                return circuitBreaker.executeSupplier(() -> odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest));
-            } catch (Throwable t) {
-                throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
-            }
-        };
-
-        // then
-        assertThrows(ClientException.class, supplierWithFallback::get);
-        assertEquals(circuitBreaker.getState(), CircuitBreaker.State.OPEN);
-        verify(odsayTransitRouteSearchClient, never()).sendRequest(odsayTransitRouteSearchRequest);
+            // then
+            assertThrows(ClientException.class, supplierWithFallback::get);
+            assertEquals(circuitBreaker.getState(), CircuitBreaker.State.OPEN);
+            verify(odsayTransitRouteSearchClient, never()).sendRequest(odsayTransitRouteSearchRequest);
+        }
     }
 }

--- a/src/test/java/com/meetup/server/global/clients/resilience4j/Resilience4jTest.java
+++ b/src/test/java/com/meetup/server/global/clients/resilience4j/Resilience4jTest.java
@@ -106,7 +106,8 @@ public class Resilience4jTest extends IntegrationTestContainer {
             };
 
             // then
-            assertThrows(ClientException.class, supplierWithFallback::get);
+            ClientException exception = assertThrows(ClientException.class, supplierWithFallback::get);
+            assertEquals(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE, exception.getErrorType());
             verify(kakaoMobilityClient, times(3)).sendRequest(kakaoMobilityRequest);
         }
 
@@ -128,7 +129,8 @@ public class Resilience4jTest extends IntegrationTestContainer {
             };
 
             // then
-            assertThrows(ClientException.class, supplierWithFallback::get);
+            ClientException exception = assertThrows(ClientException.class, supplierWithFallback::get);
+            assertEquals(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE, exception.getErrorType());
             assertEquals(circuitBreaker.getState(), CircuitBreaker.State.OPEN);
             verify(kakaoMobilityClient, never()).sendRequest(kakaoMobilityRequest);
         }
@@ -174,7 +176,8 @@ public class Resilience4jTest extends IntegrationTestContainer {
             };
 
             // then
-            assertThrows(ClientException.class, supplierWithFallback::get);
+            ClientException exception = assertThrows(ClientException.class, supplierWithFallback::get);
+            assertEquals(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE, exception.getErrorType());
             verify(odsayTransitRouteSearchClient, times(3)).sendRequest(odsayTransitRouteSearchRequest);
         }
 
@@ -196,7 +199,8 @@ public class Resilience4jTest extends IntegrationTestContainer {
             };
 
             // then
-            assertThrows(ClientException.class, supplierWithFallback::get);
+            ClientException exception = assertThrows(ClientException.class, supplierWithFallback::get);
+            assertEquals(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE, exception.getErrorType());
             assertEquals(circuitBreaker.getState(), CircuitBreaker.State.OPEN);
             verify(odsayTransitRouteSearchClient, never()).sendRequest(odsayTransitRouteSearchRequest);
         }

--- a/src/test/java/com/meetup/server/global/clients/resilience4j/Resilience4jTest.java
+++ b/src/test/java/com/meetup/server/global/clients/resilience4j/Resilience4jTest.java
@@ -1,0 +1,195 @@
+package com.meetup.server.global.clients.resilience4j;
+
+import com.meetup.server.global.clients.exception.ClientErrorType;
+import com.meetup.server.global.clients.exception.ClientException;
+import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityClient;
+import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityRequest;
+import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityResponse;
+import com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchClient;
+import com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchRequest;
+import com.meetup.server.global.clients.odsay.OdsayTransitRouteSearchResponse;
+import com.meetup.server.support.IntegrationTestContainer;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class Resilience4jTest extends IntegrationTestContainer {
+
+    @MockitoBean
+    private KakaoMobilityClient kakaoMobilityClient;
+
+    @MockitoBean
+    private OdsayTransitRouteSearchClient odsayTransitRouteSearchClient;
+
+    private KakaoMobilityRequest kakaoMobilityRequest;
+    private OdsayTransitRouteSearchRequest odsayTransitRouteSearchRequest;
+    private CircuitBreaker circuitBreaker;
+    private Retry retry;
+
+    @BeforeEach
+    void setUp() {
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+                .failureRateThreshold(50)
+                .slidingWindowSize(5)
+                .minimumNumberOfCalls(5)
+                .waitDurationInOpenState(Duration.ofSeconds(1))
+                .build();
+        circuitBreaker = CircuitBreaker.of("testCircuitBreaker", circuitBreakerConfig);
+
+        RetryConfig retryConfig = RetryConfig.custom()
+                .maxAttempts(3)
+                .waitDuration(Duration.ofMillis(100))
+                .build();
+        retry = Retry.of("testRetry", retryConfig);
+
+        kakaoMobilityRequest = KakaoMobilityRequest.builder()
+                .origin("127.10764191124568,37.402464820205246")
+                .destination("127.11056336672839,37.39419693653072")
+                .build();
+
+        odsayTransitRouteSearchRequest = OdsayTransitRouteSearchRequest.builder()
+                .sx("127.10764191124568")
+                .sy("37.402464820205246")
+                .ex("127.11056336672839")
+                .ey("37.39419693653072")
+                .build();
+
+        circuitBreaker.reset();
+    }
+
+    @Test
+    @DisplayName("카카오 모빌리티: 호출 성공 시 서킷 브레이커는 닫힌 상태를 유지한다")
+    void shouldStayWhenCircuitIsClosedOnSuccessForKakaoMobility() {
+        // given
+        circuitBreaker.transitionToClosedState();
+        when(kakaoMobilityClient.sendRequest(kakaoMobilityRequest))
+                .thenReturn(new KakaoMobilityResponse("transId", new ArrayList<>()));
+
+        // when
+        assertDoesNotThrow(() -> kakaoMobilityClient.sendRequest(kakaoMobilityRequest));
+
+        // then
+        assertEquals(circuitBreaker.getState(), CircuitBreaker.State.CLOSED);
+        verify(kakaoMobilityClient, times(1)).sendRequest(kakaoMobilityRequest);
+    }
+
+    @Test
+    @DisplayName("Odsay: 호출 성공 시 서킷 브레이커는 닫힌 상태를 유지한다")
+    void shouldStayWhenCircuitIsClosedOnSuccessForOdsay() {
+        // given
+        circuitBreaker.transitionToClosedState();
+        when(odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest))
+                .thenReturn(new OdsayTransitRouteSearchResponse(
+                        new OdsayTransitRouteSearchResponse.TransitData(
+                                0, 0, 0, 0, 0, 0, 0, 0, new ArrayList<>()
+                        )));
+
+        // when
+        assertDoesNotThrow(() -> odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest));
+
+        // then
+        assertEquals(circuitBreaker.getState(), CircuitBreaker.State.CLOSED);
+        verify(odsayTransitRouteSearchClient, times(1)).sendRequest(odsayTransitRouteSearchRequest);
+    }
+
+    @Test
+    @DisplayName("카카오 모빌리티: 타임아웃 발생 시, 재시도 로직이 실행된 후 실패한다")
+    void shouldRetryOnTimeoutAndFailForKakaoMobility() {
+        // given
+        when(kakaoMobilityClient.sendRequest(kakaoMobilityRequest))
+                .thenThrow(new ResourceAccessException("Read timed out"));
+
+        // when
+        Supplier<KakaoMobilityResponse> supplierWithFallback = () -> {
+            try {
+                return retry.executeSupplier(() -> kakaoMobilityClient.sendRequest(kakaoMobilityRequest));
+            } catch (Throwable t) {
+                throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
+            }
+        };
+
+        // then
+        assertThrows(ClientException.class, supplierWithFallback::get);
+        verify(kakaoMobilityClient, times(3)).sendRequest(kakaoMobilityRequest);
+    }
+
+    @Test
+    @DisplayName("Odsay: 타임아웃 발생 시, 재시도 로직이 실행된 후 실패한다")
+    void shouldRetryOnTimeoutAndFailForOdsay() {
+        // given
+        when(odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest))
+                .thenThrow(new ResourceAccessException("Read timed out"));
+
+        // when
+        Supplier<OdsayTransitRouteSearchResponse> supplierWithFallback = () -> {
+            try {
+                return retry.executeSupplier(() -> odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest));
+            } catch (Throwable t) {
+                throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
+            }
+        };
+
+        // then
+        assertThrows(ClientException.class, supplierWithFallback::get);
+        verify(odsayTransitRouteSearchClient, times(3)).sendRequest(odsayTransitRouteSearchRequest);
+    }
+
+    @Test
+    @DisplayName("카카오 모빌리티: 서킷 브레이커가 열린 상태일 때 호출은 즉시 실패한다")
+    void shouldFailImmediatelyWhenCircuitIsOpenForKakaoMobility() {
+        // given
+        circuitBreaker.transitionToOpenState();
+        when(kakaoMobilityClient.sendRequest(kakaoMobilityRequest))
+                .thenThrow(new ResourceAccessException("Read timed out"));
+
+        // when
+        Supplier<KakaoMobilityResponse> supplierWithFallback = () -> {
+            try {
+                return circuitBreaker.executeSupplier(() -> kakaoMobilityClient.sendRequest(kakaoMobilityRequest));
+            } catch (Throwable t) {
+                throw new ClientException(ClientErrorType.KAKAO_MOBILITY_SERVICE_UNAVAILABLE);
+            }
+        };
+
+        // then
+        assertThrows(ClientException.class, supplierWithFallback::get);
+        assertEquals(circuitBreaker.getState(), CircuitBreaker.State.OPEN);
+        verify(kakaoMobilityClient, never()).sendRequest(kakaoMobilityRequest);
+    }
+
+    @Test
+    @DisplayName("Odsay: 서킷 브레이커가 열린 상태일 때 호출은 즉시 실패한다")
+    void shouldFailImmediatelyWhenCircuitIsOpenForOdsay() {
+        // given
+        circuitBreaker.transitionToOpenState();
+        when(odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest))
+                .thenThrow(new ResourceAccessException("Read timed out"));
+
+        // when
+        Supplier<OdsayTransitRouteSearchResponse> supplierWithFallback = () -> {
+            try {
+                return circuitBreaker.executeSupplier(() -> odsayTransitRouteSearchClient.sendRequest(odsayTransitRouteSearchRequest));
+            } catch (Throwable t) {
+                throw new ClientException(ClientErrorType.ODSAY_SERVICE_UNAVAILABLE);
+            }
+        };
+
+        // then
+        assertThrows(ClientException.class, supplierWithFallback::get);
+        assertEquals(circuitBreaker.getState(), CircuitBreaker.State.OPEN);
+        verify(odsayTransitRouteSearchClient, never()).sendRequest(odsayTransitRouteSearchRequest);
+    }
+}


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 외부 API 대응 로직이 전무했습니다. 외부 API 서버 장애가 발생하면, API 호출 스레드는 무한정 점유하게 되며 결국 이는 서버 부하를 발생할 수 있습니다. 따라서 Timeout, Retry, Circuit Breaker를 적용하였습니다.
  - Timeout : Http 연결 시간 및 응답 시간의 지연을 방지
  - Retry : 네트워크, 외부 API 서버의 일시적 장애 해결 가능
  - Circuit Breaker : 외부 API 서버의 지속적인 장애로 인해 외부 API 호출 전에 바로 예외 처리를 위함

## ✅ What - 무엇이 변경됐나요?

- WebClient의 이점을 전혀 사용하지 않고 있으며, 추후 MVC 방식을 계속 유지할 것으로 논의되어 RestClient로 변경하였습니다.
- Resilience4j 및 AOP 의존성 추가하였습니다.
- Retry, Circuit Breaker 실행 시 `RegistryEventConsumer` 를 사용하여 각 상태를 로깅 처리 하였습니다.
- 외부 API 별로 에러 타입을 구체화 및 fallback 실행시 디스코드 알림을 전송하여 팔로우할 수 있도록 하였습니다.

## 🛠️ How - 어떻게 해결했나요?

- 타임아웃은 HTTP Connection을 위한 connect timeout과 응답을 받아오는 read timeout이 있는데 통상적으로 connect timeout은 1~5초 이내, read timeout은 1~3초 이내가 적당하다고 하여 connect timeout은 1.5초, read timeout은 2초로 설정하였습니다.

> retry와 circuitbreaker의 설정 값은 config 레포지토리에서 확인하실 수 있습니다.

### Retry
- 재시도 횟수(maxAttempts) : 3
- 기다리는 시간(waitDuration) : 1초
- 지수 백오프(exponentialBackoffMultiplier) : 1.5초
  - 지수 백오프를 적용하여 실패할 때마다 이전 waitDuration의 1.5초 곱해진 시간 이후 재시도합니다.

### Circuit Breaker
- 전체 크기 (slidingWindowSize) : 20
- 최소 호출 수 : 10
- 실패율 : 50%
- `open -> half close` 변경 시간 : 30초

위와 같이 설정하였습니다.

---

### 동작 방식

> Retry가 먼저 작동하여 일시적인 실패를 처리합니다.
> Retry가 해결하지 못한 지속적인 실패가 발생할 때 Circuit Breaker가 개입하여 시스템을 보호하는 순서로 동작합니다.

---

### 📉 상세 동작 시나리오

1.  **초기 상태:**
    * `Circuit Breaker`는 **`CLOSED`** 상태입니다.
    * `Retry` 카운트는 0입니다.

2.  **API 호출 실패 (1~9번째 호출):**
    * **외부 API 호출:** `RestClient`를 통한 외부 API 호출이 시작됩니다.
    * **타임아웃 발생:** 설정된 `read timeout(2초)`을 초과하여 응답이 오지 않습니다.
    * **Retry 개입:** `Retry` 정책이 작동하여 재시도를 시작합니다.
        * **1차 재시도:** 1초 대기 후 재시도
        * **2차 재시도:** 1.5초(1초 \* 1.5) 대기 후 재시도
    * **Retry 실패:** `maxAttempts(3)`을 모두 소진했으므로 `retryFallback`이 실행됩니다.
    * **Circuit Breaker 기록:** 이 하나의 API 호출 과정(`Retry` 포함)이 `Circuit Breaker`에게는 **단일 실패**로 기록됩니다. `minimumNumberOfCalls(10)`을 충족하지 못했으므로 `Circuit Breaker`의 상태는 여전히 `CLOSED`로 유지됩니다.
    * **반복:** 이 과정을 9번 반복합니다.

3.  **Circuit Breaker 상태 변화 (10번째 호출):**
    * **API 호출:** 10번째 외부 API 호출이 시작됩니다.
    * **Retry 실패:** 위와 동일하게 `Retry`가 3번 시도 후 실패합니다.
    * **Circuit Breaker 개입:** 이제 `minimumNumberOfCalls(10)`을 충족했습니다.
        * `failure rate`: 10번의 호출 중 10번 모두 실패했으므로 실패율은 100%입니다.
        * **임계치 초과:** 실패율 `100%`는 `failureRateThreshold(50%)`를 초과하므로, `Circuit Breaker`의 상태는 **`CLOSED`에서 `OPEN`으로 전환**됩니다.

4.  **즉시 실패 (11번째 호출부터):**
    * **외부 API 호출:** `RestClient` 호출이 시작됩니다.
    * **Circuit Breaker 개입:** 회로가 이미 **`OPEN`** 상태이므로, `RestClient` 호출을 시도하지 않고 즉시 `circuitBreakerFallback`이 실행됩니다.
    * **반복:** `waitDurationInOpenState(30초)` 동안 이 동작을 반복합니다.

5.  **Half-Open 상태로 전환 (30초 경과 후):**
    * **대기 시간 경과:** `Circuit Breaker`가 `OPEN` 상태가 된 후 30초가 경과합니다.
    * **상태 전환:** 다음 API 호출이 발생하면, `Circuit Breaker`의 상태가 자동으로 **`OPEN`에서 `HALF_OPEN`으로 전환**됩니다. 이 시점에서 **하나의 테스트 호출**이 허용됩니다.
        * **성공 시:** 호출이 성공하면 `Circuit Breaker`는 다시 `CLOSED`로 돌아가고, 정상적인 흐름으로 복구됩니다.
        * **실패 시:** 호출이 실패하면 `Circuit Breaker`는 다시 `OPEN`으로 돌아가며, 30초의 대기 시간을 다시 시작합니다.

## 🖼️ Attachment

<img width="1701" height="399" alt="스크린샷 2025-10-01 오후 7 44 41" src="https://github.com/user-attachments/assets/ca4698fe-93e4-49cc-a5e8-b06a01423336" />

## 💬 기타 코멘트

- [외부 API 장애에 영향 덜 받는 3가지 방법](https://www.youtube.com/watch?v=nuRO0ZBFdKk&t=164s)
- [개발자 의식의 흐름대로 적용해보는 서킷브레이커](https://techblog.woowahan.com/15694/)
- [내 서비스는 내가 지킨다: 외부 API 장애에 대처하는 4가지 방어 패턴](https://blog.leaphop.co.kr/blogs/97/%EB%82%B4_%EC%84%9C%EB%B9%84%EC%8A%A4%EB%8A%94_%EB%82%B4%EA%B0%80_%EC%A7%80%ED%82%A8%EB%8B%A4__%EC%99%B8%EB%B6%80_API_%EC%9E%A5%EC%95%A0%EC%97%90_%EB%8C%80%EC%B2%98%ED%95%98%EB%8A%94_4%EA%B0%80%EC%A7%80_%EB%B0%A9%EC%96%B4_%ED%8C%A8%ED%84%B4)
- [Getting started with resilience4j-spring-boot2 or resilience4j-spring-boot3](https://resilience4j.readme.io/docs/getting-started-3)
- [Circuitbreaker를 사용한 장애 전파 방지](https://oliveyoung.tech/2023-08-31/circuitbreaker-inventory-squad/)
- [Unit Testing Circuit Breaker](https://ynovytskyy.medium.com/unit-testing-circuit-breaker-8ed2c9098e11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 외부 API 호출에 재시도·회로차단과 장애 시 Discord 알림을 도입했습니다.

* **Improvements**
  * 동기식 HTTP 클라이언트로 전환해 타임아웃 제어와 안정성을 강화했습니다.
  * 서비스별(카카오모빌리티/ODsay) 구체적 오류 유형(초과/임박/서비스 불가)을 추가했습니다.
  * 회로차단·재시도 이벤트 로깅 및 모니터링 가시성을 개선했습니다.
  * 레이트리밋 알림 로직을 정리하고 경고/초과 알림을 구분했습니다.

* **Chores**
  * 구성·의존성 및 패키지 구조를 정리하고 AOP 설정을 조정했습니다.

* **Tests**
  * 회로차단·재시도 동작과 장애 대응에 대한 통합 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->