### PR TITLE
[MOISAM-241] 지도 조회 응답을 gzip 포맷으로 압축한다

### DIFF
--- a/src/main/java/com/meetup/server/global/filter/CompressFilter.java
+++ b/src/main/java/com/meetup/server/global/filter/CompressFilter.java
@@ -1,0 +1,54 @@
+package com.meetup.server.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Component
+public class CompressFilter extends OncePerRequestFilter {
+
+    private static final List<Pattern> ALLOWED_COMPRESS_ENDPOINT_PATTERNS = List.of(
+            Pattern.compile("^/events/[^/]+$")
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (!shouldCompress(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        GzipHttpServletResponseWrapper gzipResponse = new GzipHttpServletResponseWrapper(response);
+        try {
+            filterChain.doFilter(request, gzipResponse);
+        } finally {
+            gzipResponse.finish();
+        }
+    }
+
+    private boolean shouldCompress(HttpServletRequest request) {
+        String acceptEncoding = request.getHeader(HttpHeaders.ACCEPT_ENCODING);
+        String uri = request.getRequestURI();
+        String method = request.getMethod();
+
+        boolean isGet = "GET".equalsIgnoreCase(method);
+
+        return acceptEncoding != null
+                && acceptEncoding.contains("gzip")
+                && isGet
+                && matchesAllowedUri(uri);
+    }
+
+    private boolean matchesAllowedUri(String uri) {
+        return ALLOWED_COMPRESS_ENDPOINT_PATTERNS.stream()
+                .anyMatch(pattern -> pattern.matcher(uri).matches());
+    }
+}

--- a/src/main/java/com/meetup/server/global/filter/CompressFilter.java
+++ b/src/main/java/com/meetup/server/global/filter/CompressFilter.java
@@ -5,12 +5,15 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import static com.meetup.server.global.filter.GzipHttpServletResponseWrapper.GZIP;
 
 @Component
 public class CompressFilter extends OncePerRequestFilter {
@@ -39,10 +42,10 @@ public class CompressFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
         String method = request.getMethod();
 
-        boolean isGet = "GET".equalsIgnoreCase(method);
+        boolean isGet = HttpMethod.GET.name().equalsIgnoreCase(method);
 
         return acceptEncoding != null
-                && acceptEncoding.contains("gzip")
+                && acceptEncoding.contains(GZIP)
                 && isGet
                 && matchesAllowedUri(uri);
     }

--- a/src/main/java/com/meetup/server/global/filter/GzipHttpServletResponseWrapper.java
+++ b/src/main/java/com/meetup/server/global/filter/GzipHttpServletResponseWrapper.java
@@ -9,26 +9,28 @@ import java.io.IOException;
 
 public class GzipHttpServletResponseWrapper extends HttpServletResponseWrapper {
 
-    private GzipServletOutputStream gzipOutputStream;
+    public static final String GZIP = "gzip";
+
+    private GzipServletOutputStream gzipServletOutputStream;
 
     public GzipHttpServletResponseWrapper(HttpServletResponse response) {
         super(response);
-        response.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
+        response.addHeader(HttpHeaders.CONTENT_ENCODING, GZIP);
         response.addHeader(HttpHeaders.VARY, HttpHeaders.ACCEPT_ENCODING);
     }
 
     @Override
     public ServletOutputStream getOutputStream() throws IOException {
-        if (gzipOutputStream == null) {
-            gzipOutputStream = new GzipServletOutputStream(getResponse().getOutputStream());
+        if (gzipServletOutputStream == null) {
+            gzipServletOutputStream = new GzipServletOutputStream(getResponse().getOutputStream());
         }
-        return gzipOutputStream;
+        return gzipServletOutputStream;
     }
 
     public void finish() throws IOException {
-        if (gzipOutputStream != null) {
-            gzipOutputStream.flush();
-            gzipOutputStream.close();
+        if (gzipServletOutputStream != null) {
+            gzipServletOutputStream.flush();
+            gzipServletOutputStream.close();
         }
     }
 }

--- a/src/main/java/com/meetup/server/global/filter/GzipHttpServletResponseWrapper.java
+++ b/src/main/java/com/meetup/server/global/filter/GzipHttpServletResponseWrapper.java
@@ -1,0 +1,33 @@
+package com.meetup.server.global.filter;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+import org.springframework.http.HttpHeaders;
+
+import java.io.IOException;
+
+public class GzipHttpServletResponseWrapper extends HttpServletResponseWrapper {
+
+    private GzipServletOutputStream gzipOutputStream;
+
+    public GzipHttpServletResponseWrapper(HttpServletResponse response) {
+        super(response);
+        response.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        if (gzipOutputStream == null) {
+            gzipOutputStream = new GzipServletOutputStream(getResponse().getOutputStream());
+        }
+        return gzipOutputStream;
+    }
+
+    public void finish() throws IOException {
+        if (gzipOutputStream != null) {
+            gzipOutputStream.flush();
+            gzipOutputStream.close();
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/global/filter/GzipHttpServletResponseWrapper.java
+++ b/src/main/java/com/meetup/server/global/filter/GzipHttpServletResponseWrapper.java
@@ -14,6 +14,7 @@ public class GzipHttpServletResponseWrapper extends HttpServletResponseWrapper {
     public GzipHttpServletResponseWrapper(HttpServletResponse response) {
         super(response);
         response.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
+        response.addHeader(HttpHeaders.VARY, HttpHeaders.ACCEPT_ENCODING);
     }
 
     @Override

--- a/src/main/java/com/meetup/server/global/filter/GzipServletOutputStream.java
+++ b/src/main/java/com/meetup/server/global/filter/GzipServletOutputStream.java
@@ -36,7 +36,6 @@ public class GzipServletOutputStream extends ServletOutputStream {
 
     @Override
     public void close() throws IOException {
-        gzipOutputStream.finish();
         gzipOutputStream.close();
     }
 }

--- a/src/main/java/com/meetup/server/global/filter/GzipServletOutputStream.java
+++ b/src/main/java/com/meetup/server/global/filter/GzipServletOutputStream.java
@@ -1,0 +1,42 @@
+package com.meetup.server.global.filter;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class GzipServletOutputStream extends ServletOutputStream {
+
+    private final GZIPOutputStream gzipOutputStream;
+
+    public GzipServletOutputStream(OutputStream outputStream) throws IOException {
+        this.gzipOutputStream = new GZIPOutputStream(outputStream);
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        gzipOutputStream.write(b);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        gzipOutputStream.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        gzipOutputStream.finish();
+        gzipOutputStream.close();
+    }
+}


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 외부 API를 통해 경로를 취합해 응답을 만드는 시간은 멀티 스레드를 사용해 개선하였으나, 지도 응답은 전송 데이터의 크기가 커서 데이터 전송 시간이 오래 걸리는 문제가 있습니다.
- 전송 데이터의 크기를 gzip 포맷으로 압축하여 데이터 전송 시간을 줄이도록 변경했습니다.

## ✅ What - 무엇이 변경됐나요?

- 지도 조회 API만 gzip 포맷으로 압축했습니다. 필터에서 처리하도록 구현했습니다.

## 🛠️ How - 어떻게 해결했나요?

- java.util.zip의 GzipOutputStream을 OutputStream으로 사용하여 응답 데이터를 압축했습니다.

## 🖼️ Attachment

### 출발지 8개 기준

`압축 전`
<img width="1623" height="817" alt="스크린샷 2025-11-07 오후 4 45 21" src="https://github.com/user-attachments/assets/c6c69c4b-1dd2-4bef-a4b4-e796d44fc141" />

`압축 후`
<img width="1626" height="773" alt="스크린샷 2025-11-07 오후 4 43 11" src="https://github.com/user-attachments/assets/e9b28964-b80a-48cb-996f-2a3076dbeafb" />

## 💬 기타 코멘트

- Traefik(Ingress Controller)에서 처리할 수 있으나, 특정 경로에서의 처리가 불가능하여 필터에서 처리하도록 구현했습니다.
  - 압축 과정에서 CPU 자원이 소모되어 응답 데이터가 큰 지도 조회에서만 적용하는게 나을 거라 판단했습니다.
- gzip보다 압축률이 좋은 Brotli를 적용하려 했지만, Brotli는 의존성을 추가로 설치해야 하고 MacOS, ARM에서 동작이 안돼서 로컬에서 동작이 불가피했습니다. 그래서 공식으로 제공하는 gzip을 적용했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이벤트 상세 API(/events/{id})에 대해 클라이언트가 gzip 수신을 허용하는 GET 요청에 한해 서버 응답을 자동으로 gzip 압축합니다. 전송 데이터 크기 감소로 페이지 로딩 속도 및 대역폭 효율성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->