### PR TITLE
[MOISAM-243] 회원가입, 로그인, 이벤트 조회 기능의 어드민 페이지를 구현한다

### DIFF
--- a/src/main/java/com/meetup/server/admin/application/AdminDetailsService.java
+++ b/src/main/java/com/meetup/server/admin/application/AdminDetailsService.java
@@ -1,0 +1,34 @@
+package com.meetup.server.admin.application;
+
+import com.meetup.server.admin.domain.Admin;
+import com.meetup.server.admin.implement.AdminReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDetailsService implements UserDetailsService {
+
+    private final AdminReader adminReader;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Admin admin = adminReader.readByUsername(username);
+
+        switch (admin.getRole()) {
+            case ADMIN_PENDING -> throw new DisabledException("승인 대기 중인 계정입니다.");
+            case ADMIN_REJECTED -> throw new DisabledException("승인이 거부된 계정입니다.");
+        }
+
+        return User.builder()
+                .username(admin.getUsername())
+                .password(admin.getPassword())
+                .roles(admin.getRole().name())
+                .build();
+    }
+}

--- a/src/main/java/com/meetup/server/admin/application/AdminService.java
+++ b/src/main/java/com/meetup/server/admin/application/AdminService.java
@@ -1,0 +1,64 @@
+package com.meetup.server.admin.application;
+
+import com.meetup.server.admin.dto.request.AdminRegisterRequest;
+import com.meetup.server.admin.dto.response.AdminEventResponse;
+import com.meetup.server.admin.implement.AdminWriter;
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.implement.EventReader;
+import com.meetup.server.startpoint.implement.StartPointReader;
+import com.meetup.server.startpoint.infrastructure.querydsl.projection.ParticipantCount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminService {
+
+    private final AdminWriter adminWriter;
+    private final EventReader eventReader;
+    private final StartPointReader startPointReader;
+
+    @Transactional
+    public void register(AdminRegisterRequest request) {
+        adminWriter.save(request.name(), request.username(), request.password());
+    }
+
+    public Page<AdminEventResponse> getAllEvents(Pageable pageable) {
+        Page<Event> events = eventReader.readAll(pageable);
+
+        List<UUID> eventIds = events.stream()
+                .map(Event::getEventId)
+                .toList();
+
+        List<ParticipantCount> participantCounts = startPointReader.readParticipantCounts(eventIds);
+
+        Map<UUID, Integer> eventParticipantCountMap = participantCounts.stream()
+                .collect(Collectors.toMap(
+                        ParticipantCount::eventId,
+                        participant -> participant.count().intValue()
+                ));
+
+        List<AdminEventResponse> adminEventResponses = events.getContent().stream()
+                .map(event -> {
+                    int count = eventParticipantCountMap.getOrDefault(event.getEventId(), 0);
+                    return AdminEventResponse.of(event, count);
+                })
+                .toList();
+
+        return new PageImpl<>(
+                adminEventResponses,
+                pageable,
+                events.getTotalElements()
+        );
+    }
+}

--- a/src/main/java/com/meetup/server/admin/application/AdminService.java
+++ b/src/main/java/com/meetup/server/admin/application/AdminService.java
@@ -2,6 +2,7 @@ package com.meetup.server.admin.application;
 
 import com.meetup.server.admin.dto.request.AdminRegisterRequest;
 import com.meetup.server.admin.dto.response.AdminEventResponse;
+import com.meetup.server.admin.implement.AdminValidator;
 import com.meetup.server.admin.implement.AdminWriter;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.implement.EventReader;
