### PR TITLE
[MOISAM-247] 경로 조회 재시도 로직 추가 및 Virtual Thread로 전환한다

### DIFF
--- a/src/main/java/com/meetup/server/event/implement/EventValidator.java
+++ b/src/main/java/com/meetup/server/event/implement/EventValidator.java
@@ -48,10 +48,4 @@ public class EventValidator {
             throw new EventException(EventErrorType.NO_INTERMEDIATE_SUBWAYS_FOUND);
         }
     }
-
-    public void validateEventCacheExist(Cache.ValueWrapper eventCache) {
-        if (eventCache == null) {
-            throw new EventException(EventErrorType.CACHE_NOT_FOUND);
-        }
-    }
 }

--- a/src/main/java/com/meetup/server/event/implement/route/RouteAssembler.java
+++ b/src/main/java/com/meetup/server/event/implement/route/RouteAssembler.java
@@ -54,9 +54,14 @@ public class RouteAssembler {
     }
 
     private RouteResponse fetchWithRetry(StartPoint startPoint, Subway subway) {
+        RouteResponse route = null;
+
         for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-            RouteResponse route = routeFetcher.fetch(startPoint, subway);
-            if (isValid(route)) return route;
+            route = routeFetcher.fetch(startPoint, subway);
+
+            if (isValid(route)) {
+                return route;
+            }
 
             if (attempt < MAX_ATTEMPTS - 1) {
                 log.warn("[RouteAssembler] Route fetch failed for {}. Retrying... (Attempt {}/{})",
@@ -69,7 +74,9 @@ public class RouteAssembler {
                 }
             }
         }
-        return null;
+
+        log.warn("[RouteAssembler] All retry attempts failed. StartPoint: {}, Subway: {}", startPoint.getName(), subway.getName());
+        return route;
     }
 
     private boolean isValid(RouteResponse route) {

--- a/src/main/java/com/meetup/server/event/implement/route/RouteAssembler.java
+++ b/src/main/java/com/meetup/server/event/implement/route/RouteAssembler.java
@@ -2,6 +2,8 @@ package com.meetup.server.event.implement.route;
 
 import com.meetup.server.event.dto.response.route.MeetingPointRouteGroup;
 import com.meetup.server.event.dto.response.route.RouteResponse;
+import com.meetup.server.event.exception.EventErrorType;
+import com.meetup.server.event.exception.EventException;
 import com.meetup.server.parkinglot.implement.ParkingLotFinder;
 import com.meetup.server.parkinglot.infrastructure.jpa.projection.ClosestParkingLot;
 import com.meetup.server.startpoint.domain.StartPoint;
@@ -14,7 +16,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -22,49 +23,58 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RouteAssembler {
 
-    private static final int THREAD_POOL_SIZE = 2;
+    private static final int MAX_ATTEMPTS = 2;
+    private static final int RETRY_DELAY_MS = 100;
 
+    private final ExecutorService routeExecutor;
     private final ParkingLotFinder parkingLotFinder;
     private final RouteFetcher routeFetcher;
 
     public CompletableFuture<MeetingPointRouteGroup> assemble(List<StartPoint> startPoints, Subway subway) {
-        try (ExecutorService executor = Executors.newFixedThreadPool(THREAD_POOL_SIZE)) {
-            List<CompletableFuture<RouteResponse>> routeFutures = startPoints.stream()
-                    .map(startPoint -> CompletableFuture.supplyAsync(() -> routeFetcher.fetch(startPoint, subway), executor))
-                    .toList();
+        List<CompletableFuture<RouteResponse>> routeFutures = startPoints.stream()
+                .map(startPoint -> CompletableFuture.supplyAsync(() -> fetchWithRetry(startPoint, subway), routeExecutor))
+                .toList();
 
-            CompletableFuture<List<RouteResponse>> allRoutesFuture = CompletableFuture.allOf(routeFutures.toArray(new CompletableFuture[0]))
-                    .thenApply(v -> routeFutures.stream()
-                            .map(routeFuture -> {
-                                try {
-                                    return routeFuture.get();
-                                } catch (Exception e) {
-                                    log.warn("[RouteAssembler] Failed fetching route", e);
-                                    return null;
-                                }
-                            })
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toList()));
+        CompletableFuture<List<RouteResponse>> allRoutesFuture = CompletableFuture.allOf(routeFutures.toArray(new CompletableFuture[0]))
+                .thenApply(v -> routeFutures.stream()
+                        .map(CompletableFuture::join)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()));
 
-            CompletableFuture<ClosestParkingLot> closestParkingLotFuture =
-                    CompletableFuture.supplyAsync(() -> parkingLotFinder.findClosestParkingLot(subway.getPoint()), executor);
+        CompletableFuture<ClosestParkingLot> closestParkingLotFuture =
+                CompletableFuture.supplyAsync(() -> parkingLotFinder.findClosestParkingLot(subway.getPoint()), routeExecutor);
 
-            CompletableFuture<Void> combinedFuture = CompletableFuture.allOf(allRoutesFuture, closestParkingLotFuture);
-            return combinedFuture.thenApply(v -> {
+        return allRoutesFuture.thenCombine(closestParkingLotFuture, (routes, closestParkingLot) -> {
+            if (routes.isEmpty()) {
+                log.warn("[RouteAssembler] No routes found for subway: {}", subway.getName());
+                return null;
+            }
+            return MeetingPointRouteGroup.of(routes, subway, closestParkingLot);
+        });
+    }
+
+    private RouteResponse fetchWithRetry(StartPoint startPoint, Subway subway) {
+        for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+            RouteResponse route = routeFetcher.fetch(startPoint, subway);
+            if (isValid(route)) return route;
+
+            if (attempt < MAX_ATTEMPTS - 1) {
+                log.warn("[RouteAssembler] Route fetch failed for {}. Retrying... (Attempt {}/{})",
+                        startPoint.getName(), attempt + 1, MAX_ATTEMPTS);
                 try {
-                    List<RouteResponse> routes = allRoutesFuture.get();
-                    ClosestParkingLot closestParkingLot = closestParkingLotFuture.get();
-
-                    if (routes == null || routes.isEmpty()) {
-                        log.warn("[RouteAssembler] No routes found for subway: {}", subway);
-                        return null;
-                    }
-                    return MeetingPointRouteGroup.of(routes, subway, closestParkingLot);
-                } catch (Exception e) {
-                    log.warn("[RouteAssembler] Failed assembling MeetingPointRouteGroup", e);
-                    return null;
+                    Thread.sleep(RETRY_DELAY_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new EventException(EventErrorType.ROUTE_FETCH_FAILED);
                 }
-            });
+            }
         }
+        return null;
+    }
+
+    private boolean isValid(RouteResponse route) {
+        if (route == null) return false;
+        return (route.getIsTransit() && route.getTransitRoute() != null) ||
+                (!route.getIsTransit() && route.getDrivingRoute() != null);
     }
 }

