### PR TITLE
[MOISAM-245] 금일 생성된 모임, 참여자 수를 어드민 페이지에서 조회한다

### DIFF
--- a/src/main/java/com/meetup/server/admin/application/AdminService.java
+++ b/src/main/java/com/meetup/server/admin/application/AdminService.java
@@ -2,6 +2,7 @@ package com.meetup.server.admin.application;
 
 import com.meetup.server.admin.dto.request.AdminRegisterRequest;
 import com.meetup.server.admin.dto.response.AdminEventResponse;
+import com.meetup.server.admin.dto.response.DailyStatsResponse;
 import com.meetup.server.admin.implement.AdminValidator;
 import com.meetup.server.admin.implement.AdminWriter;
 import com.meetup.server.event.domain.Event;
@@ -15,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -63,5 +65,13 @@ public class AdminService {
                 pageable,
                 events.getTotalElements()
         );
+    }
+
+    public DailyStatsResponse getDailyStats() {
+        LocalDate todayDate = LocalDate.now();
+        Long dailyEventCount = eventReader.readDailyEventCount(todayDate);
+        Long dailyParticipantCount = startPointReader.readDailyParticipantCount(todayDate);
+
+        return DailyStatsResponse.of(dailyEventCount, dailyParticipantCount);
     }
 }

