### PR TITLE
[MOISAM-240] 출발지 추가 처리 중 동일 사용자의 중복 요청을 방지하기

### DIFF
--- a/src/main/java/com/meetup/server/event/domain/value/ParticipantKey.java
+++ b/src/main/java/com/meetup/server/event/domain/value/ParticipantKey.java
@@ -1,0 +1,13 @@
+package com.meetup.server.event.domain.value;
+
+import java.util.UUID;
+
+public record ParticipantKey(Long userId, UUID guestId) {
+    public static ParticipantKey ofUser(Long userId) {
+        return new ParticipantKey(userId, null);
+    }
+
+    public static ParticipantKey ofGuest(UUID guestId) {
+        return new ParticipantKey(null, guestId);
+    }
+}

--- a/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/EventStartPointResponse.java
@@ -22,4 +22,8 @@ public record EventStartPointResponse(
                 .username(UsernameExtractor.extractDisplayName(startPoint))
                 .build();
     }
+
+    public static EventStartPointResponse ignored(Event event) {
+        return new EventStartPointResponse(event.getEventId(), null, null, null);
+    }
 }

--- a/src/main/java/com/meetup/server/event/implement/EventLockManager.java
+++ b/src/main/java/com/meetup/server/event/implement/EventLockManager.java
@@ -1,6 +1,5 @@
 package com.meetup.server.event.implement;
 
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -10,7 +9,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
 @Slf4j
