### PR TITLE
[MOISAM-250] Logback을 적용하고 Filter에서 요청, 응답 에러를 로깅한다

### DIFF
--- a/deploy/prod/spot-backend-deployment.yaml
+++ b/deploy/prod/spot-backend-deployment.yaml
@@ -35,5 +35,13 @@ spec:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
+          volumeMounts:
+            - name: backend-log-volume
+              mountPath: /logs
+      volumes:
+        - name: backend-log-volume
+          hostPath:
+            path: /var/log/moisam
+            type: DirectoryOrCreate
       imagePullSecrets:
         - name: ncp-registry-secret

--- a/src/main/java/com/meetup/server/auth/application/AuthService.java
+++ b/src/main/java/com/meetup/server/auth/application/AuthService.java
@@ -53,8 +53,8 @@ public class AuthService {
     }
 
     private String resolveToken(String token) {
-        log.info("accessToken check: {}", token);
-        log.info("resolveToken check: {}", token);
+        log.debug("accessToken check: {}", token);
+        log.debug("resolveToken check: {}", token);
 
         if (token == null) {
             throw new AuthException(AuthErrorType.INVALID_REFRESH_TOKEN);

--- a/src/main/java/com/meetup/server/auth/application/AuthService.java
+++ b/src/main/java/com/meetup/server/auth/application/AuthService.java
@@ -5,7 +5,6 @@ import com.meetup.server.auth.exception.AuthErrorType;
 import com.meetup.server.auth.exception.AuthException;
 import com.meetup.server.auth.support.CookieUtil;
 import com.meetup.server.global.support.jwt.JwtTokenProvider;
-import com.meetup.server.user.application.UserService;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.implement.UserReader;
 import jakarta.servlet.http.HttpServletResponse;
@@ -53,9 +52,6 @@ public class AuthService {
     }
 
     private String resolveToken(String token) {
-        log.debug("accessToken check: {}", token);
-        log.debug("resolveToken check: {}", token);
-
         if (token == null) {
             throw new AuthException(AuthErrorType.INVALID_REFRESH_TOKEN);
         }

--- a/src/main/java/com/meetup/server/auth/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/meetup/server/auth/application/CustomOAuth2UserService.java
@@ -49,15 +49,22 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private User getOrGenerateUser(OAuthAttributes attributes) {
         String socialId = attributes.oauth2UserInfo().getSocialId();
-        log.info("attributes: {}", attributes);
+        String email = attributes.oauth2UserInfo().getEmail();
 
         return userRepository.findBySocialId(socialId)
                 .map(user -> {
                     if (user.isDeleted()) {
+                        log.info("[Rejoin] 탈퇴 후 재가입 - Email: {}", email);
                         user.rejoin(attributes.toEntity(attributes.oauth2UserInfo()));
+                        return userRepository.save(user);
                     }
-                    return userRepository.save(user);
+                    log.info("[Login] 로그인 - UserId: {}, Email: {}", user.getUserId(), email);
+                    return user;
                 })
-                .orElseGet(() -> userRepository.save(attributes.toEntity(attributes.oauth2UserInfo())));
+                .orElseGet(() -> {
+                    log.info("[Register] 회원가입 - Email: {}", email);
+                    User newUser = attributes.toEntity(attributes.oauth2UserInfo());
+                    return userRepository.save(newUser);
+                });
     }
 }

--- a/src/main/java/com/meetup/server/auth/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/meetup/server/auth/application/CustomOAuth2UserService.java
@@ -49,20 +49,19 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private User getOrGenerateUser(OAuthAttributes attributes) {
         String socialId = attributes.oauth2UserInfo().getSocialId();
-        String email = attributes.oauth2UserInfo().getEmail();
 
         return userRepository.findBySocialId(socialId)
                 .map(user -> {
                     if (user.isDeleted()) {
-                        log.info("[Rejoin] 탈퇴 후 재가입 - Email: {}", email);
+                        log.info("[Rejoin] 탈퇴 후 재가입 - SocialId: {}, UserId: {}", socialId, user.getUserId());
                         user.rejoin(attributes.toEntity(attributes.oauth2UserInfo()));
                         return userRepository.save(user);
                     }
-                    log.info("[Login] 로그인 - UserId: {}, Email: {}", user.getUserId(), email);
+                    log.info("[Login] 로그인 - SocialId: {}, UserId: {}", socialId, user.getUserId());
                     return user;
                 })
                 .orElseGet(() -> {
-                    log.info("[Register] 회원가입 - Email: {}", email);
+                    log.info("[Register] 회원가입 - SocialId: {}", socialId);
                     User newUser = attributes.toEntity(attributes.oauth2UserInfo());
                     return userRepository.save(newUser);
                 });

--- a/src/main/java/com/meetup/server/auth/exception/AuthErrorType.java
+++ b/src/main/java/com/meetup/server/auth/exception/AuthErrorType.java
@@ -12,6 +12,8 @@ public enum AuthErrorType implements ErrorType {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
     INVALID_TOKEN_ROLE(HttpStatus.FORBIDDEN, "ROLE이 유효하지 않습니다."),
+    INVALID_PERMISSION(HttpStatus.FORBIDDEN, "해당 요청을 수행할 권한이 없거나 유효하지 않습니다."),
+    FAILED_OAUTH_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "소셜 로그인 인증 과정에서 오류가 발생했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/meetup/server/auth/presentation/filter/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/meetup/server/auth/presentation/filter/JwtAccessDeniedHandler.java
@@ -3,9 +3,11 @@ package com.meetup.server.auth.presentation.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meetup.server.auth.exception.AuthErrorType;
 import com.meetup.server.global.support.response.ApiResponse;
+import com.meetup.server.global.util.LoggingUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
@@ -14,8 +16,9 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-@RequiredArgsConstructor
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
     private final ObjectMapper mapper;
@@ -23,6 +26,8 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
+        LoggingUtil.logError("[Forbidden]", AuthErrorType.INVALID_PERMISSION, accessDeniedException);
+
         response.setStatus(HttpStatus.FORBIDDEN.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/meetup/server/auth/presentation/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/meetup/server/auth/presentation/filter/JwtAuthenticationEntryPoint.java
@@ -3,9 +3,11 @@ package com.meetup.server.auth.presentation.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meetup.server.auth.exception.AuthErrorType;
 import com.meetup.server.global.support.response.ApiResponse;
+import com.meetup.server.global.util.LoggingUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -14,8 +16,9 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-@RequiredArgsConstructor
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper mapper;
@@ -23,6 +26,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
+        LoggingUtil.logError("[UnAuthorized]", AuthErrorType.INVALID_TOKEN, authException);
+
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/meetup/server/auth/presentation/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/meetup/server/auth/presentation/filter/JwtAuthenticationFilter.java
@@ -2,9 +2,11 @@ package com.meetup.server.auth.presentation.filter;
 
 import com.meetup.server.auth.application.AuthService;
 import com.meetup.server.auth.dto.response.ReissueTokenResponse;
+import com.meetup.server.auth.exception.AuthErrorType;
 import com.meetup.server.auth.support.AuthenticationUtil;
 import com.meetup.server.auth.support.CookieUtil;
 import com.meetup.server.global.support.jwt.JwtTokenProvider;
+import com.meetup.server.global.util.LoggingUtil;
 import com.meetup.server.user.exception.UserException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -55,7 +57,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 cookieUtil.setAccessTokenCookie(response, reissueTokenResponse.accessToken());
                 authenticationUtil.setAuthenticationFromRequest(request, reissueTokenResponse.accessToken());
             } catch (UserException e) {
-                log.error("Token is invalid, user check failed: {}", e.getMessage());
+                LoggingUtil.logError("[ReissueFailed]", AuthErrorType.INVALID_REFRESH_TOKEN, e);
                 cookieUtil.deleteAccessTokenCookie(response);
                 cookieUtil.deleteRefreshTokenCookie(response);
             }

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginFailureHandler.java
@@ -1,5 +1,7 @@
 package com.meetup.server.auth.support.handler;
 
+import com.meetup.server.auth.exception.AuthErrorType;
+import com.meetup.server.global.util.LoggingUtil;
 import com.meetup.server.log.domain.type.LoginStatus;
 import com.meetup.server.log.implement.LogUserLoginWriter;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,11 +32,11 @@ public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHan
             HttpServletRequest request, HttpServletResponse response, AuthenticationException exception
     ) throws IOException {
 
-        log.info("OAuth2 login failed: {}", exception.getMessage());
-
         String ipAddress = request.getHeader("X-Real-IP");
         String userAgent = request.getHeader(HttpHeaders.USER_AGENT);
         logUserLoginWriter.save(null, LoginStatus.FAILURE, ipAddress, userAgent, exception.getMessage());
+
+        LoggingUtil.logError("[OAuth2Failed]", AuthErrorType.FAILED_OAUTH_AUTHENTICATION, exception);
 
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
                 .queryParam("error", exception.getLocalizedMessage())

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -63,7 +63,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             redirectUrl = buildDefaultCallbackUrl(stateParams.eventId, stateParams.to);
         }
 
-        log.info("[Redirect URI] - {}", redirectUrl);
         return redirectUrl;
     }
 

--- a/src/main/java/com/meetup/server/batch/place/job/PlaceSaveJob.java
+++ b/src/main/java/com/meetup/server/batch/place/job/PlaceSaveJob.java
@@ -116,7 +116,7 @@ public class PlaceSaveJob {
             for (KakaoSearchResponse kakaoSearchResponse : kakaoLocalResponse.getKakaoSearchResponses()) {
                 try {
                     if (placeRepository.existsByKakaoPlaceId(kakaoSearchResponse.getId())) {
-                        log.info("이미 존재하는 장소, 건너뜀: {}", kakaoSearchResponse.getPlaceName());
+                        log.debug("이미 존재하는 장소, 건너뜀: {}", kakaoSearchResponse.getPlaceName());
                         continue;
                     }
 

--- a/src/main/java/com/meetup/server/global/cache/LoggingCache.java
+++ b/src/main/java/com/meetup/server/global/cache/LoggingCache.java
@@ -16,13 +16,13 @@ public class LoggingCache implements Cache {
 
     @Override
     public String getName() {
-        log.info("[Redis] Cache Name: {}", delegate.getName());
+        log.debug("[Redis] Cache Name: {}", delegate.getName());
         return delegate.getName();
     }
 
     @Override
     public Object getNativeCache() {
-        log.info("[Redis] Accessing Native Cache instance");
+        log.debug("[Redis] Accessing Native Cache instance");
         return delegate.getNativeCache();
     }
 
@@ -30,9 +30,9 @@ public class LoggingCache implements Cache {
     public ValueWrapper get(Object key) {
         ValueWrapper valueWrapper = delegate.get(key);
         if (valueWrapper != null) {
-            log.info("[Redis] Cache Hit AND Key: {}", key);
+            log.debug("[Redis] Cache Hit AND Key: {}", key);
         } else {
-            log.info("[Redis] Cache Miss AND Key: {}", key);
+            log.debug("[Redis] Cache Miss AND Key: {}", key);
         }
         return valueWrapper;
     }
@@ -41,9 +41,9 @@ public class LoggingCache implements Cache {
     public <T> T get(Object key, Class<T> type) {
         T value = delegate.get(key, type);
         if (value != null) {
-            log.info("[Redis] Cache Hit AND Key: {} with type: {}", key, type.getName());
+            log.debug("[Redis] Cache Hit AND Key: {} with type: {}", key, type.getName());
         } else {
-            log.info("[Redis] Cache Miss AND Key: {} with type: {}", key, type.getName());
+            log.debug("[Redis] Cache Miss AND Key: {} with type: {}", key, type.getName());
         }
         return value;
     }
@@ -53,9 +53,9 @@ public class LoggingCache implements Cache {
         try {
             T value = delegate.get(key, valueLoader);
             if (value != null) {
-                log.info("[Redis] Cache Hit AND Key: {}", key);
+                log.debug("[Redis] Cache Hit AND Key: {}", key);
             } else {
-                log.info("[Redis] Cache Miss AND Key: {}", key);
+                log.debug("[Redis] Cache Miss AND Key: {}", key);
             }
             return value;
         } catch (Exception e) {
@@ -66,19 +66,19 @@ public class LoggingCache implements Cache {
 
     @Override
     public void put(Object key, Object value) {
-        log.info("[Redis] Putting Cache Key: {} with Value: {}", key, value);
+        log.debug("[Redis] Putting Cache Key: {} with Value: {}", key, value);
         delegate.put(key, value);
     }
 
     @Override
     public void evict(Object key) {
-        log.info("[Redis] Evicting Cache Key: {}", key);
+        log.debug("[Redis] Evicting Cache Key: {}", key);
         delegate.evict(key);
     }
 
     @Override
     public void clear() {
-        log.info("[Redis] Clearing all cache entries");
+        log.debug("[Redis] Clearing all cache entries");
         delegate.clear();
     }
 }

--- a/src/main/java/com/meetup/server/global/config/FilterConfig.java
+++ b/src/main/java/com/meetup/server/global/config/FilterConfig.java
@@ -1,0 +1,20 @@
+package com.meetup.server.global.config;
+
+import com.meetup.server.global.filter.LoggingFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<LoggingFilter> loggingFilterRegistration(LoggingFilter loggingFilter) {
+        FilterRegistrationBean<LoggingFilter> registration = new FilterRegistrationBean<>(loggingFilter);
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        registration.addUrlPatterns("/*");
+
+        return registration;
+    }
+}

--- a/src/main/java/com/meetup/server/global/filter/LoggingFilter.java
+++ b/src/main/java/com/meetup/server/global/filter/LoggingFilter.java
@@ -1,0 +1,75 @@
+package com.meetup.server.global.filter;
+
+import com.meetup.server.global.util.LoggingUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class LoggingFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID = "TRACE_ID";
+    private static final List<String> EXCLUDE_PATHS = Arrays.asList(
+            "/actuator",
+            "/swagger-ui",
+            "/swagger-resources",
+            "/v3/api-docs",
+            "/webjars",
+            "/favicon.ico"
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (shouldSkipLogging(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+        long startTime = System.currentTimeMillis();
+        String traceId = getOrGenerateTraceId(requestWrapper);
+        MDC.put(TRACE_ID, traceId);
+
+        try {
+            filterChain.doFilter(requestWrapper, responseWrapper);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+
+            LoggingUtil.logRequest(requestWrapper);
+            LoggingUtil.logResponse(responseWrapper, duration);
+
+            responseWrapper.copyBodyToResponse();
+            MDC.clear();
+        }
+    }
+
+    private boolean shouldSkipLogging(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        return EXCLUDE_PATHS.stream().anyMatch(uri::startsWith);
+    }
+
+    private String getOrGenerateTraceId(HttpServletRequest request) {
+        String traceId = request.getHeader("X-Trace-Id");
+        if (traceId == null || traceId.isBlank()) {
+            traceId = UUID.randomUUID().toString().substring(0, 8);
+        }
+        return traceId;
+    }
+}

--- a/src/main/java/com/meetup/server/global/presentation/ApiControllerAdvice.java
+++ b/src/main/java/com/meetup/server/global/presentation/ApiControllerAdvice.java
@@ -4,6 +4,7 @@ import com.meetup.server.global.support.error.GlobalErrorType;
 import com.meetup.server.global.support.error.GlobalException;
 import com.meetup.server.global.support.error.discord.DiscordAlarmSender;
 import com.meetup.server.global.support.response.ApiResponse;
+import com.meetup.server.global.util.LoggingUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,13 +16,13 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
-public class ApiControllerAdvice{
+public class ApiControllerAdvice {
 
     private final DiscordAlarmSender discordAlarmSender;
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
-        log.error("Exception : {}", e.getMessage(), e);
+        LoggingUtil.logError("[Exception]", GlobalErrorType.INTERNAL_ERROR, e);
         discordAlarmSender.sendErrorAlert(e);
         return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.INTERNAL_ERROR), GlobalErrorType.INTERNAL_ERROR.getStatus());
     }
@@ -33,19 +34,19 @@ public class ApiControllerAdvice{
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        log.error("MethodArgumentNotValidException : {}", e.getMessage(), e);
+        LoggingUtil.logError("[MethodArgumentNotValidException]", GlobalErrorType.FAILED_REQUEST_VALIDATION, e);
         return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.FAILED_REQUEST_VALIDATION), GlobalErrorType.FAILED_REQUEST_VALIDATION.getStatus());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
-        log.error("IllegalArgumentException : {}", e.getMessage(), e);
+        LoggingUtil.logError("[IllegalArgumentException]", GlobalErrorType.INVALID_REQUEST_ARGUMENT, e);
         return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.INVALID_REQUEST_ARGUMENT), GlobalErrorType.INVALID_REQUEST_ARGUMENT.getStatus());
     }
 
     @ExceptionHandler(GlobalException.class)
     public ResponseEntity<ApiResponse<?>> handleGlobalException(GlobalException e) {
-        log.error("GlobalException : {}", e.getMessage(), e);
+        LoggingUtil.logError(String.format("[%s]", e.getClass().getSimpleName()), e.getErrorType(), e);
         return new ResponseEntity<>(ApiResponse.error(e.getErrorType()), e.getErrorType().getStatus());
     }
 

--- a/src/main/java/com/meetup/server/global/support/PerformanceAspect.java
+++ b/src/main/java/com/meetup/server/global/support/PerformanceAspect.java
@@ -21,7 +21,7 @@ public class PerformanceAspect {
         } finally {
             long elapsed = System.currentTimeMillis() - start;
             String methodName = joinPoint.getSignature().toShortString();
-            log.info("[Performance] methodName : {}, executeTime : {} ms", methodName, elapsed);
+            log.debug("[Performance] methodName : {}, executeTime : {} ms", methodName, elapsed);
         }
     }
 }

--- a/src/main/java/com/meetup/server/global/util/LoggingUtil.java
+++ b/src/main/java/com/meetup/server/global/util/LoggingUtil.java
@@ -1,0 +1,94 @@
+package com.meetup.server.global.util;
+
+import com.meetup.server.global.support.error.ErrorType;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LoggingUtil {
+
+    private static final int HTTP_ERROR_THRESHOLD = 400;
+
+    public static void logRequest(ContentCachingRequestWrapper request) {
+        String method = request.getMethod();
+        String path = request.getRequestURI();
+        String queryString = request.getQueryString() != null ? "?" + request.getQueryString() : "";
+        String requestBody = getRequestBody(request);
+        String cookies = getCookies(request);
+
+        String msg = """
+                [Request] Method=%s, Path=%s
+                QueryString=%s
+                Body=%s
+                Cookies=%s""".formatted(method, path, queryString, requestBody, cookies);
+
+        log.info(msg);
+    }
+
+    public static void logResponse(ContentCachingResponseWrapper response, long duration) {
+        String msg = "[Response] StatusCode=%d, Duration=%dms".formatted(response.getStatus(), duration);
+
+        if (response.getStatus() >= HTTP_ERROR_THRESHOLD) {
+            log.error(msg);
+        } else {
+            log.info(msg);
+        }
+    }
+
+    public static void logError(String logTag, ErrorType errorType, Exception e) {
+        String errorCode = ((Enum<?>) errorType).name();
+        String message = errorType.getMessage();
+        String exceptionType = e.getClass().getSimpleName();
+
+        String errorBody = """
+                {
+                  "errorCode": "%s",
+                  "message": "%s",
+                  "type": "%s"
+                }""".formatted(errorCode, message, exceptionType);
+
+        String logMsg = """
+                %s ErrorCode=%d
+                Message=%s
+                Body=%s""".formatted(logTag, errorType.getStatus().value(), message, errorBody);
+
+        log.error(logMsg, e);
+    }
+
+    public static String getCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0) {
+            return "[]";
+        }
+
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < cookies.length; i++) {
+            sb.append(String.format("{\"%s\":\"%s\"}", cookies[i].getName(), cookies[i].getValue()));
+            if (i < cookies.length - 1) {
+                sb.append(", ");
+            }
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    public static String getRequestBody(ContentCachingRequestWrapper request) {
+        byte[] content = request.getContentAsByteArray();
+        if (content.length == 0) return "";
+        try {
+            String encoding = request.getCharacterEncoding();
+            return new String(content, encoding);
+        } catch (UnsupportedEncodingException e) {
+            return new String(content, StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/main/java/com/meetup/server/global/util/LoggingUtil.java
+++ b/src/main/java/com/meetup/server/global/util/LoggingUtil.java
@@ -1,8 +1,6 @@
 package com.meetup.server.global.util;
 
 import com.meetup.server.global.support.error.ErrorType;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,14 +21,11 @@ public class LoggingUtil {
         String path = request.getRequestURI();
         String queryString = request.getQueryString() != null ? "?" + request.getQueryString() : "";
         String requestBody = getRequestBody(request);
-        String cookies = getCookies(request);
 
         String msg = """
                 [Request] Method=%s, Path=%s
                 QueryString=%s
-                Body=%s
-                Cookies=%s""".formatted(method, path, queryString, requestBody, cookies);
-
+                Body=%s""".formatted(method, path, queryString, requestBody);
         log.info(msg);
     }
 
@@ -62,23 +57,6 @@ public class LoggingUtil {
                 Body=%s""".formatted(logTag, errorType.getStatus().value(), message, errorBody);
 
         log.error(logMsg, e);
-    }
-
-    public static String getCookies(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null || cookies.length == 0) {
-            return "[]";
-        }
-
-        StringBuilder sb = new StringBuilder("[");
-        for (int i = 0; i < cookies.length; i++) {
-            sb.append(String.format("{\"%s\":\"%s\"}", cookies[i].getName(), cookies[i].getValue()));
-            if (i < cookies.length - 1) {
-                sb.append(", ");
-            }
-        }
-        sb.append("]");
-        return sb.toString();
     }
 
     public static String getRequestBody(ContentCachingRequestWrapper request) {

--- a/src/main/java/com/meetup/server/place/infrastructure/jpa/init/PlaceDummy.java
+++ b/src/main/java/com/meetup/server/place/infrastructure/jpa/init/PlaceDummy.java
@@ -27,7 +27,7 @@ public class PlaceDummy implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         if (placeRepository.count() > 0) {
-            log.info("[REVIEW]더미 데이터 존재");
+            log.debug("[REVIEW]더미 데이터 존재");
         } else {
             List<Place> placeList = new ArrayList<>();
 

--- a/src/main/java/com/meetup/server/review/implement/ReviewTranslator.java
+++ b/src/main/java/com/meetup/server/review/implement/ReviewTranslator.java
@@ -23,7 +23,7 @@ public class ReviewTranslator {
 
     public String translate(String originalContent) {
         ClovaRequest request = createRequest(originalContent);
-        log.info("[Clova Studio] Request: {}", request);
+        log.debug("[Clova Studio] Request: {}", request);
 
         ClovaResponse response = clovaClient.sendRequest(request);
         if (response == null || response.result() == null || response.result().message() == null) {
@@ -32,7 +32,7 @@ public class ReviewTranslator {
         }
 
         String translated = response.result().message().content();
-        log.info("[Clova Studio] Translated: {}", translated);
+        log.debug("[Clova Studio] Translated: {}", translated);
         return translated;
     }
 

--- a/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
+++ b/src/main/java/com/meetup/server/startpoint/application/StartPointService.java
@@ -65,7 +65,7 @@ public class StartPointService {
 
             eventProcessor.deleteRoute(eventId);
             routeProcessor.deleteCache(eventId);
-            log.info("[DELETE ROUTE/CACHE] eventId: {}", eventId);
+            log.debug("[DELETE ROUTE/CACHE] eventId: {}", eventId);
 
             return EventStartPointResponse.of(event, startPoint);
         } finally {

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathProcessor.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathProcessor.java
@@ -81,7 +81,7 @@ public class SubwayPathProcessor {
             }
 
             if (nodeCount >= MAX_NODES) {
-                log.warn("[SubwayPathProcessor] : 노드 수 제한 초과로 대체 경로 반환 (startSubwayId: {}, endSubwayId: {})", startSubwayId, endSubwayId);
+                log.debug("노드 수 제한 초과로 대체 경로 반환 (startSubwayId: {}, endSubwayId: {})", startSubwayId, endSubwayId);
                 return createFallbackPath(subwayMap, bestNode, startSubwayId, endSubwayId);
             }
 
@@ -124,7 +124,7 @@ public class SubwayPathProcessor {
             }
         }
 
-        log.warn("[SubwayPathProcessor] : 경로를 찾지 못해 대체 경로 반환 (startSubwayId: {}, endSubwayId: {})", startSubwayId, endSubwayId);
+        log.debug("경로를 찾지 못해 대체 경로 반환 (startSubwayId: {}, endSubwayId: {})", startSubwayId, endSubwayId);
         return createFallbackPath(subwayMap, bestNode, startSubwayId, endSubwayId);
     }
 
@@ -132,9 +132,9 @@ public class SubwayPathProcessor {
      * A* 알고리즘의 휴리스틱 함수.
      * 현재 역에서 도착역까지의 직선 거리 기반 예상 소요 시간(초) 계산.
      *
-     * @param subwayId     현재 역 ID
-     * @param endSubwayId  도착역 ID
-     * @param subwayMap    역 정보 맵
+     * @param subwayId    현재 역 ID
+     * @param endSubwayId 도착역 ID
+     * @param subwayMap   역 정보 맵
      * @return 예상 소요 시간 (초)
      */
     private double heuristic(int subwayId, int endSubwayId, Map<Integer, Subway> subwayMap) {
@@ -148,8 +148,8 @@ public class SubwayPathProcessor {
      * 최단 경로 탐색 실패 시 대체 경로 생성.
      * bestNode를 기반으로 경로를 만들고, 도착역 미도달 시 직선 거리 기반 시간 추가.
      *
-     * @param subwayMap    역 정보 맵
-     * @param bestNode     가장 유망한 노드 (최소 totalTime)
+     * @param subwayMap     역 정보 맵
+     * @param bestNode      가장 유망한 노드 (최소 totalTime)
      * @param startSubwayId 출발역 ID
      * @param endSubwayId   도착역 ID
      * @return 대체 경로 결과
@@ -174,7 +174,7 @@ public class SubwayPathProcessor {
         List<String> pathNames = path.stream()
                 .map(id -> subwayMap.get(id).getName())
                 .collect(Collectors.toList());
-        log.info("[SubwayPathProcessor] : 대체 경로 생성 - path: {}, totalTime: {}", path, estimatedTime);
+        log.debug("대체 경로 생성 - path: {}, totalTime: {}", path, estimatedTime);
         return new SubwayPathResult(estimatedTime, path, pathNames);
     }
 

--- a/src/main/java/com/meetup/server/subway/infrastructure/csv/SubwayCsvLoader.java
+++ b/src/main/java/com/meetup/server/subway/infrastructure/csv/SubwayCsvLoader.java
@@ -170,7 +170,7 @@ public class SubwayCsvLoader implements ApplicationRunner {
                 Subway toSubway = subwayRepository.findByCode(mapping.getToCode()).orElse(null);
 
                 if (fromSubway == null || toSubway == null) {
-                    log.warn("지하철 정보 없음 - from: {} (code: {}, line: {}) / to: {} (code: {}, line: {})",
+                    log.debug("지하철 정보 없음 - from: {} (code: {}, line: {}) / to: {} (code: {}, line: {})",
                             mapping.getFromName(), mapping.getFromCode(), mapping.getFromLine(),
                             mapping.getToName(), mapping.getToCode(), mapping.getToLine());
                     continue;
@@ -178,7 +178,7 @@ public class SubwayCsvLoader implements ApplicationRunner {
 
                 String key = fromSubway.getSubwayId() + "-" + toSubway.getSubwayId();
                 if (existingTransferKeys.contains(key)) {
-                    log.info("중복 환승 정보 무시됨 - from: {} / to: {}", fromSubway.getSubwayId(), toSubway.getSubwayId());
+                    log.debug("중복 환승 정보 무시됨 - from: {} / to: {}", fromSubway.getSubwayId(), toSubway.getSubwayId());
                     continue;
                 }
 

--- a/src/main/java/com/meetup/server/user/infrastructure/jpa/init/UserDummy.java
+++ b/src/main/java/com/meetup/server/user/infrastructure/jpa/init/UserDummy.java
@@ -25,7 +25,7 @@ public class UserDummy implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) {
         if (userRepository.count() > 0) {
-            log.info("[USER]더미 데이터 존재");
+            log.debug("[USER]더미 데이터 존재");
         } else {
             ArrayList<User> userList = new ArrayList<>();
 

--- a/src/main/resources/logback-appenders.xml
+++ b/src/main/resources/logback-appenders.xml
@@ -1,0 +1,20 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] [%X{TRACE_ID}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./logs/api-app.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./logs/api-app.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] [%X{TRACE_ID}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,26 @@
+<configuration>
+    <include resource="logback-appenders.xml"/>
+
+    <logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="OFF"/>
+    <springProfile name="local">
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="org.hibernate.type.descriptor.sql" level="TRACE"/>
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="stg">
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="com.meetup.server" level="debug"/>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="info">
+            <appender-ref ref="ROLLING"/>
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="OFF"/>
     <springProfile name="local">
         <logger name="org.hibernate.SQL" level="DEBUG"/>
-        <logger name="org.hibernate.type.descriptor.sql" level="TRACE"/>
+        <logger name="org.hibernate.orm.jdbc.bind" level="TRACE"/>
         <root level="info">
             <appender-ref ref="CONSOLE"/>
         </root>

--- a/src/test/resources/docker-java.properties
+++ b/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

현재는 개발하면서 필요한 부분에 확인하는 용도로 로깅을 해왔습니다. 다만 서버 오류나 장애가 발생할 경우, 어디서부터 시작했는지, 어떤 요청에서 문제가 발생한건지 확인하기 어려운 문제가 있습니다. 
이번 PR에서 Logback을 적용하고 필터에서 요청, 응답 로깅을 하여 위 문제를 해결하고자 했습니다.

## ✅ What - 무엇이 변경됐나요?

- Logback 추가
  - 로컬: SQL Query, INFO 레벨 이상 로깅
  - 스테이징: DEBUG 레벨 이상 로깅
  - 운영: INFO 레벨 이상 로깅 + Rolling을 통해 로그 파일 저장 (7일 동안 저장)

- LoggingFilter 추가
  - 요청, 응답은 ContentCachingRequestWrapper, ContentCachingResponseWrapper에서 기존 요청, 응답을 감싸고 Controller에서 읽고 나서 감싼 클래스에서 요청, 응답을 가져와서 로깅하도록 구현
  - MDC를 사용해 요청, 응답, 에러의 key(TraceId) 부여 -> 어떤 요청에서 문제가 발생했는지 파악 가능

- Security 인증, 인가 로깅 추가
  - Security는 ApiControllerAdvice까지 에러를 가져오지 않고 Security 내부에서 처리하므로 Security 에러는 각 필터에 로깅 추가

## 🛠️ How - 어떻게 해결했나요?

What 참고

## 🖼️ Attachment

```
// 에러
2026-02-12 23:00:53 [http-nio-8080-exec-1] [62f4dfd2] ERROR c.m.server.global.util.LoggingUtil - [EventException] ErrorCode=404
Message=모임을 찾을 수 없습니다.
Body={
  "errorCode": "EVENT_NOT_FOUND",
  "message": "모임을 찾을 수 없습니다.",
  "type": "EventException"
}
com.meetup.server.event.exception.EventException: 모임을 찾을 수 없습니다.
	at com.meetup.server.event.implement.EventReader.lambda$read$0(EventReader.java:26)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at com.meetup.server.event.implement.EventReader.read(EventReader.java:26)
	at com.meetup.server.place.application.PlaceService.getAllPlaces(PlaceService.java:41)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:359)
// 요청
2026-02-12 23:00:53 [http-nio-8080-exec-1] [62f4dfd2] INFO  c.m.server.global.util.LoggingUtil - [Request] Method=GET, Path=/places
QueryString=?eventId=550e8400-e29b-41d4-a716-446655440000&subwayId=1
Body=
// 응답
2026-02-12 23:00:53 [http-nio-8080-exec-1] [62f4dfd2] ERROR c.m.server.global.util.LoggingUtil - [Response] StatusCode=404, Duration=147ms
```

## 💬 기타 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 요청/응답 로깅 필터와 트레이스 ID 지원, 중앙화된 로깅 유틸리티 및 필터 등록 추가
  * 환경별 콘솔/롤링 파일 로그 설정과 포맷 도입

* **버그 수정 / 개선**
  * 인증·권한·소셜 로그인 오류에 대한 일관된 구조화된 오류 로깅 및 응답 개선
  * 여러 컴포넌트의 로그 레벨을 INFO→DEBUG로 낮춰 운영 시 노이즈 감소

* **Chores**
  * 프로덕션 배포 설정을 통해 호스트에 로그를 영구 저장하도록 업데이트
* **기타**
  * 인증 오류 유형 확장 (권한/소셜 로그인 관련)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->