### PR TITLE
[MOISAM-239] OpenAPI Specification를 사용하여 Swagger와 Spring REST Docs를 통합한다

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -34,7 +34,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build -x test
+        run: ./gradlew build
 
       - name: move jar file to deploy
         run: mv ./build/libs/*.jar ./deploy

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -34,7 +34,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew clean build
 
       - name: move jar file to deploy
         run: mv ./build/libs/*.jar ./deploy

--- a/.github/workflows/stg-deploy.yml
+++ b/.github/workflows/stg-deploy.yml
@@ -36,7 +36,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew clean build
 
       - name: move jar file to deploy
         run: mv ./build/libs/*.jar ./deploy

--- a/.github/workflows/stg-deploy.yml
+++ b/.github/workflows/stg-deploy.yml
@@ -36,7 +36,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build -x test
+        run: ./gradlew build
 
       - name: move jar file to deploy
         run: mv ./build/libs/*.jar ./deploy

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/resources/static/swagger-ui
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.4'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'com.epages.restdocs-api-spec' version '0.19.4'
 }
 
 group = 'com.meetup'
@@ -26,7 +27,6 @@ dependencyManagement {
 repositories {
 	mavenCentral()
 }
-
 
 apply from: "gradle/spring.gradle"
 apply from: "gradle/database.gradle"

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -20,3 +20,11 @@ tasks.register('copyOasToSwagger', Copy) {
 tasks.named('build') {
     finalizedBy 'copyOasToSwagger'
 }
+
+bootJar {
+    dependsOn copyOasToSwagger
+    from('src/main/resources/static/swagger-ui') {
+        include 'openapi3.json'
+        into 'static/swagger-ui/'
+    }
+}

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -11,14 +11,12 @@ openapi3 {
 }
 
 tasks.register('copyOasToSwagger', Copy) {
-    delete "src/main/resources/static/swagger-ui/openapi3.json"
-    from(layout.buildDirectory.file("api-spec/openapi3.json"))
-    into("src/main/resources/static/swagger-ui/.")
-    dependsOn("openapi3")
-}
-
-tasks.named('build') {
-    finalizedBy 'copyOasToSwagger'
+    dependsOn('openapi3')
+    doFirst {
+        delete "src/main/resources/static/swagger-ui/openapi3.json"
+    }
+    from file("build/api-spec/openapi3.json")
+    into file("src/main/resources/static/swagger-ui/.")
 }
 
 bootJar {

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -1,3 +1,22 @@
 dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.4'
+}
+
+openapi3 {
+    title = 'MOISAM API Specification'
+    version = '1.1.2'
+    description = 'OpenAPI 3.0 specification for the MOISAM'
+    format = 'json'
+}
+
+tasks.register('copyOasToSwagger', Copy) {
+    delete "src/main/resources/static/swagger-ui/openapi3.json"
+    from(layout.buildDirectory.file("api-spec/openapi3.json"))
+    into("src/main/resources/static/swagger-ui/.")
+    dependsOn("openapi3")
+}
+
+tasks.named('build') {
+    finalizedBy 'copyOasToSwagger'
 }

--- a/gradle/spring.gradle
+++ b/gradle/spring.gradle
@@ -22,4 +22,5 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }

--- a/src/main/java/com/meetup/server/event/domain/Event.java
+++ b/src/main/java/com/meetup/server/event/domain/Event.java
@@ -49,7 +49,8 @@ public class Event extends BaseEntity {
     }
 
     @Builder
-    public Event(Subway subway, Place place, String eventName, LocalDateTime eventDateTime, MeetingPointRouteGroups routes) {
+    public Event(UUID eventId, Subway subway, Place place, String eventName, LocalDateTime eventDateTime, MeetingPointRouteGroups routes) {
+        this.eventId = eventId;
         this.subway = subway;
         this.place = place;
         this.eventName = eventName;

--- a/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/EventRequest.java
@@ -1,7 +1,6 @@
 package com.meetup.server.event.dto.request;
 
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
 import java.time.LocalDate;
@@ -9,49 +8,38 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record EventRequest(
-
         @NotBlank
         @Size(min = 1, max = 50)
-        @Schema(description = "모임명", example = "입력핑")
         String eventName,
 
         @NotNull
-        @Schema(description = "모임 날짜", example = "2026-01-01")
         LocalDate eventDate,
 
         @NotNull
-        @Schema(description = "모임 시간", example = "15:30")
         LocalTime eventTime,
 
         @NotBlank
         @Size(min = 1, max = 5)
-        @Schema(description = "사용자명", example = "김아무개")
         String username,
 
         @NotBlank(message = "출발지명은 필수 값입니다.")
-        @Schema(description = "출발지명", example = "선정릉역 수인분당선")
         String startPoint,
 
         @NotBlank(message = "지번주소는 필수 값입니다.")
-        @Schema(description = "지번주소", example = "서울특별시 강남구 삼성동 111-114")
         String address,
 
         @NotNull
-        @Schema(description = "도로명주소 (빈 문자열 허용)", example = "서울특별시 강남구 선릉로 지하580")
         String roadAddress,
 
         @DecimalMin(value = "-180.0", message = "경도는 -180.0보다 크거나 같아야 합니다.")
         @DecimalMax(value = "180.0", message = "경도는 180.0보다 작거나 같아야 합니다.")
-        @Schema(description = "경도", example = "127.043999")
         double longitude,
 
         @DecimalMin(value = "-90.0", message = "위도는 -90.0보다 크거나 같아야 합니다.")
         @DecimalMax(value = "90.0", message = "위도는 90.0보다 작거나 같아야 합니다.")
-        @Schema(description = "위도", example = "37.510297")
         double latitude,
 
         @NotNull(message = "대중교통/자가용 선택 여부는 필수 값입니다.")
-        @Schema(description = "대중교통/자가용 선택 여부", example = "true")
         boolean isTransit
 ) {
     public LocalDateTime toDateTime() {

--- a/src/main/java/com/meetup/server/event/dto/request/UpdateEventRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/UpdateEventRequest.java
@@ -1,6 +1,5 @@
 package com.meetup.server.event.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -10,18 +9,14 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record UpdateEventRequest(
-
         @NotBlank
         @Size(min = 1, max = 50)
-        @Schema(description = "모임명", example = "입력핑")
         String eventName,
 
         @NotNull
-        @Schema(description = "모임 날짜", example = "2026-01-01")
         LocalDate eventDate,
 
         @NotNull
-        @Schema(description = "모임 시간", example = "15:30")
         LocalTime eventTime
 ) {
     public LocalDateTime toDateTime() {

--- a/src/main/java/com/meetup/server/event/dto/request/UpdatePlaceRequest.java
+++ b/src/main/java/com/meetup/server/event/dto/request/UpdatePlaceRequest.java
@@ -1,17 +1,13 @@
 package com.meetup.server.event.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
 public record UpdatePlaceRequest(
-
         @NotNull
-        @Schema(description = "확정 장소 ID", example = "0196f346-5244-79b9-85b0-955d6328f09b")
         UUID placeId,
 
-        @Schema(description = "지하철역 ID", example = "1")
         int subwayId
 ) {
 }

--- a/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
@@ -1,25 +1,17 @@
 package com.meetup.server.event.dto.response;
 
 import com.meetup.server.event.domain.Event;
-import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.event.util.UsernameExtractor;
-import io.swagger.v3.oas.annotations.media.Schema;
+import com.meetup.server.startpoint.domain.StartPoint;
 import lombok.Builder;
 
 import java.util.UUID;
 
 @Builder
 public record EventStartPointResponse(
-        @Schema(description = "이벤트 ID", example = "01968fe2-5277-712a-ad3c-98f29c2782e0")
         UUID eventId,
-
-        @Schema(description = "출발지 ID", example = "01968fe2-5277-712a-ad3c-98f29c2782e1")
         UUID startPointId,
-
-        @Schema(description = "비회원 ID", example = "01968fe2-5277-712a-ad3c-98f29c2782e1")
         UUID guestId,
-
-        @Schema(description = "사용자명", example = "땡수팟")
         String username
 ) {
     public static EventStartPointResponse of(Event event, StartPoint startPoint) {

--- a/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRoutesResponse.java
@@ -1,11 +1,10 @@
 package com.meetup.server.event.dto.response.route;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.util.UsernameExtractor;
 import com.meetup.server.global.util.TimeUtil;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.startpoint.domain.StartPoint;
-import com.meetup.server.event.util.UsernameExtractor;
-import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -13,25 +12,12 @@ import java.util.List;
 import java.util.Optional;
 
 public record MeetingPointRoutesResponse(
-        @Schema(description = "모임명", example = "SPOT 정기회의")
         String eventName,
-
-        @Schema(description = "모임 날짜 (yyyy-MM-dd 형식)", example = "2025-07-09")
         String eventDate,
-
-        @Schema(description = "모임 시간 (HH:mm 형식)", example = "14:00")
         String eventTime,
-
-        @Schema(description = "모임 생성자", example = "홍길동")
         String eventMaker,
-
-        @Schema(description = "확정 장소명", example = "스타벅스 방배카페거리점")
         String placeName,
-
-        @Schema(description = "참여자 수", example = "5")
         int peopleCount,
-
-        @Schema(description = "모임 경로 관련 그룹 데이터")
         List<MeetingPointRouteGroup> meetingPointRouteGroups
 ) {
 

--- a/src/main/java/com/meetup/server/event/dto/response/route/RouteResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/RouteResponse.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RouteResponse {
-
     private Boolean isTransit;  // true: 대중교통, false: 자동차
     private Boolean isMe;
     private UUID id;

--- a/src/main/java/com/meetup/server/event/presentation/EventController.java
+++ b/src/main/java/com/meetup/server/event/presentation/EventController.java
@@ -7,8 +7,6 @@ import com.meetup.server.event.dto.request.UpdatePlaceRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.dto.response.route.MeetingPointRoutesResponse;
 import com.meetup.server.global.support.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Tag(name = "Event API", description = "모임 API")
 @RestController
 @RequestMapping("/events")
 @RequiredArgsConstructor
@@ -24,7 +21,6 @@ public class EventController {
 
     private final EventService eventService;
 
-    @Operation(summary = "모임 생성 API", description = "모임 생성자의 출발지를 입력받아 모임을 생성합니다")
     @PostMapping
     public ApiResponse<EventStartPointResponse> createEvent(
             @Valid @RequestBody EventRequest eventRequest,
@@ -33,21 +29,18 @@ public class EventController {
         return ApiResponse.success(eventService.createEvent(userId, guestId, eventRequest));
     }
 
-    @Operation(summary = "모임 수정 API", description = "모임명과 시간을 입력받아 모임을 수정합니다")
     @PatchMapping("/{eventId}")
     public ApiResponse<?> updateEvent(@PathVariable UUID eventId, @Valid @RequestBody UpdateEventRequest updateEventRequest) {
         eventService.updateEvent(eventId, updateEventRequest);
         return ApiResponse.success();
     }
 
-    @Operation(summary = "모임 삭제 API", description = "모임을 삭제합니다")
     @DeleteMapping("/{eventId}")
     public ApiResponse<?> deleteEvent(@PathVariable UUID eventId) {
         eventService.deleteEvent(eventId);
         return ApiResponse.success();
     }
 
-    @Operation(summary = "지도 조회 API", description = "모임의 중간 지점 계산 및 모임 참여자의 경로 조회를 진행합니다")
     @GetMapping("/{eventId}")
     public ApiResponse<MeetingPointRoutesResponse> getMeetingPointRoutes(
             @PathVariable UUID eventId,
@@ -56,7 +49,6 @@ public class EventController {
         return ApiResponse.success(eventService.getMeetingPointRoutes(eventId, userId, guestId));
     }
 
-    @Operation(summary = "모임 장소 확정/변경 API", description = "모임 ID와 장소 ID를 통해 모임 장소를 확정/변경합니다.")
     @PatchMapping("/{eventId}/place")
     public ApiResponse<?> updatePlace(
             @PathVariable UUID eventId,
@@ -66,7 +58,6 @@ public class EventController {
         return ApiResponse.success();
     }
 
-    @Operation(summary = "확정된 모임 장소 취소 API", description = "모임 ID를 통해 확정된 모임 장소를 취소합니다.")
     @DeleteMapping("/{eventId}/place")
     public ApiResponse<?> deletePlace(@PathVariable UUID eventId) {
         eventService.deletePlace(eventId);

--- a/src/main/java/com/meetup/server/global/config/SwaggerConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SwaggerConfig.java
@@ -1,5 +1,9 @@
 package com.meetup.server.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meetup.server.global.support.error.GlobalErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
@@ -9,28 +13,60 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
+import java.io.InputStream;
 import java.util.Collections;
-@OpenAPIDefinition(
-        info = @Info(title = "SPOT API 명세서",
-                description = "SPOT API 명세서",
-                version = "v1"
-        ),
-        servers = @Server(url = "${springdoc.server-url}", description = "Default Server URL")
-)
 
+@OpenAPIDefinition(
+        info = @Info(
+                title = "MOISAM API Specification",
+                description = "OpenAPI 3.0 specification for the MOISAM",
+                version = "v1.1.2"
+        ),
+        servers = @Server(url = "${springdoc.server-url}", description = "Server URL")
+)
 @Configuration
 public class SwaggerConfig {
 
-        @Bean
-        public OpenAPI openAPI() {
-                SecurityScheme securityScheme = new SecurityScheme()
-                        .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
-                        .in(SecurityScheme.In.HEADER).name("Authorization");
-                SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+    private static final String OAS_FILE_PATH = "static/swagger-ui/openapi3.json";
+    private static final String SECURITY_SCHEME_NAME = "BearerAuth";
 
-                return new OpenAPI()
-                        .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
-                        .security(Collections.singletonList(securityRequirement));
+    @Bean
+    public OpenAPI openAPI() {
+        OpenAPI openAPI = new OpenAPI();
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        ObjectMapper swaggerMapper = Json.mapper();
+        ClassPathResource resource = new ClassPathResource(OAS_FILE_PATH);
+
+        try (InputStream inputStream = resource.getInputStream()) {
+            OpenAPI restDocsOpenAPI = swaggerMapper.readValue(inputStream, OpenAPI.class);
+
+            Components components = restDocsOpenAPI.getComponents() != null
+                    ? restDocsOpenAPI.getComponents()
+                    : new Components();
+
+            components.addSecuritySchemes(SECURITY_SCHEME_NAME, securityScheme);
+            openAPI.components(components);
+
+            if (restDocsOpenAPI.getPaths() != null) {
+                openAPI.setPaths(restDocsOpenAPI.getPaths());
+            }
+
+            SecurityRequirement securityRequirement = new SecurityRequirement().addList(SECURITY_SCHEME_NAME);
+            openAPI.security(Collections.singletonList(securityRequirement));
+
+        } catch (Exception e) {
+            throw new GlobalException(GlobalErrorType.FAILED_SWAGGER_REST_DOCS_INTEGRATION);
         }
+
+        return openAPI;
+    }
 }

--- a/src/main/java/com/meetup/server/global/config/SwaggerConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SwaggerConfig.java
@@ -1,8 +1,6 @@
 package com.meetup.server.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.meetup.server.global.support.error.GlobalErrorType;
-import com.meetup.server.global.support.error.GlobalException;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -11,6 +9,7 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
@@ -18,6 +17,7 @@ import org.springframework.core.io.ClassPathResource;
 import java.io.InputStream;
 import java.util.Collections;
 
+@Slf4j
 @OpenAPIDefinition(
         info = @Info(
                 title = "MOISAM API Specification",
@@ -64,7 +64,14 @@ public class SwaggerConfig {
             openAPI.security(Collections.singletonList(securityRequirement));
 
         } catch (Exception e) {
-            throw new GlobalException(GlobalErrorType.FAILED_SWAGGER_REST_DOCS_INTEGRATION);
+            log.warn("Not Exist an OpenAPI Specification", e);
+
+            Components components = new Components();
+            components.addSecuritySchemes(SECURITY_SCHEME_NAME, securityScheme);
+            openAPI.components(components);
+
+            SecurityRequirement securityRequirement = new SecurityRequirement().addList(SECURITY_SCHEME_NAME);
+            openAPI.security(Collections.singletonList(securityRequirement));
         }
 
         return openAPI;

--- a/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
+++ b/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
@@ -15,7 +15,6 @@ public enum GlobalErrorType implements ErrorType {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다."),
     IMAGE_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환 중 예외가 발생했습니다."),
     IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 예외가 발생했습니다."),
-    FAILED_SWAGGER_REST_DOCS_INTEGRATION(HttpStatus.INTERNAL_SERVER_ERROR, "Swagger와 Rest Docs 통합 과정에서 예외가 발생했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
+++ b/src/main/java/com/meetup/server/global/support/error/GlobalErrorType.java
@@ -15,6 +15,7 @@ public enum GlobalErrorType implements ErrorType {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다."),
     IMAGE_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 변환 중 예외가 발생했습니다."),
     IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 예외가 발생했습니다."),
+    FAILED_SWAGGER_REST_DOCS_INTEGRATION(HttpStatus.INTERNAL_SERVER_ERROR, "Swagger와 Rest Docs 통합 과정에서 예외가 발생했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
+++ b/src/main/java/com/meetup/server/startpoint/domain/StartPoint.java
@@ -66,7 +66,8 @@ public class StartPoint extends BaseEntity {
     }
 
     @Builder
-    public StartPoint(Event event, User user, String name, Address address, Location location, String nonUserName, Point point, boolean isUser, UUID guestId, boolean isTransit) {
+    public StartPoint(UUID startPointId, Event event, User user, String name, Address address, Location location, String nonUserName, Point point, boolean isUser, UUID guestId, boolean isTransit) {
+        this.startPointId = startPointId;
         this.event = event;
         this.user = user;
         this.name = name;
@@ -81,10 +82,6 @@ public class StartPoint extends BaseEntity {
 
     public boolean getIsUser() {
         return isUser;
-    }
-
-    public void updateIsTransit(boolean isTransit) {
-        this.isTransit = isTransit;
     }
 
     public void updateStartPoint(String name, Address address, Location location, String nonUserName, Point point, boolean isTransit) {

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -67,13 +67,14 @@ class EventServiceTest extends IntegrationTestContainer {
 
     @BeforeEach
     void setUp() {
-        eventWithRoute = eventRepository.save(EventFixture.getEventWithRoute());
         user = userRepository.save(UserFixture.getUser());
         eventRequest = EventFixture.getEventRequest();
         guestId = UUID.randomUUID();
         updateEventRequest = EventFixture.getUpdateEventRequest();
         meetingPointRouteGroups = EventFixture.getMeetingPointRouteGroups();
+        eventWithRoute = EventFixture.getEventWithRoute();
         placeRepository.save(eventWithRoute.getPlace());
+        eventWithRoute = eventRepository.save(eventWithRoute);
     }
 
     @Test

--- a/src/test/java/com/meetup/server/event/application/EventServiceTest.java
+++ b/src/test/java/com/meetup/server/event/application/EventServiceTest.java
@@ -11,6 +11,7 @@ import com.meetup.server.event.infrastructure.jpa.EventRepository;
 import com.meetup.server.event.infrastructure.redis.CachedRouteRepository;
 import com.meetup.server.fixture.EventFixture;
 import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.place.infrastructure.jpa.PlaceRepository;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.infrastructure.jpa.StartPointRepository;
 import com.meetup.server.support.IntegrationTestContainer;
@@ -43,6 +44,9 @@ class EventServiceTest extends IntegrationTestContainer {
     private UserRepository userRepository;
 
     @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
     private CachedRouteRepository cachedRouteRepository;
 
     @Autowired
@@ -54,7 +58,6 @@ class EventServiceTest extends IntegrationTestContainer {
     @Autowired
     private CacheManager cacheManager;
 
-    private Event event;
     private User user;
     private EventRequest eventRequest;
     private UUID guestId;
@@ -64,16 +67,17 @@ class EventServiceTest extends IntegrationTestContainer {
 
     @BeforeEach
     void setUp() {
-        event = eventRepository.save(EventFixture.getEvent());
+        eventWithRoute = eventRepository.save(EventFixture.getEventWithRoute());
         user = userRepository.save(UserFixture.getUser());
         eventRequest = EventFixture.getEventRequest();
         guestId = UUID.randomUUID();
         updateEventRequest = EventFixture.getUpdateEventRequest();
-        eventWithRoute = eventRepository.save(EventFixture.getEventWithRoute());
         meetingPointRouteGroups = EventFixture.getMeetingPointRouteGroups();
+        placeRepository.save(eventWithRoute.getPlace());
     }
 
     @Test
+    @Transactional
     void 비로그인_사용자가_이벤트를_생성한다() {
         EventStartPointResponse eventStartPointResponse = eventService.createEvent(null, guestId, eventRequest);
 
@@ -93,8 +97,8 @@ class EventServiceTest extends IntegrationTestContainer {
         assertThat(optionalStartPoint.get().getGuestId()).isEqualTo(guestId);
     }
 
-    @Transactional
     @Test
+    @Transactional
     void 로그인_사용자가_이벤트를_생성한다() {
         EventStartPointResponse eventStartPointResponse = eventService.createEvent(user.getUserId(), null, eventRequest);
 

--- a/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
+++ b/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
@@ -1,0 +1,472 @@
+package com.meetup.server.event.presentation;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.meetup.server.event.application.EventService;
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.domain.type.TrafficType;
+import com.meetup.server.event.dto.request.EventRequest;
+import com.meetup.server.event.dto.request.UpdateEventRequest;
+import com.meetup.server.event.dto.request.UpdatePlaceRequest;
+import com.meetup.server.event.dto.response.EventStartPointResponse;
+import com.meetup.server.event.dto.response.route.MeetingPointRouteGroup;
+import com.meetup.server.event.dto.response.route.MeetingPointRoutesResponse;
+import com.meetup.server.fixture.EventFixture;
+import com.meetup.server.fixture.StartPointFixture;
+import com.meetup.server.global.support.response.ResultType;
+import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.support.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class EventControllerTest extends ControllerTestSupport {
+
+    @MockitoBean
+    private EventService eventService;
+
+    @DisplayName("모임을 생성한다.")
+    @Test
+    void createEvent() throws Exception {
+        // given
+        EventRequest request = EventFixture.getEventRequest();
+        UUID guestId = StartPointFixture.GUEST_ID;
+
+        Event event = EventFixture.getEvent();
+        StartPoint startPoint = StartPointFixture.getStartPoint(event, null);
+        EventStartPointResponse response = EventStartPointResponse.of(event, startPoint);
+
+        // when
+        Mockito.when(eventService.createEvent(nullable(Long.class), nullable(UUID.class), any(EventRequest.class)))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/events")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .queryParam("guestId", guestId.toString())
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andExpect(jsonPath("$.data.eventId").value(EventFixture.EVENT_ID.toString()))
+                .andExpect(jsonPath("$.data.startPointId").value(StartPointFixture.START_POINT_ID.toString()))
+                .andExpect(jsonPath("$.data.guestId").value(guestId.toString()))
+                .andExpect(jsonPath("$.data.username").value(request.username()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("event/create-event",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Event API")
+                                                .description("모임을 생성한다. (회원 - JWT Token, 비회원 - guestId)")
+                                                .requestHeaders(
+                                                        headerWithName(HttpHeaders.AUTHORIZATION).description("JWT Token").optional()
+                                                )
+                                                .queryParameters(
+                                                        parameterWithName("guestId").description("비회원 ID (UUID)").optional()
+                                                )
+                                                .requestFields(
+                                                        fieldWithPath("eventName").type(JsonFieldType.STRING).description("모임 이름 (최소 1자, 최대 50자)"),
+                                                        fieldWithPath("eventDate").type(JsonFieldType.STRING).description("모임 날짜 (YYYY-MM-DD)"),
+                                                        fieldWithPath("eventTime").type(JsonFieldType.STRING).description("모임 시간 (HH:MM)"),
+                                                        fieldWithPath("username").type(JsonFieldType.STRING).description("사용자 이름 (최소 1자, 최대 5자)"),
+                                                        fieldWithPath("startPoint").type(JsonFieldType.STRING).description("출발지 이름"),
+                                                        fieldWithPath("address").type(JsonFieldType.STRING).description("지번주소"),
+                                                        fieldWithPath("roadAddress").type(JsonFieldType.STRING).description("도로명주소 (빈 문자열 허용)"),
+                                                        fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도 (범위: -180.0 ~ 180.0)"),
+                                                        fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도 (범위: -90.0 ~ 90.0)"),
+                                                        fieldWithPath("isTransit").type(JsonFieldType.BOOLEAN).description("대중교통/자가용 선택 여부 (true/false)")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                                        fieldWithPath("data.eventId").type(JsonFieldType.STRING).description("이벤트 ID"),
+                                                        fieldWithPath("data.startPointId").type(JsonFieldType.STRING).description("출발지 ID"),
+                                                        fieldWithPath("data.guestId").type(JsonFieldType.STRING).description("비회원 ID"),
+                                                        fieldWithPath("data.username").type(JsonFieldType.STRING).description("사용자 이름"),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .requestSchema(Schema.schema("EventRequest"))
+                                                .responseSchema(Schema.schema("EventStartPointResponse"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("모임을 수정한다.")
+    @Test
+    void updateEvent() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+        UpdateEventRequest request = EventFixture.getUpdateEventRequest();
+
+        // when
+        Mockito.doNothing().when(eventService).updateEvent(any(UUID.class), any(UpdateEventRequest.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.patch("/events/{eventId}", eventId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("event/update-event",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Event API")
+                                                .description("모임을 수정한다.")
+                                                .pathParameters(
+                                                        parameterWithName("eventId").description("수정할 이벤트 ID (UUID)")
+                                                )
+                                                .requestFields(
+                                                        fieldWithPath("eventName").type(JsonFieldType.STRING).description("모임 이름 (최소 1자, 최대 50자)"),
+                                                        fieldWithPath("eventDate").type(JsonFieldType.STRING).description("모임 날짜 (YYYY-MM-DD)"),
+                                                        fieldWithPath("eventTime").type(JsonFieldType.STRING).description("모임 시간 (HH:MM)")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .requestSchema(Schema.schema("UpdateEventRequest"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("모임을 삭제한다.")
+    @Test
+    void deleteEvent() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+
+        // when
+        Mockito.doNothing().when(eventService).deleteEvent(any(UUID.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/events/{eventId}", eventId)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("event/delete-event",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Event API")
+                                                .description("모임을 삭제한다.")
+                                                .pathParameters(
+                                                        parameterWithName("eventId").description("삭제할 이벤트 ID (UUID)")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .build())
+                        )
+                );
+    }
+
+    @Test
+    @DisplayName("중간 지점 경로를 조회한다.")
+    void getMeetingPointRoutes() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+        UUID guestId = StartPointFixture.GUEST_ID;
+
+        Event event = EventFixture.getEventWithRoute();
+        StartPoint startPoint = StartPointFixture.getStartPoint(event, null);
+        List<MeetingPointRouteGroup> meetingPointRouteGroups = event.getRoutes().meetingPointRouteGroups();
+        MeetingPointRoutesResponse response = MeetingPointRoutesResponse.of(event, List.of(startPoint), meetingPointRouteGroups);
+
+        // when
+        Mockito.when(eventService.getMeetingPointRoutes(any(UUID.class), nullable(Long.class), nullable(UUID.class)))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/events/{eventId}", eventId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .queryParam("guestId", guestId.toString())
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andExpect(jsonPath("$.data.eventName").value("모임핑"))
+                .andExpect(jsonPath("$.data.eventDate").value("2025-10-01"))
+                .andExpect(jsonPath("$.data.eventTime").value("10:00"))
+                .andExpect(jsonPath("$.data.eventMaker").value("땡수팟"))
+                .andExpect(jsonPath("$.data.placeName").value("놀숲 건대점"))
+                .andExpect(jsonPath("$.data.peopleCount").value(1))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].subwayId").value(240))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].averageTime").value(0))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].meetingPoint.endStationName").value("논현"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].meetingPoint.endLongitude").value(127.021385))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].meetingPoint.endLatitude").value(37.511108))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse").isArray())
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].isTransit").value(true))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].isMe").value(false))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].id").value("0198c64a-5a06-7095-a692-3c5e1a2c294f"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].nickname").value("김아무개"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].startName").value("강남구 삼성동"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].startLongitude").value(127.043999))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].startLatitude").value(37.510297))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].totalTime").value(10))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].trafficType").value(TrafficType.SUBWAY.name()))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].startExitNo").value("3"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].endExitNo").value("5"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].distance").value(3500.0))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].laneName").value("2"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].startBoardName").value("강남"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].endBoardName").value("교대"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].stationCount").value(2))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].sectionTime").value(10))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations").isArray())
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations[0].index").value(0))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations[0].stationName").value("강남"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations[0].x").value("127.027636"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations[0].y").value("37.497985"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].isTransit").value(false))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingInfo.taxi").value(10000))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingInfo.toll").value(3500))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingInfo.duration").value(30))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingInfo.distance").value(15500))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].name").value("테헤란로/강남대로"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates").isArray())
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates[0].x").value("127.043999"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates[0].y").value("37.510297"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates[2].x").value("127.021385"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates[2].y").value("37.511108"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].parkingLot.name").value("강남대로150길(구)"))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].parkingLot.longitude").value(127.0201132))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].parkingLot.latitude").value(37.5156578))
+                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].parkingLot.distance").value(517.33672526))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("event/get-meeting-point-routes",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Event API")
+                                                .description("중간 지점 경로를 조회한다. (회원 - JWT Token, 비회원 - guestId)")
+                                                .requestHeaders(
+                                                        headerWithName(HttpHeaders.AUTHORIZATION).description("JWT Token").optional()
+                                                )
+                                                .pathParameters(
+                                                        parameterWithName("eventId").description("조회할 이벤트 ID (UUID)")
+                                                )
+                                                .queryParameters(
+                                                        parameterWithName("guestId").description("비회원 ID (UUID)").optional()
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                                        fieldWithPath("data.eventName").type(JsonFieldType.STRING).description("모임 이름"),
+                                                        fieldWithPath("data.eventDate").type(JsonFieldType.STRING).description("모임 날짜 (YYYY-MM-DD)"),
+                                                        fieldWithPath("data.eventTime").type(JsonFieldType.STRING).description("모임 시간 (HH:MM)"),
+                                                        fieldWithPath("data.eventMaker").type(JsonFieldType.STRING).description("모임 생성자"),
+                                                        fieldWithPath("data.placeName").type(JsonFieldType.STRING).description("장소 이름"),
+                                                        fieldWithPath("data.peopleCount").type(JsonFieldType.NUMBER).description("모임 참여자 수"),
+
+                                                        fieldWithPath("data.meetingPointRouteGroups").type(JsonFieldType.ARRAY).description("중간 지점별 경로 그룹 목록"),
+
+                                                        fieldWithPath("data.meetingPointRouteGroups[].subwayId").type(JsonFieldType.NUMBER).description("중간 지점의 지하철 ID"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].averageTime").type(JsonFieldType.NUMBER).description("모든 참여자 출발지로부터의 평균 소요 시간 (분)"),
+
+                                                        fieldWithPath("data.meetingPointRouteGroups[].meetingPoint").type(JsonFieldType.OBJECT).description("중간 지점 정보"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].meetingPoint.endStationName").type(JsonFieldType.STRING).description("중간 지점 이름의 지하철역"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].meetingPoint.endLongitude").type(JsonFieldType.NUMBER).description("중간 지점 경도"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].meetingPoint.endLatitude").type(JsonFieldType.NUMBER).description("중간 지점 위도"),
+
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse").type(JsonFieldType.ARRAY).description("각 참여자의 출발지-중간 지점 경로 정보"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].isTransit").type(JsonFieldType.BOOLEAN).description("대중교통 경로 제공 여부 (false인 경우 자가용)"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].isMe").type(JsonFieldType.BOOLEAN).description("경로 주인이 요청자 본인(guestId 또는 userId 일치)인지 여부"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].id").type(JsonFieldType.STRING).description("출발지 ID"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].userId").type(JsonFieldType.NUMBER).description("출발지 설정한 회원 ID (비회원인 경우 null)").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].guestId").type(JsonFieldType.STRING).description("출발지 설정한 비회원 ID (회원인 경우 null)").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].profileImage").type(JsonFieldType.STRING).description("프로필 이미지 URL").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].startName").type(JsonFieldType.STRING).description("출발지 이름"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].startLongitude").type(JsonFieldType.NUMBER).description("출발지 경도"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].startLatitude").type(JsonFieldType.NUMBER).description("출발지 위도"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].totalTime").type(JsonFieldType.NUMBER).description("총 소요 시간 (분)"),
+
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute").type(JsonFieldType.ARRAY).description("대중교통 경로 상세 정보 (isTransit=true일 때만 제공)").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].trafficType").type(JsonFieldType.STRING).description("교통 수단 ('SUBWAY', 'BUS', 'WALKING)"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].startExitNo").type(JsonFieldType.STRING).description("출발 정거장의 출구 번호").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].endExitNo").type(JsonFieldType.STRING).description("도착 정거장의 출구 번호").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].distance").type(JsonFieldType.NUMBER).description("이동 거리 (m)"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].laneName").type(JsonFieldType.STRING).description("노선 이름"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].startBoardName").type(JsonFieldType.STRING).description("승차 정거장 이름"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].endBoardName").type(JsonFieldType.STRING).description("하차 정거장 이름"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].stationCount").type(JsonFieldType.NUMBER).description("이동 정거장 수"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList").type(JsonFieldType.OBJECT).description("경유 정류장/역 목록").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations").type(JsonFieldType.ARRAY).description("경유 정류장/역 상세 목록").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations[].index").type(JsonFieldType.NUMBER).description("인덱스"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations[].stationName").type(JsonFieldType.STRING).description("역/정류장 이름"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations[].x").type(JsonFieldType.STRING).description("경도"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations[].y").type(JsonFieldType.STRING).description("위도"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].sectionTime").type(JsonFieldType.NUMBER).description("해당 구간 소요 시간 (분)"),
+
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo").type(JsonFieldType.OBJECT).description("자가용 경로 요약 정보 (isTransit=false일 때만 제공)").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo.taxi").type(JsonFieldType.NUMBER).description("예상 택시 요금 (원)"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo.toll").type(JsonFieldType.NUMBER).description("예상 통행료 (원)"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo.duration").type(JsonFieldType.NUMBER).description("총 소요 시간 (초)"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo.distance").type(JsonFieldType.NUMBER).description("총 거리 (m)"),
+
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute").type(JsonFieldType.ARRAY).description("자가용 경로 상세 정보 (isTransit=false일 때만 제공)").optional(),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute[].name").type(JsonFieldType.STRING).description("도로명"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute[].coordinates").type(JsonFieldType.ARRAY).description("경로 좌표 목록"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute[].coordinates[].x").type(JsonFieldType.STRING).description("경도"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute[].coordinates[].y").type(JsonFieldType.STRING).description("위도"),
+
+                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot").type(JsonFieldType.OBJECT).description("중간 지점 근처 주차장 정보"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot.name").type(JsonFieldType.STRING).description("주차장 이름"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot.longitude").type(JsonFieldType.NUMBER).description("주차장 경도"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot.latitude").type(JsonFieldType.NUMBER).description("주차장 위도"),
+                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot.distance").type(JsonFieldType.NUMBER).description("중간 지점으로부터의 거리 (m)"),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .responseSchema(Schema.schema("MeetingPointRoutesResponse"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("모임 장소를 확정 또는 변경한다.")
+    @Test
+    void updatePlace() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+        UpdatePlaceRequest request = EventFixture.getUpdatePlaceRequest();
+
+        // when
+        Mockito.doNothing().when(eventService).updatePlace(any(UUID.class), any(UpdatePlaceRequest.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.patch("/events/{eventId}/place", eventId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("event/update-place",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Event API")
+                                                .description("모임 장소를 확정 또는 변경한다.")
+                                                .pathParameters(
+                                                        parameterWithName("eventId").description("수정할 이벤트 ID (UUID)")
+                                                )
+                                                .requestFields(
+                                                        fieldWithPath("placeId").type(JsonFieldType.STRING).description("장소 ID (UUID)"),
+                                                        fieldWithPath("subwayId").type(JsonFieldType.NUMBER).description("지하철 ID")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .requestSchema(Schema.schema("UpdatePlaceRequest"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("확정된 모임 장소를 취소한다.")
+    @Test
+    void deletePlace() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+
+        // when
+        Mockito.doNothing().when(eventService).deletePlace(any(UUID.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/events/{eventId}/place", eventId)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("event/delete-place",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Event API")
+                                                .description("확정된 모임 장소를 취소한다.")
+                                                .pathParameters(
+                                                        parameterWithName("eventId").description("삭제할 이벤트 ID (UUID)")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .build())
+                        )
+                );
+    }
+}

--- a/src/test/java/com/meetup/server/fixture/EventFixture.java
+++ b/src/test/java/com/meetup/server/fixture/EventFixture.java
@@ -4,9 +4,8 @@ import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.domain.value.MeetingPointRouteGroups;
 import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.request.UpdateEventRequest;
-import com.meetup.server.event.dto.response.route.MeetingPoint;
-import com.meetup.server.event.dto.response.route.MeetingPointRouteGroup;
-import com.meetup.server.event.dto.response.route.RouteResponse;
+import com.meetup.server.event.dto.request.UpdatePlaceRequest;
+import com.meetup.server.event.dto.response.route.*;
 import com.meetup.server.parkinglot.dto.response.ParkingLotResponse;
 
 import java.time.LocalDate;
@@ -17,8 +16,11 @@ import java.util.UUID;
 
 public class EventFixture {
 
+    public static final UUID EVENT_ID = UUID.fromString("01968fe2-5277-712a-ad3c-98f29c2782e0");
+
     public static Event getEvent() {
         return Event.builder()
+                .eventId(EVENT_ID)
                 .eventName("모임핑")
                 .eventDateTime(LocalDateTime.parse("2025-10-01T10:00:00"))
                 .build();
@@ -29,6 +31,13 @@ public class EventFixture {
                 "수정핑",
                 LocalDate.parse("2025-08-01"),
                 LocalTime.parse("12:00")
+        );
+    }
+
+    public static UpdatePlaceRequest getUpdatePlaceRequest() {
+        return new UpdatePlaceRequest(
+                UUID.fromString("0196f346-5244-79b9-85b0-955d6328f09b"),
+                1
         );
     }
 
@@ -52,21 +61,25 @@ public class EventFixture {
                 .eventName("모임핑")
                 .eventDateTime(LocalDateTime.parse("2025-10-01T10:00:00"))
                 .routes(getMeetingPointRouteGroups())
+                .place(PlaceFixture.getPlace())
                 .build();
     }
 
     public static MeetingPointRouteGroups getMeetingPointRouteGroups() {
+        List<TransitRouteResponse> transitRoutes = List.of(RouteFixture.getTransitRoute());
+        DrivingInfoResponse drivingInfo = RouteFixture.getDrivingInfo();
+        List<DrivingRouteResponse> drivingRoutes = List.of(RouteFixture.getDrivingRoute());
 
         List<RouteResponse> routeResponses = List.of(
-                new RouteResponse(false, false, UUID.fromString("0198c64a-5a06-7095-a692-3c5e1a2c294f"),
+                new RouteResponse(true, false, UUID.fromString("0198c64a-5a06-7095-a692-3c5e1a2c294f"),
                         null, UUID.fromString("0198c64a-5a06-7095-a693-c3f8ebde622c"), "김아무개",
-                        null, "강남구 삼성동", 127.043999, 37.510297, null, null, null, 0),
+                        null, "강남구 삼성동", 127.043999, 37.510297, transitRoutes, null, null, 10),
                 new RouteResponse(false, false, UUID.fromString("0198c64b-086a-796d-a4d3-105c89ee529e"),
                         null, UUID.fromString("0198c64b-086a-796d-a4d4-8d44881d2ad7"), "안연아바보",
-                        null, "강남구 삼성동", 127.043999, 37.510297, null, null, null, 0),
+                        null, "강남구 삼성동", 127.043999, 37.510297, null, drivingInfo, drivingRoutes, 0),
                 new RouteResponse(false, false, UUID.fromString("0198c64d-780c-736b-9ba9-589632f5f136"),
                         null, UUID.fromString("0198c64d-780c-736b-9baa-a3f2fe33c325"), "나야나",
-                        null, "동작구 상도동", 126.95781764313084, 37.4963172817574, null, null, null, 0)
+                        null, "동작구 상도동", 126.95781764313084, 37.4963172817574, null, drivingInfo, drivingRoutes, 0)
         );
 
         List<MeetingPointRouteGroup> groups = List.of(

--- a/src/test/java/com/meetup/server/fixture/RouteFixture.java
+++ b/src/test/java/com/meetup/server/fixture/RouteFixture.java
@@ -1,0 +1,54 @@
+package com.meetup.server.fixture;
+
+import com.meetup.server.event.domain.type.TrafficType;
+import com.meetup.server.event.dto.response.route.DrivingInfoResponse;
+import com.meetup.server.event.dto.response.route.DrivingRouteResponse;
+import com.meetup.server.event.dto.response.route.TransitRouteResponse;
+import com.meetup.server.global.util.Coordinate;
+import com.meetup.server.subway.dto.response.PassStopList;
+import com.meetup.server.subway.dto.response.Stations;
+
+import java.util.List;
+
+public class RouteFixture {
+
+    public static TransitRouteResponse getTransitRoute() {
+        Stations station = new Stations(0, "강남", "127.027636", "37.497985");
+        PassStopList passStopList = new PassStopList(List.of(station));
+
+        return TransitRouteResponse.builder()
+                .trafficType(TrafficType.SUBWAY)
+                .startExitNo("3")
+                .endExitNo("5")
+                .distance(3500.0)
+                .laneName("2")
+                .startBoardName("강남")
+                .endBoardName("교대")
+                .stationCount(2)
+                .passStopList(passStopList)
+                .sectionTime(10)
+                .build();
+    }
+
+    public static DrivingInfoResponse getDrivingInfo() {
+        return new DrivingInfoResponse(
+                10000,
+                3500,
+                30,
+                15500
+        );
+    }
+
+    public static DrivingRouteResponse getDrivingRoute() {
+        List<Coordinate> coordinates = List.of(
+                Coordinate.of(127.043999, 37.510297),
+                Coordinate.of(127.030000, 37.515000),
+                Coordinate.of(127.021385, 37.511108)
+        );
+
+        return new DrivingRouteResponse(
+                "테헤란로/강남대로",
+                coordinates
+        );
+    }
+}

--- a/src/test/java/com/meetup/server/fixture/StartPointFixture.java
+++ b/src/test/java/com/meetup/server/fixture/StartPointFixture.java
@@ -8,7 +8,12 @@ import com.meetup.server.startpoint.domain.type.Location;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.user.domain.User;
 
+import java.util.UUID;
+
 public class StartPointFixture {
+
+    public static final UUID START_POINT_ID = UUID.fromString("01968fe2-5277-712a-ad3c-98f29c2782e0");
+    public static final UUID GUEST_ID = UUID.fromString("01968fe2-5277-712a-ad3c-98f29c2782e1");
 
     public static StartPointRequest getStartPointRequest() {
         return new StartPointRequest(
@@ -19,12 +24,16 @@ public class StartPointFixture {
 
     public static StartPoint getStartPoint(Event event, User user) {
         return StartPoint.builder()
+                .startPointId(START_POINT_ID)
                 .event(event)
                 .user(user)
                 .name("선정릉역 수인분당선")
                 .address(Address.of("서울특별시 강남구 삼성동 111-114", "서울특별시 강남구 선릉로 지하580"))
                 .location(Location.of(127.043999, 37.510297))
                 .point(CoordinateUtil.createPoint(127.043999, 37.510297))
+                .isUser(user != null)
+                .guestId(GUEST_ID)
+                .nonUserName("땡수팟")
                 .isTransit(true)
                 .build();
     }

--- a/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
+++ b/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
@@ -74,11 +74,12 @@ class StartPointServiceTest extends IntegrationTestContainer {
         user = userRepository.save(UserFixture.getUser());
         newUser = userRepository.save(UserFixture.getNewUser());
         guestId = UUID.randomUUID();
-        eventWithRoute = eventRepository.save(EventFixture.getEventWithRoute());
+        eventWithRoute = EventFixture.getEventWithRoute();
+        placeRepository.save(eventWithRoute.getPlace());
+        eventWithRoute = eventRepository.save(eventWithRoute);
         meetingPointRouteGroups = EventFixture.getMeetingPointRouteGroups();
         startPoint = startPointRepository.save(StartPointFixture.getStartPoint(eventWithRoute, newUser));
         cachedRouteRepository.save(eventWithRoute.getEventId(), meetingPointRouteGroups);
-        placeRepository.save(eventWithRoute.getPlace());
     }
 
     @Test

--- a/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
+++ b/src/test/java/com/meetup/server/startpoint/application/StartPointServiceTest.java
@@ -9,6 +9,7 @@ import com.meetup.server.event.infrastructure.redis.CachedRouteRepository;
 import com.meetup.server.fixture.EventFixture;
 import com.meetup.server.fixture.StartPointFixture;
 import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.place.infrastructure.jpa.PlaceRepository;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
 import com.meetup.server.startpoint.infrastructure.jpa.StartPointRepository;
@@ -43,6 +44,9 @@ class StartPointServiceTest extends IntegrationTestContainer {
     private UserRepository userRepository;
 
     @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
     private CachedRouteRepository cachedRouteRepository;
 
     @Autowired
@@ -74,9 +78,11 @@ class StartPointServiceTest extends IntegrationTestContainer {
         meetingPointRouteGroups = EventFixture.getMeetingPointRouteGroups();
         startPoint = startPointRepository.save(StartPointFixture.getStartPoint(eventWithRoute, newUser));
         cachedRouteRepository.save(eventWithRoute.getEventId(), meetingPointRouteGroups);
+        placeRepository.save(eventWithRoute.getPlace());
     }
 
     @Test
+    @Transactional
     void 비로그인_사용자가_출발지를_저장한다() {
         EventStartPointResponse eventStartPointResponse = startPointService.createStartPoint(
                 event.getEventId(),
@@ -95,8 +101,8 @@ class StartPointServiceTest extends IntegrationTestContainer {
         assertThat(optionalStartPoint.get().isTransit()).isEqualTo(startPointRequest.isTransit());
     }
 
-    @Transactional
     @Test
+    @Transactional
     void 로그인_사용자가_출발지를_저장한다() {
         EventStartPointResponse eventStartPointResponse = startPointService.createStartPoint(
                 event.getEventId(),
@@ -131,6 +137,7 @@ class StartPointServiceTest extends IntegrationTestContainer {
     }
 
     @Test
+    @Transactional
     void 출발지_생성_후_캐시와_모임경로데이터_삭제_검증() {
         // given
         Cache cache = cacheManager.getCache("routeDetails");
@@ -143,6 +150,9 @@ class StartPointServiceTest extends IntegrationTestContainer {
                 null,
                 startPointRequest
         );
+
+        entityManager.flush();
+        entityManager.clear();
 
         //then
         assertThat(eventReader.read(eventWithRoute.getEventId()).getRoutes()).isNull();

--- a/src/test/java/com/meetup/server/support/ControllerTestSupport.java
+++ b/src/test/java/com/meetup/server/support/ControllerTestSupport.java
@@ -1,0 +1,37 @@
+package com.meetup.server.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class ControllerTestSupport extends IntegrationTestContainer {
+
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp(WebApplicationContext applicationContext, RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(applicationContext)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentation))
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .alwaysDo(print())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- Swagger를 이용한 문서 작성 시, 애노테이션과 예시 값 작성을 누락할 때가 많았습니다.
- Swagger와 달리 Spring REST Docs는 소스코드에 문서 작성에 필요한 코드가 침투하지 않고, 테스트를 필수로 작성해야만 문서를 만들어줌으로 이점이 많습니다.
- Swagger의 문서 가독성 및 API Test와 Spring REST Docs의 테스트 강제 및 운영 코드에 침투하지 않는 양 이점을 통합하여 API 문서를 만들도록 변경했습니다.

## ✅ What - 무엇이 변경됐나요?

- OpenAPI Specification 및 Spring REST Docs 의존성을 추가했습니다. 또한 빌드 시 openapi3.json이 생성하도록 task 추가했습니다.
- 운영 코드에 침투했던 스웨거 애노테이션 제거 및 openapi3를 가지고 Swagger와 통합하도록 SwaggerConfig 수정했습니다.
- ControllerTestSupport를 만들어 Controller Test에서 REST Docs와 API Test를 Mocking할 수 있도록 하였습니다.

## 🛠️ How - 어떻게 해결했나요?

## 🖼️ Attachment

<img width="1435" height="395" alt="스크린샷 2025-10-28 오후 8 21 20" src="https://github.com/user-attachments/assets/24e0f539-cb51-4162-b627-4408dc82a00f" />
<img width="1391" height="890" alt="스크린샷 2025-10-28 오후 8 21 52" src="https://github.com/user-attachments/assets/26dbe485-a606-4ebf-8e19-70f6d565dca3" />


## 💬 기타 코멘트

- openapi3.json이 생성된 이후 Spring Application이 실행되어야 합니다.
  - `./gradlew clean build`를 하여 `static/swagger-ui/openapi3.json` 파일이 생성됨을 확인 후 Spring Application을 run하면 됩니다.

- EventController의 테스트를 만들었습니다. API가 6개라서 테스트 코드는 많지만, 대부분 유사한 코드이며 HTTP Method 또한 전부 포함하고 있기 때문에 이 테스트를 템플릿과 같이 참고하여 테스트 작성하면 좋을 거 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * OpenAPI 기반 내장 명세 로딩과 자동 문서 생성 도입 및 Bearer 인증 스키마 통합

* **테스트**
  * 이벤트/출발지 관련 테스트·컨트롤러 테스트 확충 및 테스트 픽스처·헬퍼 추가
  * MockMvc 기반 테스트 지원 유틸리티 및 테스트 데이터/거래 경계 정리

* **Chores**
  * CI 빌드에 클린 빌드 및 테스트 실행 추가
  * 빌드 과정에서 API 명세를 산출물에 포함하도록 배포 흐름 개선

* **기타**
  * API 문서용 어노테이션 정리 및 문서 생성 흐름 단순화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->