-@Getter
 @Component
 public class EventLockManager {
     private final ConcurrentHashMap<UUID, ReentrantLock> eventLocks = new ConcurrentHashMap<>();
@@ -20,11 +18,12 @@ public class EventLockManager {
         return eventLocks.computeIfAbsent(eventId, key -> new ReentrantLock());
     }
 
-    public void markParticipantInProcess(UUID eventId, Object participantId) {
-        participantLocks
+    public boolean markParticipantInProcess(UUID eventId, Object participantId) {
+        log.debug("[EVENT LOCK] mark participant lock , eventId: {}, participantId: {}", eventId, participantId);
+
+        return participantLocks
                 .computeIfAbsent(eventId, key -> ConcurrentHashMap.newKeySet())
                 .add(participantId);
-        log.debug("[EVENT LOCK] mark participant lock , eventId: {}, participantId: {}", eventId, participantId);
     }
 
     public void removeParticipantInProcess(UUID eventId, Object participantId) {

--- a/src/main/java/com/meetup/server/event/implement/EventLockManager.java
+++ b/src/main/java/com/meetup/server/event/implement/EventLockManager.java
@@ -1,16 +1,37 @@
 package com.meetup.server.event.implement;
 
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
+@Slf4j
+@Getter
 @Component
 public class EventLockManager {
     private final ConcurrentHashMap<UUID, ReentrantLock> eventLocks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, Set<Object>> participantLocks = new ConcurrentHashMap<>();
 
     public ReentrantLock getLock(UUID eventId) {
-        return eventLocks.computeIfAbsent(eventId, k -> new ReentrantLock());
+        return eventLocks.computeIfAbsent(eventId, key -> new ReentrantLock());
+    }
+
+    public void markParticipantInProcess(UUID eventId, Object participantId) {
+        participantLocks
+                .computeIfAbsent(eventId, key -> ConcurrentHashMap.newKeySet())
+                .add(participantId);
+        log.debug("[EVENT LOCK] mark participant lock , eventId: {}, participantId: {}", eventId, participantId);
+    }
+
+    public void removeParticipantInProcess(UUID eventId, Object participantId) {
+        participantLocks
+                .computeIfAbsent(eventId, key -> ConcurrentHashMap.newKeySet())
+                .remove(participantId);
+
+        log.debug("[EVENT LOCK] remove participant lock , eventId: {}, participantId: {}", eventId, participantId);
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/EventLockManager.java
+++ b/src/main/java/com/meetup/server/event/implement/EventLockManager.java
@@ -1,5 +1,6 @@
 package com.meetup.server.event.implement;
 
+import com.meetup.server.event.domain.value.ParticipantKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -12,13 +13,13 @@ import java.util.concurrent.locks.ReentrantLock;
 @Component
 public class EventLockManager {
     private final ConcurrentHashMap<UUID, ReentrantLock> eventLocks = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<UUID, Set<Object>> participantLocks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, Set<ParticipantKey>> participantLocks = new ConcurrentHashMap<>();
 
     public ReentrantLock getLock(UUID eventId) {
         return eventLocks.computeIfAbsent(eventId, key -> new ReentrantLock());
     }
 
-    public boolean markParticipantInProcess(UUID eventId, Object participantId) {
+    public boolean markParticipantInProcess(UUID eventId, ParticipantKey participantId) {
         log.debug("[EVENT LOCK] mark participant lock , eventId: {}, participantId: {}", eventId, participantId);
 
         return participantLocks
@@ -26,7 +27,7 @@ public class EventLockManager {
                 .add(participantId);
     }
 
-    public void removeParticipantInProcess(UUID eventId, Object participantId) {
+    public void removeParticipantInProcess(UUID eventId, ParticipantKey participantId) {
         participantLocks
                 .computeIfAbsent(eventId, key -> ConcurrentHashMap.newKeySet())
                 .remove(participantId);

--- a/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
+++ b/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
@@ -50,9 +50,12 @@ public class StartPointService {
 
         lock.lock();
         try {
-            eventLockManager.markParticipantInProcess(eventId, participantId);
-
             event = eventReader.read(eventId);
+
+            if (!eventLockManager.markParticipantInProcess(eventId, participantId)) {
+               return EventStartPointResponse.ignored(event);
+            }
+
             List<StartPoint> startPointList = startPointReader.readAll(event);
 
             eventValidator.validateEventIsNotFull(event);

--- a/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
+++ b/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
@@ -42,12 +42,16 @@ public class StartPointService {
     @Performance
     @Transactional
     public EventStartPointResponse createStartPoint(UUID eventId, Long userId, UUID guestId, StartPointRequest startPointRequest) {
-        ReentrantLock lock = eventLockManager.getLock(eventId);
+        Object participantId = userId != null ? userId : guestId;
         StartPoint startPoint;
         Event event;
 
+        ReentrantLock lock = eventLockManager.getLock(eventId);
+
         lock.lock();
         try {
+            eventLockManager.markParticipantInProcess(eventId, participantId);
+
             event = eventReader.read(eventId);
             List<StartPoint> startPointList = startPointReader.readAll(event);
 
@@ -69,6 +73,7 @@ public class StartPointService {
 
             return EventStartPointResponse.of(event, startPoint);
         } finally {
+            eventLockManager.removeParticipantInProcess(eventId, participantId);
             lock.unlock();
         }
     }

--- a/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
+++ b/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
@@ -1,6 +1,7 @@
 package com.meetup.server.startpoint.application;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.domain.value.ParticipantKey;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.implement.EventLockManager;
 import com.meetup.server.event.implement.EventProcessor;
@@ -42,7 +43,7 @@ public class StartPointService {
     @Performance
     @Transactional
     public EventStartPointResponse createStartPoint(UUID eventId, Long userId, UUID guestId, StartPointRequest startPointRequest) {
-        Object participantId = userId != null ? userId : guestId;
+        ParticipantKey participantId = userId != null ? ParticipantKey.ofUser(userId) : ParticipantKey.ofGuest(guestId);
         StartPoint startPoint;
         Event event;
 


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 출발지 추가 처리 대기 사용자가 버튼을 중복해서 누를 경우 동일 출발지가 중복해서 반영되는 문제가 있었습니다.

## ✅ What - 무엇이 변경됐나요?

- `EventLockManager` 에서 사용자 단위로 중복을 제거하는 과정을 추가했습니다.

## 🛠️ How - 어떻게 해결했나요?

- `concurrentHashMap` 에 `Set` 을 활용해 중복을 제거했습니다.
- 해당 event 내의 `guestId` 혹은 `usetId` 를 통해 동일 사용자인지 확인했습니다.
- 처리 이후 사용자가 출발지 추가를 진행할 수도 있기에 lock 을 해제하기 직전 `finally` 부분에서 `concurrentHashMap`에 추가했던 객체를 삭제하여 중복이 아닌 경우인데도 추가가 되지 않는 문제를 예방했습니다.

## 🖼️ Attachment

- `화면 이미지, 결과 캡처 등 첨부`

## 💬 기타 코멘트

- `리뷰어에게 전하고 싶은 말, 테스트 방법, 주의할 점 등`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이벤트 단위가 아닌 참가자 단위 추적 도입으로 동시성 제어 개선
  * 참가자별 진행 상태 표시(등록 중인 참가자 관리) 및 종료 시 정리 기능 추가
  * 참가 신청 시 중복 처리 방지: 이미 처리 중인 참가자는 무시 응답 반환
  * 참가자 식별 방식 확장으로 사용자/게스트 구분 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->