--- a/src/main/java/com/meetup/server/global/config/ThreadConfig.java
+++ b/src/main/java/com/meetup/server/global/config/ThreadConfig.java
@@ -1,0 +1,18 @@
+package com.meetup.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+@Configuration
+public class ThreadConfig {
+
+    @Bean
+    public ExecutorService routeExecutor() {
+        ThreadFactory threadFactory = Thread.ofVirtual().name("route-thread-", 0).factory();
+        return Executors.newThreadPerTaskExecutor(threadFactory);
+    }
+}


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

<img width="580" height="297" alt="스크린샷 2026-01-08 오후 11 12 37" src="https://github.com/user-attachments/assets/05fc5578-3e18-46b9-b25f-c60040f92b25" />

출발지 수가 6개 이상 + 중간지점 수 2개 이상일 경우, 1개의 중간지점의 경로 조회가 대부분 실패합니다. 
이 경우를 대처하기 위해 작업을 진행했습니다.

## ✅ What - 무엇이 변경됐나요?

- 기존 Platform Thread에서 Virtual Thread로 변경
- `get + try-catch`에서 join으로 변경
- 경로 못가져올 경우, 1번 재시도하는 로직 추가

## 🛠️ How - 어떻게 해결했나요?

- 재시도는 첫시도 포함 2번이고 재시도 간격은 0.1초 (100ms)입니다. 보수적으로 잡았으며 100ms로 했을 때 중간지점 3개 + 출발지 8개에서 경로를 다 가져올 수 있었습니다. 추후 경과를 보고 값 변경 진행 필요합니다.
- Platform Thread는 sleep 시 block 하여 OS 자원을 점유하지만 Virtual Thread는 sleep 시 block이 아닌 unmount를 통해 다른 Virtual Thread를 실행할 수 있습니다. 따라서 Virtual Thread로 변경했습니다. ([참고](https://d2.naver.com/helloworld/1203723))

## 🖼️ Attachment

## 💬 기타 코멘트

- 스테이징 서버에서 충분한 테스트 진행 후 릴리즈 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 경로 조회에 재시도 메커니즘 추가로 실패 시 자동 재시도 지원

* **성능 개선**
  * 가상 스레드 기반 실행 환경 도입으로 경로 처리 효율성 향상

* **개선 사항**
  * 경로 응답 유효성 검증 로직 추가로 더 안정적인 결과 선별

* **수정**
  * 이벤트 캐시 검사 흐름이 변경되어 관련 예외 처리 방식이 조정됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->