@@ -24,12 +25,14 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class AdminService {
 
+    private final AdminValidator adminValidator;
     private final AdminWriter adminWriter;
     private final EventReader eventReader;
     private final StartPointReader startPointReader;
 
     @Transactional
     public void register(AdminRegisterRequest request) {
+        adminValidator.validateAdminNotAlreadyExists(request.username());
         adminWriter.save(request.name(), request.username(), request.password());
     }
 

--- a/src/main/java/com/meetup/server/admin/domain/Admin.java
+++ b/src/main/java/com/meetup/server/admin/domain/Admin.java
@@ -1,0 +1,42 @@
+package com.meetup.server.admin.domain;
+
+import com.meetup.server.global.domain.BaseEntity;
+import com.meetup.server.user.domain.type.Role;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "admin")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Admin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_id", nullable = false)
+    private Long adminId;
+
+    @Column(name = "name", nullable = false, length = 10)
+    private String name;
+
+    @Column(name = "username", nullable = false, length = 20, unique = true)
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", length = 20, nullable = false)
+    private Role role;
+
+    @Builder
+    public Admin(String name, String username, String password, Role role) {
+        this.name = name;
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/meetup/server/admin/dto/request/AdminLoginRequest.java
+++ b/src/main/java/com/meetup/server/admin/dto/request/AdminLoginRequest.java
@@ -1,0 +1,15 @@
+package com.meetup.server.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminLoginRequest(
+        @NotBlank(message = "아이디를 입력해주세요.")
+        @Size(min = 4, max = 20, message = "아이디는 4자 이상 20자 이하여야 합니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Size(min = 8, max = 30, message = "비밀번호는 8자 이상 30자 이하여야 합니다.")
+        String password
+) {
+}

--- a/src/main/java/com/meetup/server/admin/dto/request/AdminRegisterRequest.java
+++ b/src/main/java/com/meetup/server/admin/dto/request/AdminRegisterRequest.java
@@ -25,4 +25,9 @@ public record AdminRegisterRequest(
     public boolean isPasswordConfirmed() {
         return password.equals(confirmPassword);
     }
+
+    @AssertTrue(message = "비밀번호는 공백으로 시작하거나 끝날 수 없습니다.")
+    public boolean isPasswordNotTrim() {
+        return this.password.equals(this.password.trim());
+    }
 }

--- a/src/main/java/com/meetup/server/admin/dto/request/AdminRegisterRequest.java
+++ b/src/main/java/com/meetup/server/admin/dto/request/AdminRegisterRequest.java
@@ -1,0 +1,28 @@
+package com.meetup.server.admin.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminRegisterRequest(
+        @NotBlank(message = "이름을 입력해주세요.")
+        @Size(min = 1, max = 10, message = "이름은 1자 이상 10자 이하여야 합니다.")
+        String name,
+
+        @NotBlank(message = "아이디를 입력해주세요.")
+        @Size(min = 4, max = 20, message = "아이디는 4자 이상 20자 이하여야 합니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Size(min = 8, max = 30, message = "비밀번호는 8자 이상 30자 이하여야 합니다.")
+        String password,
+
+        @NotBlank(message = "비밀번호 확인을 입력해주세요.")
+        @Size(min = 8, max = 30, message = "비밀번호는 8자 이상 30자 이하여야 합니다.")
+        String confirmPassword
+) {
+    @AssertTrue(message = "비밀번호가 일치하지 않습니다.")
+    public boolean isPasswordConfirmed() {
+        return password.equals(confirmPassword);
+    }
+}

--- a/src/main/java/com/meetup/server/admin/dto/request/AdminRegisterRequest.java
+++ b/src/main/java/com/meetup/server/admin/dto/request/AdminRegisterRequest.java
@@ -23,11 +23,17 @@ public record AdminRegisterRequest(
 ) {
     @AssertTrue(message = "비밀번호가 일치하지 않습니다.")
     public boolean isPasswordConfirmed() {
+        if (password == null || confirmPassword == null) {
+            return true;
+        }
         return password.equals(confirmPassword);
     }
 
     @AssertTrue(message = "비밀번호는 공백으로 시작하거나 끝날 수 없습니다.")
     public boolean isPasswordNotTrim() {
-        return this.password.equals(this.password.trim());
+        if (password == null) {
+            return true;
+        }
+        return password.equals(password.trim());
     }
 }

--- a/src/main/java/com/meetup/server/admin/dto/response/AdminEventResponse.java
+++ b/src/main/java/com/meetup/server/admin/dto/response/AdminEventResponse.java
@@ -1,0 +1,31 @@
+package com.meetup.server.admin.dto.response;
+
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.place.domain.Place;
+import com.meetup.server.subway.domain.Subway;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+public record AdminEventResponse(
+        UUID eventId,
+        String eventName,
+        LocalDateTime eventDateTime,
+        String meetingPoint,
+        String meetingPlace,
+        int participantCount,
+        LocalDateTime createdDateTime
+) {
+    public static AdminEventResponse of(Event event, int participantCount) {
+        return new AdminEventResponse(
+                event.getEventId(),
+                event.getEventName(),
+                event.getEventDateTime(),
+                Optional.ofNullable(event.getSubway()).map(Subway::getName).orElse(null),
+                Optional.ofNullable(event.getPlace()).map(Place::getName).orElse(null),
+                participantCount,
+                event.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/meetup/server/admin/exception/AdminErrorType.java
+++ b/src/main/java/com/meetup/server/admin/exception/AdminErrorType.java
@@ -1,0 +1,17 @@
+package com.meetup.server.admin.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminErrorType implements ErrorType {
+    ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+
+    private final String message;
+}

--- a/src/main/java/com/meetup/server/admin/exception/AdminErrorType.java
+++ b/src/main/java/com/meetup/server/admin/exception/AdminErrorType.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AdminErrorType implements ErrorType {
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자를 찾을 수 없습니다."),
+    ADMIN_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 등록된 관리자입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/admin/exception/AdminException.java
+++ b/src/main/java/com/meetup/server/admin/exception/AdminException.java
@@ -1,0 +1,11 @@
+package com.meetup.server.admin.exception;
+
+import com.meetup.server.global.support.error.ErrorType;
+import com.meetup.server.global.support.error.GlobalException;
+
+public class AdminException extends GlobalException {
+
+    public AdminException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/meetup/server/admin/implement/AdminReader.java
+++ b/src/main/java/com/meetup/server/admin/implement/AdminReader.java
@@ -1,0 +1,22 @@
+package com.meetup.server.admin.implement;
+
+import com.meetup.server.admin.domain.Admin;
+import com.meetup.server.admin.exception.AdminErrorType;
+import com.meetup.server.admin.exception.AdminException;
+import com.meetup.server.admin.infrastructure.jpa.AdminRepository;
+import com.meetup.server.user.domain.type.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminReader {
+
+    private final AdminRepository adminRepository;
+
+    public Admin readByUsername(String username) {
+        return adminRepository.findByUsername(username)
+                .orElseThrow(() -> new AdminException(AdminErrorType.ADMIN_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/meetup/server/admin/implement/AdminValidator.java
+++ b/src/main/java/com/meetup/server/admin/implement/AdminValidator.java
@@ -1,0 +1,20 @@
+package com.meetup.server.admin.implement;
+
+import com.meetup.server.admin.exception.AdminErrorType;
+import com.meetup.server.admin.exception.AdminException;
+import com.meetup.server.admin.infrastructure.jpa.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminValidator {
+
+    private final AdminRepository adminRepository;
+
+    public void validateAdminNotAlreadyExists(String username) {
+        if (adminRepository.existsByUsername(username)) {
+            throw new AdminException(AdminErrorType.ADMIN_ALREADY_EXISTS);
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/admin/implement/AdminWriter.java
+++ b/src/main/java/com/meetup/server/admin/implement/AdminWriter.java
@@ -1,0 +1,29 @@
+package com.meetup.server.admin.implement;
+
+import com.meetup.server.admin.domain.Admin;
+import com.meetup.server.admin.infrastructure.jpa.AdminRepository;
+import com.meetup.server.user.domain.type.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminWriter {
+
+    private final PasswordEncoder passwordEncoder;
+    private final AdminRepository adminRepository;
+
+    public void save(String name, String username, String password) {
+        String encodedPassword = passwordEncoder.encode(password);
+
+        Admin admin = Admin.builder()
+                .name(name)
+                .username(username)
+                .password(encodedPassword)
+                .role(Role.ADMIN_PENDING)
+                .build();
+
+        adminRepository.save(admin);
+    }
+}

--- a/src/main/java/com/meetup/server/admin/infrastructure/jpa/AdminRepository.java
+++ b/src/main/java/com/meetup/server/admin/infrastructure/jpa/AdminRepository.java
@@ -1,0 +1,11 @@
+package com.meetup.server.admin.infrastructure.jpa;
+
+import com.meetup.server.admin.domain.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByUsername(String username);
+}

--- a/src/main/java/com/meetup/server/admin/infrastructure/jpa/AdminRepository.java
+++ b/src/main/java/com/meetup/server/admin/infrastructure/jpa/AdminRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface AdminRepository extends JpaRepository<Admin, Long> {
 
     Optional<Admin> findByUsername(String username);
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/meetup/server/admin/presentation/AdminController.java
+++ b/src/main/java/com/meetup/server/admin/presentation/AdminController.java
@@ -24,8 +24,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/admins")
 public class AdminController {
 
-    @Value("${server-url}")
-    private String serverUrl;
+    @Value("${client-url}")
+    private String clientUrl;
 
     private final AdminService adminService;
 
@@ -57,11 +57,11 @@ public class AdminController {
     @GetMapping("/events")
     public String getAllEvents(
             Model model,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<AdminEventResponse> eventPages = adminService.getAllEvents(pageable);
         model.addAttribute("eventPages", eventPages);
-        model.addAttribute("serverUrl", serverUrl);
+        model.addAttribute("clientUrl", clientUrl);
         return "admin/events";
     }
 }

--- a/src/main/java/com/meetup/server/admin/presentation/AdminController.java
+++ b/src/main/java/com/meetup/server/admin/presentation/AdminController.java
@@ -4,6 +4,8 @@ import com.meetup.server.admin.application.AdminService;
 import com.meetup.server.admin.dto.request.AdminLoginRequest;
 import com.meetup.server.admin.dto.request.AdminRegisterRequest;
 import com.meetup.server.admin.dto.response.AdminEventResponse;
+import com.meetup.server.admin.exception.AdminErrorType;
+import com.meetup.server.admin.exception.AdminException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,7 +46,16 @@ public class AdminController {
             return "admin/register";
         }
 
-        adminService.register(adminRegisterRequest);
+        try {
+            adminService.register(adminRegisterRequest);
+        } catch (AdminException e) {
+            if (e.getErrorType() == AdminErrorType.ADMIN_ALREADY_EXISTS) {
+                bindingResult.rejectValue("username", "AdminAlreadyExists", e.getMessage());
+            }
+            return "admin/register";
+        } catch (Exception e) {
+            bindingResult.reject("InternalServerError", "회원가입 중 오류가 발생했습니다.");
+        }
         return "redirect:/admins/login";
     }
 

--- a/src/main/java/com/meetup/server/admin/presentation/AdminController.java
+++ b/src/main/java/com/meetup/server/admin/presentation/AdminController.java
@@ -1,0 +1,67 @@
+package com.meetup.server.admin.presentation;
+
+import com.meetup.server.admin.application.AdminService;
+import com.meetup.server.admin.dto.request.AdminLoginRequest;
+import com.meetup.server.admin.dto.request.AdminRegisterRequest;
+import com.meetup.server.admin.dto.response.AdminEventResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admins")
+public class AdminController {
+
+    @Value("${server-url}")
+    private String serverUrl;
+
+    private final AdminService adminService;
+
+    @GetMapping("/register")
+    public String registerForm(Model model) {
+        model.addAttribute("adminRegisterRequest", new AdminRegisterRequest("", "", "", ""));
+        return "admin/register";
+    }
+
+    @PostMapping("/register")
+    public String register(
+            @Valid @ModelAttribute("adminRegisterRequest") AdminRegisterRequest adminRegisterRequest,
+            BindingResult bindingResult
+    ) {
+        if (bindingResult.hasErrors()) {
+            return "admin/register";
+        }
+
+        adminService.register(adminRegisterRequest);
+        return "redirect:/admins/login";
+    }
+
+    @GetMapping("/login")
+    public String loginForm(Model model) {
+        model.addAttribute("adminLoginRequest", new AdminLoginRequest("", ""));
+        return "admin/login";
+    }
+
+    @GetMapping("/events")
+    public String getAllEvents(
+            Model model,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<AdminEventResponse> eventPages = adminService.getAllEvents(pageable);
+        model.addAttribute("eventPages", eventPages);
+        model.addAttribute("serverUrl", serverUrl);
+        return "admin/events";
+    }
+}

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -5,6 +5,8 @@ import com.meetup.server.event.exception.EventErrorType;
 import com.meetup.server.event.exception.EventException;
 import com.meetup.server.event.infrastructure.jpa.EventRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -20,6 +22,10 @@ public class EventReader {
     public Event read(UUID eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventException(EventErrorType.EVENT_NOT_FOUND));
+    }
+
+    public Page<Event> readAll(Pageable pageable) {
+        return eventRepository.findAll(pageable);
     }
 
     public List<Event> readEventsWithPlaceAtHour(int hour) {

--- a/src/main/java/com/meetup/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.meetup.server.auth.presentation.filter.*;
 import com.meetup.server.auth.support.handler.OAuth2LoginFailureHandler;
 import com.meetup.server.auth.support.handler.OAuth2LoginSuccessHandler;
 import com.meetup.server.auth.support.resolver.CustomAuthorizationRequestResolver;
+import com.meetup.server.user.domain.type.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
@@ -14,9 +15,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -42,6 +46,31 @@ public class SecurityConfig {
     @Bean
     public CustomAuthorizationRequestResolver customAuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
         return new CustomAuthorizationRequestResolver(clientRegistrationRepository, "/oauth2/authorization");
+    }
+
+    @Bean
+    public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher(new AntPathRequestMatcher("/admins/**"))
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .formLogin(form -> form
+                        .loginPage("/admins/login")
+                        .loginProcessingUrl("/admins/login")
+                        .defaultSuccessUrl("/admins/events", true)
+                        .failureUrl("/admins/login?error=true")
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/admins/login", "/admins/register").permitAll()
+                        .requestMatchers("/admins/**").hasAuthority(Role.ADMIN.getAuthority())
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/admins/logout")
+                        .logoutSuccessUrl("/admins/login")
+                        .invalidateHttpSession(true)
+                );
+
+        return http.build();
     }
 
     @Bean
@@ -75,5 +104,10 @@ public class SecurityConfig {
                 .addFilterBefore(responseContextFilter, JwtAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/meetup/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/meetup/server/global/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
     public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
         http
                 .securityMatcher(new AntPathRequestMatcher("/admins/**"))
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(Customizer.withDefaults())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .formLogin(form -> form
                         .loginPage("/admins/login")

--- a/src/main/java/com/meetup/server/user/domain/type/Role.java
+++ b/src/main/java/com/meetup/server/user/domain/type/Role.java
@@ -8,8 +8,10 @@ import lombok.RequiredArgsConstructor;
 public enum Role {
 
     USER("ROLE_USER"),
-    ADMIN("ROLE_ADMIN"),
     WITHDRAWN("ROLE_WITHDRAWN"),
+    ADMIN("ROLE_ADMIN"),
+    ADMIN_PENDING("ROLE_ADMIN_PENDING"),
+    ADMIN_REJECTED("ROLE_ADMIN_REJECTED"),
     ;
 
     private final String authority;

--- a/src/main/resources/templates/admin/events.html
+++ b/src/main/resources/templates/admin/events.html
@@ -70,7 +70,7 @@
         <td th:text="${event.eventId}">01989e08-9eca-7cbb-a6ae-a93e21cadf6e</td>
 
         <td>
-            <a th:href="@{|${serverUrl}/mapview/${event.eventId}|}" class="event-link"
+            <a th:href="@{|${clientUrl}/mapview/${event.eventId}|}" class="event-link"
                th:text="${event.eventName}">모이삼 MAU 1000만 기념 회식</a>
         </td>
 
@@ -89,12 +89,28 @@
 </table>
 
 <div class="pagination" th:if="${eventPages.totalPages > 1}">
-    <a th:href="@{/admins/events(page=${eventPages.number - 1})}" th:if="${eventPages.hasPrevious()}">이전</a>
-    <span th:each="i : ${#numbers.sequence(0, eventPages.totalPages - 1)}">
+
+    <th:block th:with="
+        currentPageNumber=${eventPages.number},
+        blockSize=5,
+        startPage=${(currentPageNumber / blockSize) * blockSize},
+        endPage=(${(startPage + blockSize - 1) < eventPages.totalPages ? (startPage + blockSize - 1) : eventPages.totalPages - 1})
+    ">
+
+        <a th:href="@{/admins/events(page=0)}" th:if="${startPage > 0}">처음</a>
+
+        <a th:href="@{/admins/events(page=${startPage - 1})}" th:if="${startPage > 0}">이전</a>
+
+        <span th:each="i : ${#numbers.sequence(startPage, endPage)}">
         <a th:href="@{/admins/events(page=${i})}" th:text="${i + 1}"
            th:classappend="${i == eventPages.number ? 'active' : ''}">1</a>
     </span>
-    <a th:href="@{/admins/events(page=${eventPages.number + 1})}" th:if="${eventPages.hasNext()}">다음</a>
+
+        <a th:href="@{/admins/events(page=${endPage + 1})}" th:if="${endPage < eventPages.totalPages - 1}">다음</a>
+
+        <a th:href="@{/admins/events(page=${eventPages.totalPages - 1})}" th:if="${endPage < eventPages.totalPages - 1}">끝</a>
+
+    </th:block>
 </div>
 
 </body>

--- a/src/main/resources/templates/admin/events.html
+++ b/src/main/resources/templates/admin/events.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>MOISAM Admin</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+        }
+
+        h2 {
+            border-bottom: 2px solid #ccc;
+            padding-bottom: 10px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+
+        th, td {
+            border: 1px solid #ddd;
+            padding: 10px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #f2f2f2;
+        }
+
+        .pagination {
+            margin-top: 20px;
+            text-align: center;
+        }
+
+        .pagination a, .pagination span {
+            padding: 8px 12px;
+            margin: 0 4px;
+            border: 1px solid #ccc;
+            text-decoration: none;
+        }
+
+        .event-link {
+            color: #17a2b8;
+            text-decoration: underline;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+
+<h2>Events</h2>
+
+<table>
+    <thead>
+    <tr>
+        <th>모임 ID</th>
+        <th>모임명</th>
+        <th>모임 일시</th>
+        <th>중간 지점</th>
+        <th>모임 확정 장소</th>
+        <th>참여자 수</th>
+        <th>생성일</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="event : ${eventPages.content}">
+        <td th:text="${event.eventId}">01989e08-9eca-7cbb-a6ae-a93e21cadf6e</td>
+
+        <td>
+            <a th:href="@{|${serverUrl}/mapview/${event.eventId}|}" class="event-link"
+               th:text="${event.eventName}">모이삼 MAU 1000만 기념 회식</a>
+        </td>
+
+        <td th:text="${#temporals.format(event.eventDateTime, 'yyyy-MM-dd HH:mm')}">2025-12-24 12:00</td>
+
+        <td th:text="${event.meetingPoint}">강남</td>
+
+        <td th:text="${event.meetingPlace}">노벰버라운지 강남</td>
+
+        <td th:text="${event.participantCount} + '명'">8명</td>
+
+        <td th:text="${#temporals.format(event.createdDateTime, 'yyyy-MM-dd HH:mm')}">2025-12-25 12:00</td>
+
+    </tr>
+    </tbody>
+</table>
+
+<div class="pagination" th:if="${eventPages.totalPages > 1}">
+    <a th:href="@{/admins/events(page=${eventPages.number - 1})}" th:if="${eventPages.hasPrevious()}">이전</a>
+    <span th:each="i : ${#numbers.sequence(0, eventPages.totalPages - 1)}">
+        <a th:href="@{/admins/events(page=${i})}" th:text="${i + 1}"
+           th:classappend="${i == eventPages.number ? 'active' : ''}">1</a>
+    </span>
+    <a th:href="@{/admins/events(page=${eventPages.number + 1})}" th:if="${eventPages.hasNext()}">다음</a>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -51,6 +51,7 @@
     <h2>관리자 로그인</h2>
 
     <form th:action="@{/admins/login}" th:object="${adminLoginRequest}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
         <div th:if="${param.error}" class="error-message">
 

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>MOISAM Admin</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+        }
+
+        .form-container {
+            max-width: 400px;
+            margin: 0 auto;
+            padding: 20px;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+        }
+
+        label {
+            display: block;
+            margin-top: 10px;
+        }
+
+        input[type="text"], input[type="password"] {
+            width: 100%;
+            padding: 8px;
+            margin-top: 5px;
+            box-sizing: border-box;
+        }
+
+        button {
+            margin-top: 20px;
+            padding: 10px 15px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        .error-message {
+            color: red;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="form-container">
+    <h2>관리자 로그인</h2>
+
+    <form th:action="@{/admins/login}" th:object="${adminLoginRequest}" method="post">
+
+        <div th:if="${param.error}" class="error-message">
+
+            <div th:with="exception=${session['SPRING_SECURITY_LAST_EXCEPTION']}">
+
+                <p th:if="${exception != null and exception.message.contains('승인 대기 중인 계정입니다.')}">
+                    계정이 승인 대기 중입니다. 관리자에게 문의해주세요.
+                </p>
+                <p th:if="${exception != null and exception.message.contains('승인이 거부된 계정입니다.')}">
+                    관리자 승인이 거부되었습니다. 관리자에게 문의해주세요.
+                </p>
+
+                <p th:unless="${exception != null and
+                       (exception.message.contains('승인 대기 중인 계정입니다.') or
+                        exception.message.contains('승인이 거부된 계정입니다.'))}">
+                    아이디 또는 비밀번호를 다시 확인해주세요.
+                </p>
+
+            </div>
+        </div>
+        <div>
+            <label>아이디
+                <input type="text" th:field="*{username}" minlength="4" maxlength="20" required>
+            </label>
+        </div>
+
+        <div>
+            <label>비밀번호
+                <input type="password" th:field="*{password}" minlength="8" maxlength="30" required>
+            </label>
+        </div>
+
+        <button type="submit">로그인</button>
+
+        <p style="margin-top: 15px;">
+            <a th:href="@{/admins/register}">계정이 없으신가요? (회원가입)</a>
+        </p>
+    </form>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/register.html
+++ b/src/main/resources/templates/admin/register.html
@@ -81,6 +81,8 @@
             </label>
             <span class="error-message" th:if="${#fields.hasErrors('passwordConfirmed')}"
                   th:errors="*{passwordConfirmed}">비밀번호가 일치하지 않습니다.</span>
+            <span class="error-message" th:if="${#fields.hasErrors('passwordNotTrim')}"
+                  th:errors="*{passwordNotTrim}">비밀번호는 공백으로 시작하거나 끝날 수 없습니다.</span>
         </div>
 
         <button type="submit">확인</button>

--- a/src/main/resources/templates/admin/register.html
+++ b/src/main/resources/templates/admin/register.html
@@ -67,6 +67,8 @@
             <label>아이디
                 <input type="text" th:field="*{username}" minlength="4" maxlength="20" required>
             </label>
+            <span class="error-message" th:if="${#fields.hasErrors('username')}"
+                  th:errors="*{username}">이미 등록된 관리자입니다.</span>
         </div>
 
         <div>

--- a/src/main/resources/templates/admin/register.html
+++ b/src/main/resources/templates/admin/register.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>MOISAM Admin</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+        }
+
+        .form-container {
+            max-width: 400px;
+            margin: 0 auto;
+            padding: 20px;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+        }
+
+        label {
+            display: block;
+            margin-top: 10px;
+        }
+
+        input[type="text"], input[type="password"] {
+            width: 100%;
+            padding: 8px;
+            margin-top: 5px;
+            box-sizing: border-box;
+        }
+
+        button {
+            margin-top: 20px;
+            padding: 10px 15px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        .error-message {
+            color: red;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="form-container">
+    <h2>관리자 회원가입</h2>
+
+    <form th:action="@{/admins/register}" th:object="${adminRegisterRequest}" method="post">
+
+        <div class="error-message" th:if="${#fields.hasGlobalErrors()}">
+            <p th:each="err : ${#fields.globalErrors()}" th:text="${err}">전역 오류 메시지</p>
+        </div>
+
+        <div>
+            <label>이름
+                <input type="text" th:field="*{name}" minlength="1" maxlength="10" required>
+            </label>
+        </div>
+
+        <div>
+            <label>아이디
+                <input type="text" th:field="*{username}" minlength="4" maxlength="20" required>
+            </label>
+        </div>
+
+        <div>
+            <label>비밀번호
+                <input type="password" th:field="*{password}" minlength="8" maxlength="30" required>
+            </label>
+        </div>
+
+        <div>
+            <label>비밀번호 확인
+                <input type="password" th:field="*{confirmPassword}" minlength="8" maxlength="30" required>
+            </label>
+            <span class="error-message" th:if="${#fields.hasErrors('passwordConfirmed')}"
+                  th:errors="*{passwordConfirmed}">비밀번호가 일치하지 않습니다.</span>
+        </div>
+
+        <button type="submit">확인</button>
+    </form>
+
+    <p style="margin-top: 15px;">
+        이미 계정이 있으신가요? <a th:href="@{/admins/login}">로그인</a>
+    </p>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/register.html
+++ b/src/main/resources/templates/admin/register.html
@@ -51,6 +51,7 @@
     <h2>관리자 회원가입</h2>
 
     <form th:action="@{/admins/register}" th:object="${adminRegisterRequest}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
         <div class="error-message" th:if="${#fields.hasGlobalErrors()}">
             <p th:each="err : ${#fields.globalErrors()}" th:text="${err}">전역 오류 메시지</p>


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 마케팅 작업을 위해 데이터 확인이 필요합니다. 이번에 마케팅 작업에 힘을 실으면서, 유입이 많아짐과 동시에 사용자의 데이터를 확인하기 위해 착수된 작업입니다.

## ✅ What - 무엇이 변경됐나요?

- 어드민과 일반 사용자를 엔드포인트로 구별했습니다. 추후 도메인 추가하여 웹서버 앞단 프록시에서 처리할 예정입니다.
- Admin 엔티티가 추가되었습니다.

## 🛠️ How - 어떻게 해결했나요?

- 회원 가입 후, 승인 대기(`ADMIN_PENDING`)를 추가하여 가입 후 바로 사용하지 못하게 막았습니다. 추후 승인 대기 목록 페이지를 만들어 관리자가 가입 승인/반려할 수 있게 관리할 수도 있습니다. 
- 이벤트 조회는 현재 최신순 정렬 및 10개의 데이터로 페이지네이션 되어 있습니다. 정렬 또한 응답 컬럼(이벤트 일시, 참여자 수 등)으로 정렬하는 방향으로 나아가도 좋을 것 같습니다.
- adminId와 id가 구분하기 어려워 Spring Security와 동일하게 id를 username으로 통일했습니다.
- 어드민 페이지는 로그인 시 세션을 생성하고, 세션 시간이 만료되면 로그아웃되도록 구현했습니다. 세션 시간은 config repository 참고 바랍니다.

## 🖼️ Attachment

### 로그인
<img width="1433" height="740" alt="스크린샷 2025-12-06 오후 8 01 03" src="https://github.com/user-attachments/assets/b8cfaa95-a14a-4556-9334-6f350c1eb593" />

### 회원가입
<img width="1433" height="740" alt="스크린샷 2025-12-06 오후 8 01 12" src="https://github.com/user-attachments/assets/15fa31b3-190d-4b30-b366-4c38a49a013c" />

### 이벤트 조회
<img width="1433" height="740" alt="스크린샷 2025-12-06 오후 8 01 22" src="https://github.com/user-attachments/assets/2b652d91-bd8f-4317-b113-6d47ff176d74" />


## 💬 기타 코멘트

- ASAP하게 작업 처리가 이뤄져야 해서 최소한의 필요한 기능만 구현했습니다. 어드민 페이지는 앞으로 팀과 논의 후에 요구사항이 추가될 때마다 개선할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 가입 페이지 추가(이름·아이디·비밀번호·비밀번호 확인, 유효성 및 공백 검사, 중복 검사)
  * 관리자 로그인 페이지 추가(대기·거부 상태에 따른 안내 메시지 포함)
  * 관리자 전용 이벤트 목록 페이지 추가(페이지네이션·정렬·참여자 수·일시·중간지점·확정 장소 표기, 지도 보기 링크)
  * 관리자 전용 인증·접근 제어 및 로그아웃 흐름 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->