--- a/src/main/java/com/meetup/server/admin/application/AdminService.java
+++ b/src/main/java/com/meetup/server/admin/application/AdminService.java
@@ -69,8 +69,8 @@ public class AdminService {
 
     public DailyStatsResponse getDailyStats() {
         LocalDate todayDate = LocalDate.now();
-        Long dailyEventCount = eventReader.readDailyEventCount(todayDate);
-        Long dailyParticipantCount = startPointReader.readDailyParticipantCount(todayDate);
+        long dailyEventCount = eventReader.readDailyEventCount(todayDate);
+        long dailyParticipantCount = startPointReader.readDailyParticipantCount(todayDate);
 
         return DailyStatsResponse.of(dailyEventCount, dailyParticipantCount);
     }

--- a/src/main/java/com/meetup/server/admin/dto/response/DailyStatsResponse.java
+++ b/src/main/java/com/meetup/server/admin/dto/response/DailyStatsResponse.java
@@ -1,10 +1,10 @@
 package com.meetup.server.admin.dto.response;
 
 public record DailyStatsResponse(
-        Long dailyEventCount,
-        Long dailyParticipantCount
+        long dailyEventCount,
+        long dailyParticipantCount
 ) {
-    public static DailyStatsResponse of(Long dailyEventCount, Long dailyParticipantCount) {
+    public static DailyStatsResponse of(long dailyEventCount, long dailyParticipantCount) {
         return new DailyStatsResponse(dailyEventCount, dailyParticipantCount);
     }
 }

--- a/src/main/java/com/meetup/server/admin/dto/response/DailyStatsResponse.java
+++ b/src/main/java/com/meetup/server/admin/dto/response/DailyStatsResponse.java
@@ -1,0 +1,10 @@
+package com.meetup.server.admin.dto.response;
+
+public record DailyStatsResponse(
+        Long dailyEventCount,
+        Long dailyParticipantCount
+) {
+    public static DailyStatsResponse of(Long dailyEventCount, Long dailyParticipantCount) {
+        return new DailyStatsResponse(dailyEventCount, dailyParticipantCount);
+    }
+}

--- a/src/main/java/com/meetup/server/admin/presentation/AdminController.java
+++ b/src/main/java/com/meetup/server/admin/presentation/AdminController.java
@@ -4,6 +4,7 @@ import com.meetup.server.admin.application.AdminService;
 import com.meetup.server.admin.dto.request.AdminLoginRequest;
 import com.meetup.server.admin.dto.request.AdminRegisterRequest;
 import com.meetup.server.admin.dto.response.AdminEventResponse;
+import com.meetup.server.admin.dto.response.DailyStatsResponse;
 import com.meetup.server.admin.exception.AdminErrorType;
 import com.meetup.server.admin.exception.AdminException;
 import jakarta.validation.Valid;
@@ -73,6 +74,9 @@ public class AdminController {
         Page<AdminEventResponse> eventPages = adminService.getAllEvents(pageable);
         model.addAttribute("eventPages", eventPages);
         model.addAttribute("clientUrl", clientUrl);
+
+        DailyStatsResponse dailyStats = adminService.getDailyStats();
+        model.addAttribute("dailyStats", dailyStats);
         return "admin/events";
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -38,7 +38,7 @@ public class EventReader {
         return eventRepository.findAllByEventDateTimeWithPlace(targetTime);
     }
 
-    public Long readDailyEventCount(LocalDate todayDate) {
+    public long readDailyEventCount(LocalDate todayDate) {
         LocalDateTime startDateTime = todayDate.atStartOfDay();
         LocalDateTime endDateTime = todayDate.atTime(LocalTime.MAX);
         return eventRepository.countByCreatedAtBetween(startDateTime, endDateTime);

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -9,7 +9,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,5 +36,11 @@ public class EventReader {
                 .withSecond(0)
                 .withNano(0);
         return eventRepository.findAllByEventDateTimeWithPlace(targetTime);
+    }
+
+    public Long readDailyEventCount(LocalDate todayDate) {
+        LocalDateTime startDateTime = todayDate.atStartOfDay();
+        LocalDateTime endDateTime = todayDate.atTime(LocalTime.MAX);
+        return eventRepository.countByCreatedAtBetween(startDateTime, endDateTime);
     }
 }

--- a/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
+++ b/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
@@ -24,4 +24,6 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
 
     @Query("SELECT e FROM Event e JOIN FETCH e.place WHERE e.eventDateTime = :eventDateTime")
     List<Event> findAllByEventDateTimeWithPlace(@Param("eventDateTime") LocalDateTime eventDateTime);
+
+    Long countByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
+++ b/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
@@ -25,5 +25,5 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
     @Query("SELECT e FROM Event e JOIN FETCH e.place WHERE e.eventDateTime = :eventDateTime")
     List<Event> findAllByEventDateTimeWithPlace(@Param("eventDateTime") LocalDateTime eventDateTime);
 
-    Long countByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+    long countByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
@@ -11,6 +11,9 @@ import com.meetup.server.startpoint.infrastructure.querydsl.projection.Participa
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -43,5 +46,11 @@ public class StartPointReader {
 
     public List<StartPoint> readAllWithUserByEvent(Event event) {
         return startPointRepository.findAllWithUserByEvent(event);
+    }
+
+    public Long readDailyParticipantCount(LocalDate todayDate) {
+        LocalDateTime startDateTime = todayDate.atStartOfDay();
+        LocalDateTime endDateTime = todayDate.atTime(LocalTime.MAX);
+        return startPointRepository.countByCreatedAtBetween(startDateTime, endDateTime);
     }
 }

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
@@ -48,7 +48,7 @@ public class StartPointReader {
         return startPointRepository.findAllWithUserByEvent(event);
     }
 
-    public Long readDailyParticipantCount(LocalDate todayDate) {
+    public long readDailyParticipantCount(LocalDate todayDate) {
         LocalDateTime startDateTime = todayDate.atStartOfDay();
         LocalDateTime endDateTime = todayDate.atTime(LocalTime.MAX);
         return startPointRepository.countByCreatedAtBetween(startDateTime, endDateTime);

--- a/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/StartPointRepository.java
+++ b/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/StartPointRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,4 +30,6 @@ public interface StartPointRepository extends JpaRepository<StartPoint, UUID>, S
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM StartPoint sp WHERE sp.user = :user")
     void deleteAllByUser(@Param("user") User user);
+
+    Long countByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/StartPointRepository.java
+++ b/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/StartPointRepository.java
@@ -31,5 +31,5 @@ public interface StartPointRepository extends JpaRepository<StartPoint, UUID>, S
     @Query("DELETE FROM StartPoint sp WHERE sp.user = :user")
     void deleteAllByUser(@Param("user") User user);
 
-    Long countByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+    long countByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/resources/templates/admin/events.html
+++ b/src/main/resources/templates/admin/events.html
@@ -79,30 +79,48 @@
             background-color: #f9f9f9;
         }
 
-        /* 페이지네이션 스타일 */
         .pagination {
-            margin-top: 30px;
-            text-align: center;
+            margin-top: 40px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 2px;
         }
 
-        .pagination a, .pagination span {
+        .pagination a {
             padding: 8px 14px;
             margin: 0 3px;
             border: 1px solid #ddd;
             text-decoration: none;
             border-radius: 4px;
             color: #007bff;
-            display: inline-block;
+            transition: all 0.2s;
+            font-size: 0.9em;
+        }
+
+        .pagination a.nav-btn {
+            background-color: #f8f9fa;
+            color: #6c757d;
+            font-weight: bold;
+            font-size: 1.1em;
+            line-height: 1;
+        }
+
+        .pagination a:hover:not(.active) {
+            background-color: #f1f1f1;
+            border-color: #ccc;
+        }
+
+        .pagination a.nav-btn:hover {
+            background-color: #e2e6ea;
+            color: #343a40;
         }
 
         .pagination .active {
             background-color: #007bff;
             color: white;
             border-color: #007bff;
-        }
-
-        .pagination a:hover:not(.active) {
-            background-color: #f1f1f1;
+            cursor: default;
         }
 
         .event-link {
@@ -128,7 +146,6 @@
             <span class="unit">개</span>
         </div>
     </div>
-
     <div class="stat-card">
         <span class="label">📅 금일 신규 참여자 수</span>
         <div class="value">
@@ -173,20 +190,21 @@
         startPage=${(currentPageNumber / blockSize) * blockSize},
         endPage=(${(startPage + blockSize - 1) < eventPages.totalPages ? (startPage + blockSize - 1) : eventPages.totalPages - 1})
     ">
-        <a th:href="@{/admins/events(page=0)}" th:if="${startPage > 0}">처음</a>
+        <a class="nav-btn" th:href="@{/admins/events(page=0)}" th:if="${startPage > 0}" title="처음">&laquo;</a>
 
-        <a th:href="@{/admins/events(page=${startPage - 1})}" th:if="${startPage > 0}">이전</a>
+        <a class="nav-btn" th:href="@{/admins/events(page=${startPage - 1})}" th:if="${startPage > 0}" title="이전">&lsaquo;</a>
 
-        <span th:each="i : ${#numbers.sequence(startPage, endPage)}">
-            <a th:href="@{/admins/events(page=${i})}" th:text="${i + 1}"
+        <th:block th:each="i : ${#numbers.sequence(startPage, endPage)}">
+            <a th:href="@{/admins/events(page=${i})}"
+               th:text="${i + 1}"
                th:classappend="${i == eventPages.number ? 'active' : ''}">1</a>
-        </span>
+        </th:block>
 
-        <a th:href="@{/admins/events(page=${endPage + 1})}" th:if="${endPage < eventPages.totalPages - 1}">다음</a>
+        <a class="nav-btn" th:href="@{/admins/events(page=${endPage + 1})}"
+           th:if="${endPage < eventPages.totalPages - 1}" title="다음">&rsaquo;</a>
 
-        <a th:href="@{/admins/events(page=${eventPages.totalPages - 1})}"
-           th:if="${endPage < eventPages.totalPages - 1}">끝</a>
-
+        <a class="nav-btn" th:href="@{/admins/events(page=${eventPages.totalPages - 1})}"
+           th:if="${endPage < eventPages.totalPages - 1}" title="끝">&raquo;</a>
     </th:block>
 </div>
 

--- a/src/main/resources/templates/admin/events.html
+++ b/src/main/resources/templates/admin/events.html
@@ -7,51 +7,136 @@
         body {
             font-family: Arial, sans-serif;
             padding: 20px;
+            color: #333;
         }
 
         h2 {
             border-bottom: 2px solid #ccc;
             padding-bottom: 10px;
+            margin-bottom: 20px;
         }
 
+        /* 통계 컨테이너 */
+        .stats-container {
+            display: flex;
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+
+        .stat-card {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-left: 5px solid #17a2b8;
+            padding: 15px 25px;
+            border-radius: 6px;
+            min-width: 220px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+        }
+
+        .stat-card.event {
+            border-left-color: #28a745;
+        }
+
+        .stat-card .label {
+            display: block;
+            font-size: 0.85em;
+            color: #6c757d;
+            margin-bottom: 8px;
+            font-weight: bold;
+        }
+
+        .stat-card .value {
+            font-size: 1.6em;
+            font-weight: bold;
+            color: #212529;
+        }
+
+        .stat-card .unit {
+            font-size: 0.6em;
+            margin-left: 4px;
+            color: #495057;
+        }
+
+        /* 테이블 스타일 */
         table {
             width: 100%;
             border-collapse: collapse;
-            margin-top: 20px;
+            margin-top: 10px;
         }
 
         th, td {
             border: 1px solid #ddd;
-            padding: 10px;
+            padding: 12px;
             text-align: left;
         }
 
         th {
             background-color: #f2f2f2;
+            font-weight: bold;
         }
 
+        tr:hover {
+            background-color: #f9f9f9;
+        }
+
+        /* 페이지네이션 스타일 */
         .pagination {
-            margin-top: 20px;
+            margin-top: 30px;
             text-align: center;
         }
 
         .pagination a, .pagination span {
-            padding: 8px 12px;
-            margin: 0 4px;
-            border: 1px solid #ccc;
+            padding: 8px 14px;
+            margin: 0 3px;
+            border: 1px solid #ddd;
             text-decoration: none;
+            border-radius: 4px;
+            color: #007bff;
+            display: inline-block;
+        }
+
+        .pagination .active {
+            background-color: #007bff;
+            color: white;
+            border-color: #007bff;
+        }
+
+        .pagination a:hover:not(.active) {
+            background-color: #f1f1f1;
         }
 
         .event-link {
             color: #17a2b8;
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .event-link:hover {
             text-decoration: underline;
-            cursor: pointer;
         }
     </style>
 </head>
 <body>
 
 <h2>Events</h2>
+
+<div class="stats-container" th:if="${dailyStats != null}">
+    <div class="stat-card event">
+        <span class="label">📍 금일 신규 이벤트 수</span>
+        <div class="value">
+            <span th:text="${#numbers.formatInteger(dailyStats.dailyEventCount(), 0, 'COMMA')}">0</span>
+            <span class="unit">개</span>
+        </div>
+    </div>
+
+    <div class="stat-card">
+        <span class="label">📅 금일 신규 참여자 수</span>
+        <div class="value">
+            <span th:text="${#numbers.formatInteger(dailyStats.dailyParticipantCount(), 0, 'COMMA')}">0</span>
+            <span class="unit">명</span>
+        </div>
+    </div>
+</div>
 
 <table>
     <thead>
@@ -67,48 +152,40 @@
     </thead>
     <tbody>
     <tr th:each="event : ${eventPages.content}">
-        <td th:text="${event.eventId}">01989e08-9eca-7cbb-a6ae-a93e21cadf6e</td>
-
+        <td th:text="${event.eventId}">ID</td>
         <td>
             <a th:href="@{|${clientUrl}/mapview/${event.eventId}|}" class="event-link"
-               th:text="${event.eventName}">모이삼 MAU 1000만 기념 회식</a>
+               th:text="${event.eventName}">모임명</a>
         </td>
-
         <td th:text="${#temporals.format(event.eventDateTime, 'yyyy-MM-dd HH:mm')}">2025-12-24 12:00</td>
-
-        <td th:text="${event.meetingPoint}">강남</td>
-
-        <td th:text="${event.meetingPlace}">노벰버라운지 강남</td>
-
-        <td th:text="${event.participantCount} + '명'">8명</td>
-
+        <td th:text="${event.meetingPoint}">중간 지점</td>
+        <td th:text="${event.meetingPlace}">확정 장소</td>
+        <td th:text="${event.participantCount} + '명'">0명</td>
         <td th:text="${#temporals.format(event.createdDateTime, 'yyyy-MM-dd HH:mm')}">2025-12-25 12:00</td>
-
     </tr>
     </tbody>
 </table>
 
 <div class="pagination" th:if="${eventPages.totalPages > 1}">
-
     <th:block th:with="
         currentPageNumber=${eventPages.number},
         blockSize=5,
         startPage=${(currentPageNumber / blockSize) * blockSize},
         endPage=(${(startPage + blockSize - 1) < eventPages.totalPages ? (startPage + blockSize - 1) : eventPages.totalPages - 1})
     ">
-
         <a th:href="@{/admins/events(page=0)}" th:if="${startPage > 0}">처음</a>
 
         <a th:href="@{/admins/events(page=${startPage - 1})}" th:if="${startPage > 0}">이전</a>
 
         <span th:each="i : ${#numbers.sequence(startPage, endPage)}">
-        <a th:href="@{/admins/events(page=${i})}" th:text="${i + 1}"
-           th:classappend="${i == eventPages.number ? 'active' : ''}">1</a>
-    </span>
+            <a th:href="@{/admins/events(page=${i})}" th:text="${i + 1}"
+               th:classappend="${i == eventPages.number ? 'active' : ''}">1</a>
+        </span>
 
         <a th:href="@{/admins/events(page=${endPage + 1})}" th:if="${endPage < eventPages.totalPages - 1}">다음</a>
 
-        <a th:href="@{/admins/events(page=${eventPages.totalPages - 1})}" th:if="${endPage < eventPages.totalPages - 1}">끝</a>
+        <a th:href="@{/admins/events(page=${eventPages.totalPages - 1})}"
+           th:if="${endPage < eventPages.totalPages - 1}">끝</a>
 
     </th:block>
 </div>


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 금일 생성된 모임, 참여자 수 확인이 필요해 어드민페이지에서 조회할 수 있도록 추가했습니다.

## ✅ What - 무엇이 변경됐나요?

- 금일 생성된 모임, 참여자 수 조회 로직 추가
- 어드민 페이지의 모임, 참여자 수 div tag 추가 및 일부 CSS 변경

## 🛠️ How - 어떻게 해결했나요?

- JPA 쿼리메소드 between을 사용해 금일 생성된 데이터를 카운트했습니다.

## 🖼️ Attachment
<img width="1418" height="695" alt="스크린샷 2025-12-25 오후 8 43 28" src="https://github.com/user-attachments/assets/06e1c492-90aa-4f95-9687-1e2297a5604b" />


## 💬 기타 코멘트
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자 대시보드에 일일 통계(일별 이벤트 수 및 참여자 수) 조회 기능 추가

* **UI/UX Improvements**
  * 통계 카드 위젯으로 주요 지표 시각화 (일일 이벤트·참여자 수)
  * 이벤트 관리 테이블 레이아웃·스타일 개선 및 한글 컬럼 레이블 적용
  * 페이지네이션 인터페이스 강화(첫/이전/다음/마지막, 블록형 페이지네비게이션)
  * 테이블 행 하이라이트·링크 동작 유지 및 전반적 스타일 정돈

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->