### PR TITLE
[MOISAM-251] 구글 리뷰 작성일자의 NPE 방지한다

### DIFF
--- a/src/main/java/com/meetup/server/batch/place/job/PlaceSaveJob.java
+++ b/src/main/java/com/meetup/server/batch/place/job/PlaceSaveJob.java
@@ -188,7 +188,7 @@ public class PlaceSaveJob {
                              GoogleSearchTextResponse.Place googlePlace,
                              String photoUri,
                              double longitude,
-                             double latitude) throws JsonProcessingException {
+                             double latitude) {
         return Place.builder()
                 .id(placeId)
                 .kakaoPlaceId(kakaoSearchResponse.getId())
@@ -211,7 +211,6 @@ public class PlaceSaveJob {
                 )
                 .location(Location.of(longitude, latitude))
                 .point(CoordinateUtil.createPoint(longitude, latitude))
-                .rawJson(objectMapper.writeValueAsString(googlePlace))
                 .build();
     }
 

--- a/src/main/java/com/meetup/server/place/domain/Place.java
+++ b/src/main/java/com/meetup/server/place/domain/Place.java
@@ -62,10 +62,6 @@ public class Place extends BaseEntity {
     @Column(columnDefinition = "geography(Point, 4326)")
     private Point point;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(columnDefinition = "JSONB")
-    private String rawJson;
-
     @PrePersist
     public void prePersist() {
         if (this.id == null) {
@@ -74,7 +70,7 @@ public class Place extends BaseEntity {
     }
 
     @Builder
-    public Place(UUID id, String kakaoPlaceId, String googlePlaceId, PlaceCategory category, String name, Double googleRating, List<Image> images, List<OpeningHour> openingHours, List<GoogleReview> googleReviews, Location location, Point point, String rawJson) {
+    public Place(UUID id, String kakaoPlaceId, String googlePlaceId, PlaceCategory category, String name, Double googleRating, List<Image> images, List<OpeningHour> openingHours, List<GoogleReview> googleReviews, Location location, Point point) {
         this.id = id;
         this.kakaoPlaceId = kakaoPlaceId;
         this.googlePlaceId = googlePlaceId;
@@ -86,7 +82,6 @@ public class Place extends BaseEntity {
         this.googleReviews = googleReviews;
         this.location = location;
         this.point = point;
-        this.rawJson = rawJson;
     }
 
     public boolean isSamePlace(Place place) {

--- a/src/main/java/com/meetup/server/place/dto/response/GoogleReviewResponse.java
+++ b/src/main/java/com/meetup/server/place/dto/response/GoogleReviewResponse.java
@@ -4,9 +4,11 @@ import com.meetup.server.place.domain.value.GoogleReview;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.TextStyle;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 @Builder
 public record GoogleReviewResponse(
@@ -20,8 +22,8 @@ public record GoogleReviewResponse(
         return GoogleReviewResponse.builder()
                 .nickname(googleReview.author())
                 .profileImage(googleReview.authorProfileImage())
-                .date(googleReview.publishTime().toLocalDate())
-                .day(googleReview.publishTime().getDayOfWeek().getDisplayName(TextStyle.SHORT_STANDALONE, Locale.KOREAN))
+                .date(Optional.ofNullable(googleReview.publishTime()).map(LocalDateTime::toLocalDate).orElse(null))
+                .day(Optional.ofNullable(googleReview.publishTime()).map(LocalDateTime::getDayOfWeek).map(day -> day.getDisplayName(TextStyle.SHORT_STANDALONE, Locale.KOREAN)).orElse(null))
                 .content(googleReview.content())
                 .build();
     }

--- a/src/main/java/com/meetup/server/place/implement/PlaceSorter.java
+++ b/src/main/java/com/meetup/server/place/implement/PlaceSorter.java
@@ -40,7 +40,10 @@ public class PlaceSorter {
 
     public List<GoogleReview> sortGoogleReviewByNewest(List<GoogleReview> googleReviews) {
         return googleReviews.stream()
-                .sorted(Comparator.comparing(GoogleReview::publishTime).reversed())
+                .sorted(Comparator.comparing(
+                        GoogleReview::publishTime,
+                        Comparator.nullsLast(Comparator.reverseOrder())
+                ))
                 .toList();
     }
 }

--- a/src/test/java/com/meetup/server/fixture/PlaceFixture.java
+++ b/src/test/java/com/meetup/server/fixture/PlaceFixture.java
@@ -21,7 +21,6 @@ public class PlaceFixture {
                 .googleReviews(List.of())
                 .location(Location.of(37.5406181573079, 127.06798560729))
                 .point(CoordinateUtil.createPoint(127.06798560729, 37.5406181573079))
-                .rawJson(null)
                 .build();
     }
 }


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- raw_json이 필요하지 않습니다.
- 리뷰 작성일자가 없을 경우, NPE가 발생합니다.

## ✅ What - 무엇이 변경됐나요?

- Place 테이블의 raw_json을 제거합니다.
- 리뷰 작성일자를 Optional 처리합니다.

## 🛠️ How - 어떻게 해결했나요?

What과 동일

## 🖼️ Attachment

## 💬 기타 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 리뷰의 게시일이 없을 때 날짜/요일을 안전하게 처리하도록 개선했습니다.
  * 리뷰 정렬 시 게시일 정보가 없는 항목을 일관되게 마지막으로 배치하도록 안정성 향상했습니다.

* **잡일(Chores)**
  * 내부 원시 JSON 저장 항목을 제거하고 관련 불필요한 예외 선언을 정리했습니다.

* **테스트**
  * 테스트 픽스처에서 불필요한 설정을 제거해 테스트 유지보수성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->