### PR TITLE
[MOISAM-252] Controller 테스트 공통 설정을 위한 커스텀 애노테이션 도입

### DIFF
--- a/src/main/java/com/meetup/server/auth/presentation/AuthController.java
+++ b/src/main/java/com/meetup/server/auth/presentation/AuthController.java
@@ -2,15 +2,10 @@ package com.meetup.server.auth.presentation;
 
 import com.meetup.server.auth.application.AuthService;
 import com.meetup.server.global.support.response.ApiResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Auth", description = "인증 API")
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -18,13 +13,11 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "Test 를 위한 Access Token 발급", description = "Swagger Test 를 위한 Access Token을 발급합니다.")
     @GetMapping("/test/{userId}")
     public String getAccessToken(@PathVariable Long userId) {
         return authService.createAccessTokenForUser(userId);
     }
 
-    @Operation(summary = "로그아웃 API", description = "사용자 로그아웃을 진행합니다.")
     @PostMapping("/logout")
     public ApiResponse<?> logout(HttpServletResponse response) {
         authService.logout(response);

--- a/src/main/java/com/meetup/server/place/dto/response/PlaceResponseList.java
+++ b/src/main/java/com/meetup/server/place/dto/response/PlaceResponseList.java
@@ -2,21 +2,13 @@ package com.meetup.server.place.dto.response;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.subway.domain.Subway;
-import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
 public record PlaceResponseList(
-        @Schema(description = "모임명", example = "개발자 모임")
         String eventName,
-
-        @Schema(description = "중간지점명", example = "선정릉")
         String middlePointName,
-
-        @Schema(description = "확정 장소")
         PlaceResponse confirmedPlaceResponse,
-
-        @Schema(description = "장소 추천 리스트")
         List<PlaceResponse> placeResponses
 ) {
     public static PlaceResponseList of(Event event, Subway subway, PlaceResponse confirmedPlaceResponse, List<PlaceResponse> placeResponses) {

--- a/src/main/java/com/meetup/server/place/presentation/PlaceController.java
+++ b/src/main/java/com/meetup/server/place/presentation/PlaceController.java
@@ -4,16 +4,11 @@ import com.meetup.server.global.support.response.ApiResponse;
 import com.meetup.server.place.application.PlaceService;
 import com.meetup.server.place.dto.response.PlaceDetailResponse;
 import com.meetup.server.place.dto.response.PlaceResponseList;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Slf4j
-@Tag(name = "Place API", description = "장소 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/places")
@@ -21,7 +16,6 @@ public class PlaceController {
 
     private final PlaceService placeService;
 
-    @Operation(summary = "장소 추천 리스트 조회 API", description = "역 주변의 장소 추천 리스트를 조회합니다")
     @GetMapping
     public ApiResponse<PlaceResponseList> getAllPlaces(
             @RequestParam UUID eventId,
@@ -30,7 +24,6 @@ public class PlaceController {
         return ApiResponse.success(placeService.getAllPlaces(eventId, subwayId));
     }
 
-    @Operation(summary = "장소 상세 조회 API", description = "장소 ID를 통해 장소의 상세 정보를 조회합니다.")
     @GetMapping("/{placeId}")
     public ApiResponse<PlaceDetailResponse> getPlaceDetails(
             @PathVariable UUID placeId,
@@ -40,7 +33,6 @@ public class PlaceController {
         return ApiResponse.success(placeService.getPlace(eventId, placeId, subwayId));
     }
 
-    @Operation(summary = "리뷰용 장소 조회 API", description = "리뷰 작성을 위해 이벤트 ID로 확정된 장소 정보를 조회합니다.")
     @GetMapping("/review")
     public ApiResponse<PlaceResponseList> getPlaceForReview(@RequestParam UUID eventId) {
         return ApiResponse.success(placeService.getPlaceForReview(eventId));

--- a/src/main/java/com/meetup/server/review/dto/request/NonVisitedReviewRequest.java
+++ b/src/main/java/com/meetup/server/review/dto/request/NonVisitedReviewRequest.java
@@ -1,36 +1,18 @@
 package com.meetup.server.review.dto.request;
 
 import com.meetup.server.review.domain.type.NonVisitedReasonCategory;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
 public record NonVisitedReviewRequest(
-
-        @Schema(description = """
-                방문하지 않은 이유 : NOISY(시끄러워서), CONGESTION(사람이 너무 많아서)
-                DARKNESS(공간이 어두워서), INSUFFICIENT_SEAT(좌석이 부족해서)
-                """, example = "[\"NOISY\", \"CONGESTION\"]", nullable = true)
         List<NonVisitedReasonCategory> categories,
-
-        @Schema(description = "기타 사유 (직접 입력하기)", example = "느좋 카페 가고 싶어요", nullable = true)
         String etcReason,
-
-        @Schema(description = "출발지명", example = "선정릉역 수인분당선", nullable = true)
         String placeName,
-
-        @Schema(description = "지번주소", example = "서울특별시 강남구 삼성동 111-114", nullable = true)
         String address,
-
-        @Schema(description = "도로명주소", example = "서울특별시 강남구 선릉로 지하580", nullable = true)
         String roadAddress,
-
-        @Schema(description = "경도", example = "127.043999", nullable = true)
         Double longitude,
-
-        @Schema(description = "위도", example = "37.510297", nullable = true)
         Double latitude
 ) {
 }

--- a/src/main/java/com/meetup/server/review/dto/request/VisitedReviewRequest.java
+++ b/src/main/java/com/meetup/server/review/dto/request/VisitedReviewRequest.java
@@ -1,7 +1,6 @@
 package com.meetup.server.review.dto.request;
 
 import com.meetup.server.review.domain.type.VisitedTime;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -11,22 +10,17 @@ import lombok.Builder;
 public record VisitedReviewRequest(
 
         @NotNull
-        @Schema(description = "방문 시간 : MORNING(아침), LUNCH(점심), NIGHT(저녁)", example = "MORNING")
         VisitedTime visitedTime,
 
         @Min(value = 1) @Max(value = 5)
-        @Schema(description = "콘센트 점수 (1 ~ 5)", example = "3")
         int socket,
 
         @Min(value = 1) @Max(value = 5)
-        @Schema(description = "좌석 점수 (1 ~ 5)", example = "4")
         int seat,
 
         @Min(value = 1) @Max(value = 5)
-        @Schema(description = "한산함 점수 (1 ~ 5)", example = "2")
         int quiet,
 
-        @Schema(description = "방문 후기", example = "카공하기 좋은 느좋카페")
         String content
 ) {
 }

--- a/src/main/java/com/meetup/server/review/presentation/ReviewController.java
+++ b/src/main/java/com/meetup/server/review/presentation/ReviewController.java
@@ -4,8 +4,6 @@ import com.meetup.server.global.support.response.ApiResponse;
 import com.meetup.server.review.application.ReviewService;
 import com.meetup.server.review.dto.request.NonVisitedReviewRequest;
 import com.meetup.server.review.dto.request.VisitedReviewRequest;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Tag(name = "Review API", description = "리뷰 API")
 @RestController
 @RequestMapping("/places/{placeId}/reviews")
 @RequiredArgsConstructor
@@ -21,7 +18,6 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    @Operation(summary = "확정 장소 방문 리뷰 작성 API", description = "확정 장소를 방문한 사용자의 리뷰를 작성합니다")
     @PostMapping("/visited")
     public ApiResponse<?> createVisitedReview(
             @PathVariable("placeId") UUID placeId,
@@ -33,7 +29,6 @@ public class ReviewController {
         return ApiResponse.success();
     }
 
-    @Operation(summary = "확정 장소 미방문 리뷰 작성 API", description = "확정 장소를 미방문한 사용자의 리뷰를 작성합니다")
     @PostMapping("/non-visited")
     public ApiResponse<?> createNonVisitedReview(
             @PathVariable("placeId") UUID placeId,

--- a/src/main/java/com/meetup/server/review/presentation/TranslateReviewController.java
+++ b/src/main/java/com/meetup/server/review/presentation/TranslateReviewController.java
@@ -4,14 +4,11 @@ import com.meetup.server.global.support.response.ApiResponse;
 import com.meetup.server.review.application.TranslateGoogleReviewService;
 import com.meetup.server.review.application.TranslateService;
 import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Review API", description = "리뷰 API")
 @RestController
 @RequestMapping("/reviews/translation")
 @RequiredArgsConstructor
@@ -21,17 +18,15 @@ public class TranslateReviewController {
     private final TranslateGoogleReviewService translateGoogleReviewService;
 
     @Hidden
-    @Operation(summary = "자체 리뷰 번역 API", description = "외국어로 작성된 리뷰를 한국어로 번역하여 저장합니다")
     @PostMapping("")
-    public ApiResponse<?> translateAndSaveReview(){
+    public ApiResponse<?> translateAndSaveReview() {
         translateService.saveReviewForKor();
         return ApiResponse.success();
     }
 
     @Hidden
-    @Operation(summary = "구글 리뷰 번역 API", description = "장소의 구글 리뷰를 한국어로 번역하여 저장합니다")
     @PostMapping("/google")
-    public ApiResponse<?> translateAndSaveGoogleReview(){
+    public ApiResponse<?> translateAndSaveGoogleReview() {
         translateGoogleReviewService.saveReviewForKor();
         return ApiResponse.success();
     }

--- a/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
+++ b/src/main/java/com/meetup/server/startpoint/dto/request/StartPointRequest.java
@@ -1,39 +1,31 @@
 package com.meetup.server.startpoint.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
 public record StartPointRequest(
 
         @NotBlank
         @Size(min = 1, max = 5)
-        @Schema(description = "사용자명", example = "안연아바보")
         String username,
 
         @NotBlank(message = "출발지명은 필수 값입니다.")
-        @Schema(description = "출발지명", example = "선정릉역 수인분당선")
         String startPoint,
 
         @NotBlank(message = "지번주소는 필수 값입니다.")
-        @Schema(description = "지번주소", example = "서울특별시 강남구 삼성동 111-114")
         String address,
 
         @NotNull
-        @Schema(description = "도로명주소 (빈 문자열 허용)", example = "서울특별시 강남구 선릉로 지하580")
         String roadAddress,
 
         @DecimalMin(value = "-180.0", message = "경도는 -180.0보다 크거나 같아야 합니다.")
         @DecimalMax(value = "180.0", message = "경도는 180.0보다 작거나 같아야 합니다.")
-        @Schema(description = "경도", example = "127.043999")
         double longitude,
 
         @DecimalMin(value = "-90.0", message = "위도는 -90.0보다 크거나 같아야 합니다.")
         @DecimalMax(value = "90.0", message = "위도는 90.0보다 작거나 같아야 합니다.")
-        @Schema(description = "위도", example = "37.510297")
         double latitude,
 
         @NotNull(message = "대중교통/자가용 선택 여부는 필수 값입니다.")
-        @Schema(description = "대중교통/자가용 선택 여부", example = "true", defaultValue = "true")
         boolean isTransit
 ) {
 }

--- a/src/main/java/com/meetup/server/startpoint/presentation/StartPointController.java
+++ b/src/main/java/com/meetup/server/startpoint/presentation/StartPointController.java
@@ -5,8 +5,6 @@ import com.meetup.server.global.clients.kakao.local.KakaoLocalResponse;
 import com.meetup.server.global.support.response.ApiResponse;
 import com.meetup.server.startpoint.application.StartPointService;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,22 +12,20 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Tag(name = "StartPoint", description = "출발지 API")
 @RestController
 @RequiredArgsConstructor
 public class StartPointController {
 
     private final StartPointService startPointService;
 
-    @Operation(summary = "장소 검색 API", description = "외부 API를 통해 장소를 검색합니다.")
     @GetMapping("/start-points/search")
     public ApiResponse<KakaoLocalResponse> searchStartPoint(
-            @RequestParam(name = "textQuery") String textQuery) {
+            @RequestParam(name = "textQuery") String textQuery
+    ) {
         KakaoLocalResponse response = startPointService.searchStartPoint(textQuery);
         return ApiResponse.success(response);
     }
 
-    @Operation(summary = "출발지 생성 API", description = "출발지를 생성합니다")
     @PostMapping("/events/{eventId}/start-points")
     public ApiResponse<EventStartPointResponse> createStartPoint(
             @PathVariable UUID eventId,
@@ -40,18 +36,15 @@ public class StartPointController {
         return ApiResponse.success(startPointService.createStartPoint(eventId, userId, guestId, startPointRequest));
     }
 
-    @Operation(summary = "출발지 수정 API", description = "출발지를 수정합니다")
     @PatchMapping("/events/{eventId}/start-points/{startPointId}")
     public ApiResponse<EventStartPointResponse> updateStartPoint(
             @PathVariable UUID eventId,
             @PathVariable UUID startPointId,
             @Valid @RequestBody StartPointRequest startPointRequest
-
     ) {
         return ApiResponse.success(startPointService.updateStartPoint(eventId, startPointId, startPointRequest));
     }
 
-    @Operation(summary = "출발지 삭제 API", description = "출발지를 삭제합니다")
     @DeleteMapping("/events/{eventId}/start-points/{startPointId}")
     public ApiResponse<?> deleteStartPoint(
             @PathVariable UUID eventId,

--- a/src/main/java/com/meetup/server/user/domain/User.java
+++ b/src/main/java/com/meetup/server/user/domain/User.java
@@ -46,7 +46,8 @@ public class User extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public User(String nickname, String profileImage, String email, String socialId, Role role, boolean personalInfoAgreement, boolean marketingAgreement, LocalDateTime deletedAt) {
+    public User(Long userId, String nickname, String profileImage, String email, String socialId, Role role, boolean personalInfoAgreement, boolean marketingAgreement, LocalDateTime deletedAt) {
+        this.userId = userId;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.email = email;

--- a/src/main/java/com/meetup/server/user/presentation/UserController.java
+++ b/src/main/java/com/meetup/server/user/presentation/UserController.java
@@ -5,30 +5,24 @@ import com.meetup.server.user.application.UserService;
 import com.meetup.server.user.dto.request.UserAgreementRequest;
 import com.meetup.server.user.dto.response.UserEventHistoryResponseList;
 import com.meetup.server.user.dto.response.UserProfileInfoResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Tag(name = "User API", description = "사용자 API")
-@Slf4j
-@Validated
 @RestController
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "사용자 프로필 정보 조회 API", description = "유저의 프로필 정보를 조회합니다")
-    @GetMapping("")
+    @GetMapping
     public ApiResponse<?> getUserProfileInfo(
             @AuthenticationPrincipal Long userId
     ) {
@@ -36,7 +30,6 @@ public class UserController {
         return ApiResponse.success(response);
     }
 
-    @Operation(summary = "사용자 약관 동의 저장 API", description = "사용자의 개인정보 이용 동의와 마케팅 이용 동의를 저장합니다")
     @PostMapping("/agreement")
     public ApiResponse<?> saveUserAgreement(
             @AuthenticationPrincipal Long userId,
@@ -46,7 +39,6 @@ public class UserController {
         return ApiResponse.success();
     }
 
-    @Operation(summary = "모임 히스토리 리스트 조회 API", description = "로그인 한 사용자가 참여한 모임 리스트를 조회합니다")
     @GetMapping("/events")
     public ApiResponse<UserEventHistoryResponseList> getUserEventHistory(
             @AuthenticationPrincipal Long userId,
@@ -57,8 +49,7 @@ public class UserController {
         return ApiResponse.success(response);
     }
 
-    @Operation(summary = "사용자 닉네임 수정 API", description = "사용자의 닉네임을 수정합니다")
-    @PatchMapping("")
+    @PatchMapping
     public ApiResponse<?> updateNickname(
             @AuthenticationPrincipal Long userId,
             @RequestParam @NotBlank @Size(min = 1, max = 5) String nickname
@@ -67,8 +58,7 @@ public class UserController {
         return ApiResponse.success();
     }
 
-    @Operation(summary = "사용자 탈퇴 API", description = "사용자를 탈퇴시킵니다")
-    @DeleteMapping("")
+    @DeleteMapping
     public ApiResponse<?> withdrawUser(
             @AuthenticationPrincipal Long userId
     ) {

--- a/src/test/java/com/meetup/server/ServerApplicationTests.java
+++ b/src/test/java/com/meetup/server/ServerApplicationTests.java
@@ -1,9 +1,8 @@
 package com.meetup.server;
 
-import com.meetup.server.support.IntegrationTestContainer;
 import org.junit.jupiter.api.Test;
 
-class ServerApplicationTests extends IntegrationTestContainer {
+class ServerApplicationTests {
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/meetup/server/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/meetup/server/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,100 @@
+package com.meetup.server.auth.presentation;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.meetup.server.auth.application.AuthService;
+import com.meetup.server.fixture.AuthFixture;
+import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.global.support.response.ResultType;
+import com.meetup.server.support.ControllerTestSupport;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthControllerTest extends ControllerTestSupport {
+
+    @MockitoBean
+    private AuthService authService;
+
+    @DisplayName("Test를 위한 Access Token을 발급한다.")
+    @Test
+    void getAccessToken() throws Exception {
+        // given
+        Long userId = UserFixture.USER_ID;
+        String accessToken = AuthFixture.getAccessToken();
+
+        // when
+        Mockito.when(authService.createAccessTokenForUser(anyLong()))
+                .thenReturn(accessToken);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/auth/test/{userId}", userId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("auth/get-access-token",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Auth API")
+                                                .description("Test를 위한 Access Token을 발급한다.")
+                                                .pathParameters(
+                                                        parameterWithName("userId").description("사용자 ID")
+                                                )
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("사용자가 로그아웃한다.")
+    @Test
+    void logout() throws Exception {
+        // when
+        Mockito.doNothing().when(authService).logout(any(HttpServletResponse.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/auth/logout")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("auth/logout",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Auth API")
+                                                .description("사용자가 로그아웃한다.")
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .build())
+                        )
+                );
+    }
+}

--- a/src/test/java/com/meetup/server/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/meetup/server/auth/presentation/AuthControllerTest.java
@@ -6,6 +6,7 @@ import com.meetup.server.auth.application.AuthService;
 import com.meetup.server.fixture.AuthFixture;
 import com.meetup.server.fixture.UserFixture;
 import com.meetup.server.global.support.response.ResultType;
+import com.meetup.server.support.ControllerTest;
 import com.meetup.server.support.ControllerTestSupport;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ControllerTest(AuthController.class)
 class AuthControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
+++ b/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
@@ -16,6 +16,7 @@ import com.meetup.server.fixture.EventFixture;
 import com.meetup.server.fixture.StartPointFixture;
 import com.meetup.server.global.support.response.ResultType;
 import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.support.ControllerTest;
 import com.meetup.server.support.ControllerTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ControllerTest(EventController.class)
 class EventControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/meetup/server/fixture/AuthFixture.java
+++ b/src/test/java/com/meetup/server/fixture/AuthFixture.java
@@ -1,0 +1,10 @@
+package com.meetup.server.fixture;
+
+public class AuthFixture {
+
+    public static final String ACCESS_TOKEN = "test-access-token";
+
+    public static String getAccessToken() {
+        return ACCESS_TOKEN;
+    }
+}

--- a/src/test/java/com/meetup/server/fixture/PlaceFixture.java
+++ b/src/test/java/com/meetup/server/fixture/PlaceFixture.java
@@ -3,11 +3,26 @@ package com.meetup.server.fixture;
 import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.place.domain.type.PlaceCategory;
+import com.meetup.server.place.dto.response.PlaceDetailResponse;
+import com.meetup.server.place.dto.response.PlaceResponse;
+import com.meetup.server.place.dto.response.PlaceResponseList;
+import com.meetup.server.review.domain.value.PlaceScore;
 import com.meetup.server.startpoint.domain.type.Location;
 
+import java.time.LocalTime;
 import java.util.List;
+import java.util.UUID;
 
 public class PlaceFixture {
+
+    public static final UUID PLACE_ID = UUID.fromString("019c5b90-7e80-7875-857a-51bcf5db482a");
+    public static final String PLACE_NAME = "스타벅스 선정릉역점";
+    public static final PlaceCategory PLACE_CATEGORY = PlaceCategory.CAFE;
+    public static final int DISTANCE = 250;
+    public static final double AVERAGE_RATING = 4.3;
+    public static final double GOOGLE_RATING = 4.5;
+    public static final LocalTime OPEN_TIME = LocalTime.of(8, 0);
+    public static final LocalTime CLOSE_TIME = LocalTime.of(22, 0);
 
     public static Place getPlace() {
         return Place.builder()
@@ -21,6 +36,56 @@ public class PlaceFixture {
                 .googleReviews(List.of())
                 .location(Location.of(37.5406181573079, 127.06798560729))
                 .point(CoordinateUtil.createPoint(127.06798560729, 37.5406181573079))
+                .build();
+    }
+
+    public static PlaceResponse getPlaceResponse() {
+        return PlaceResponse.builder()
+                .id(PLACE_ID)
+                .category(PLACE_CATEGORY)
+                .name(PLACE_NAME)
+                .image("https://example.com/image.jpg")
+                .openTime(OPEN_TIME)
+                .closeTime(CLOSE_TIME)
+                .distance(DISTANCE)
+                .averageRating(AVERAGE_RATING)
+                .googleRating(GOOGLE_RATING)
+                .placeScore(PlaceScore.of(4, 5, 3))
+                .build();
+    }
+
+    public static PlaceResponseList getPlaceResponseList() {
+        return new PlaceResponseList(
+                "개발자 모임",
+                "선릉역",
+                getPlaceResponse(),
+                List.of(getPlaceResponse())
+        );
+    }
+
+    public static PlaceResponseList getPlaceResponseListForReview() {
+        return new PlaceResponseList(
+                "개발자 모임",
+                "선릉역",
+                getPlaceResponse(),
+                null
+        );
+    }
+
+    public static PlaceDetailResponse getPlaceDetailResponse() {
+        return PlaceDetailResponse.builder()
+                .id(PLACE_ID)
+                .kakaoPlaceId("1337065720")
+                .category(PLACE_CATEGORY)
+                .name(PLACE_NAME)
+                .images(List.of("https://example.com/image.jpg"))
+                .openTime(OPEN_TIME)
+                .closeTime(CLOSE_TIME)
+                .distance(DISTANCE)
+                .averageRating(AVERAGE_RATING)
+                .placeScore(PlaceScore.of(4, 5, 3))
+                .isConfirmed(true)
+                .isChanged(false)
                 .build();
     }
 }

--- a/src/test/java/com/meetup/server/fixture/ReviewFixture.java
+++ b/src/test/java/com/meetup/server/fixture/ReviewFixture.java
@@ -1,0 +1,41 @@
+package com.meetup.server.fixture;
+
+import com.meetup.server.review.domain.type.NonVisitedReasonCategory;
+import com.meetup.server.review.domain.type.VisitedTime;
+import com.meetup.server.review.dto.request.NonVisitedReviewRequest;
+import com.meetup.server.review.dto.request.VisitedReviewRequest;
+
+import java.util.List;
+
+public class ReviewFixture {
+
+    public static final String VISITED_REVIEW_CONTENT = "카공하기 좋은 느좋카페";
+    public static final String NON_VISITED_REASON = "다른 카페 가고 싶어요";
+    public static final String PLACE_NAME = "선정릉역 수인분당선";
+    public static final String ADDRESS = "서울특별시 강남구 삼성동 111-114";
+    public static final String ROAD_ADDRESS = "서울특별시 강남구 선릉로 지하580";
+    public static final double LONGITUDE = 127.043999;
+    public static final double LATITUDE = 37.510297;
+
+    public static VisitedReviewRequest getVisitedReviewRequest() {
+        return VisitedReviewRequest.builder()
+                .visitedTime(VisitedTime.MORNING)
+                .socket(4)
+                .seat(5)
+                .quiet(3)
+                .content(VISITED_REVIEW_CONTENT)
+                .build();
+    }
+
+    public static NonVisitedReviewRequest getNonVisitedReviewRequest() {
+        return NonVisitedReviewRequest.builder()
+                .categories(List.of(NonVisitedReasonCategory.NOISY, NonVisitedReasonCategory.CONGESTION))
+                .etcReason(NON_VISITED_REASON)
+                .placeName(PLACE_NAME)
+                .address(ADDRESS)
+                .roadAddress(ROAD_ADDRESS)
+                .longitude(LONGITUDE)
+                .latitude(LATITUDE)
+                .build();
+    }
+}

--- a/src/test/java/com/meetup/server/fixture/SubwayFixture.java
+++ b/src/test/java/com/meetup/server/fixture/SubwayFixture.java
@@ -6,6 +6,8 @@ import com.meetup.server.subway.domain.Subway;
 
 public class SubwayFixture {
 
+    public static final int SUBWAY_ID = 1;
+
     public static Subway getSubway() {
         return Subway.builder()
                 .name("강남")

--- a/src/test/java/com/meetup/server/fixture/UserFixture.java
+++ b/src/test/java/com/meetup/server/fixture/UserFixture.java
@@ -2,15 +2,24 @@ package com.meetup.server.fixture;
 
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.domain.type.Role;
+import com.meetup.server.user.dto.request.UserAgreementRequest;
+import com.meetup.server.user.dto.response.UserEventHistoryResponseList;
+import com.meetup.server.user.dto.response.UserProfileInfoResponse;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public class UserFixture {
 
+    public static final Long USER_ID = 1L;
+    public static final String TEST_NICKNAME = "땡수팟";
+    public static final String NEW_NICKNAME = "새닉네임";
+
     public static User getUser() {
         String uuid = UUID.randomUUID().toString();
         return User.builder()
+                .userId(USER_ID)
                 .nickname("땡수팟")
                 .socialId("kakao" + uuid)
                 .email(uuid + "@spot.com")
@@ -41,5 +50,17 @@ public class UserFixture {
                 .marketingAgreement(false)
                 .deletedAt(LocalDateTime.now())
                 .build();
+    }
+
+    public static UserProfileInfoResponse getUserProfileInfoResponse() {
+        return UserProfileInfoResponse.from(getUser());
+    }
+
+    public static UserAgreementRequest getUserAgreementRequest() {
+        return new UserAgreementRequest(true, true);
+    }
+
+    public static UserEventHistoryResponseList getUserEventHistoryResponseList() {
+        return UserEventHistoryResponseList.of(List.of(), false, null);
     }
 }

--- a/src/test/java/com/meetup/server/fixture/UserFixture.java
+++ b/src/test/java/com/meetup/server/fixture/UserFixture.java
@@ -19,6 +19,16 @@ public class UserFixture {
     public static User getUser() {
         String uuid = UUID.randomUUID().toString();
         return User.builder()
+                .nickname("땡수팟")
+                .socialId("kakao" + uuid)
+                .email(uuid + "@spot.com")
+                .role(Role.USER)
+                .build();
+    }
+
+    public static User getUserWithId() {
+        String uuid = UUID.randomUUID().toString();
+        return User.builder()
                 .userId(USER_ID)
                 .nickname("땡수팟")
                 .socialId("kakao" + uuid)
@@ -53,7 +63,7 @@ public class UserFixture {
     }
 
     public static UserProfileInfoResponse getUserProfileInfoResponse() {
-        return UserProfileInfoResponse.from(getUser());
+        return UserProfileInfoResponse.from(getUserWithId());
     }
 
     public static UserAgreementRequest getUserAgreementRequest() {

--- a/src/test/java/com/meetup/server/log/presentation/LogControllerTest.java
+++ b/src/test/java/com/meetup/server/log/presentation/LogControllerTest.java
@@ -7,6 +7,7 @@ import com.meetup.server.fixture.LogEventInflowFixture;
 import com.meetup.server.global.support.response.ResultType;
 import com.meetup.server.log.application.LogService;
 import com.meetup.server.log.dto.request.LogEventInflowRequest;
+import com.meetup.server.support.ControllerTest;
 import com.meetup.server.support.ControllerTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ControllerTest(LogController.class)
 class LogControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
@@ -10,6 +10,7 @@ import com.meetup.server.global.support.response.ResultType;
 import com.meetup.server.place.application.PlaceService;
 import com.meetup.server.place.dto.response.PlaceDetailResponse;
 import com.meetup.server.place.dto.response.PlaceResponseList;
+import com.meetup.server.support.ControllerTest;
 import com.meetup.server.support.ControllerTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ControllerTest(PlaceController.class)
 class PlaceControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
@@ -1,0 +1,264 @@
+package com.meetup.server.place.presentation;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.meetup.server.fixture.EventFixture;
+import com.meetup.server.fixture.PlaceFixture;
+import com.meetup.server.fixture.SubwayFixture;
+import com.meetup.server.global.support.response.ResultType;
+import com.meetup.server.place.application.PlaceService;
+import com.meetup.server.place.dto.response.PlaceDetailResponse;
+import com.meetup.server.place.dto.response.PlaceResponseList;
+import com.meetup.server.support.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.UUID;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PlaceControllerTest extends ControllerTestSupport {
+
+    @MockitoBean
+    private PlaceService placeService;
+
+    @DisplayName("장소 추천 리스트를 조회한다.")
+    @Test
+    void getAllPlaces() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+        int subwayId = SubwayFixture.SUBWAY_ID;
+        PlaceResponseList response = PlaceFixture.getPlaceResponseList();
+
+        // when
+        Mockito.when(placeService.getAllPlaces(any(UUID.class), anyInt()))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/places")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .queryParam("eventId", eventId.toString())
+                                .queryParam("subwayId", String.valueOf(subwayId))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("place/get-all",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Place API")
+                                                .description("장소 추천 리스트를 조회한다.")
+                                                .queryParameters(
+                                                        parameterWithName("eventId").description("이벤트 ID (UUID)"),
+                                                        parameterWithName("subwayId").description("지하철 ID")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                                        fieldWithPath("data.eventName").type(JsonFieldType.STRING).description("모임명"),
+                                                        fieldWithPath("data.middlePointName").type(JsonFieldType.STRING).description("중간지점명"),
+
+                                                        fieldWithPath("data.confirmedPlaceResponse").type(JsonFieldType.OBJECT).description("확정 장소").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.id").type(JsonFieldType.STRING).description("장소 ID").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.category").type(JsonFieldType.STRING).description("카테고리").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.name").type(JsonFieldType.STRING).description("장소명").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.image").type(JsonFieldType.STRING).description("이미지 URL").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.openTime").type(JsonFieldType.STRING).description("영업 시작 시간").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.closeTime").type(JsonFieldType.STRING).description("영업 종료 시간").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.distance").type(JsonFieldType.NUMBER).description("거리").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.averageRating").type(JsonFieldType.NUMBER).description("평균 평점").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.googleRating").type(JsonFieldType.NUMBER).description("구글 평점").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.placeScore").type(JsonFieldType.OBJECT).description("장소 점수").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.placeScore.socket").type(JsonFieldType.NUMBER).description("콘센트 점수").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.placeScore.seat").type(JsonFieldType.NUMBER).description("좌석 점수").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.placeScore.quiet").type(JsonFieldType.NUMBER).description("한산함 점수").optional(),
+
+                                                        fieldWithPath("data.placeResponses[]").type(JsonFieldType.ARRAY).description("장소 추천 리스트").optional(),
+                                                        fieldWithPath("data.placeResponses[].id").type(JsonFieldType.STRING).description("장소 ID").optional(),
+                                                        fieldWithPath("data.placeResponses[].category").type(JsonFieldType.STRING).description("카테고리").optional(),
+                                                        fieldWithPath("data.placeResponses[].name").type(JsonFieldType.STRING).description("장소명").optional(),
+                                                        fieldWithPath("data.placeResponses[].image").type(JsonFieldType.STRING).description("이미지 URL").optional(),
+                                                        fieldWithPath("data.placeResponses[].openTime").type(JsonFieldType.STRING).description("영업 시작 시간").optional(),
+                                                        fieldWithPath("data.placeResponses[].closeTime").type(JsonFieldType.STRING).description("영업 종료 시간").optional(),
+                                                        fieldWithPath("data.placeResponses[].distance").type(JsonFieldType.NUMBER).description("거리").optional(),
+                                                        fieldWithPath("data.placeResponses[].averageRating").type(JsonFieldType.NUMBER).description("평균 평점").optional(),
+                                                        fieldWithPath("data.placeResponses[].googleRating").type(JsonFieldType.NUMBER).description("구글 평점").optional(),
+                                                        fieldWithPath("data.placeResponses[].placeScore").type(JsonFieldType.OBJECT).description("장소 점수").optional(),
+                                                        fieldWithPath("data.placeResponses[].placeScore.socket").type(JsonFieldType.NUMBER).description("콘센트 점수").optional(),
+                                                        fieldWithPath("data.placeResponses[].placeScore.seat").type(JsonFieldType.NUMBER).description("좌석 점수").optional(),
+                                                        fieldWithPath("data.placeResponses[].placeScore.quiet").type(JsonFieldType.NUMBER).description("한산함 점수").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .responseSchema(Schema.schema("PlaceResponseList"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("장소 상세 정보를 조회한다.")
+    @Test
+    void getPlaceDetails() throws Exception {
+        // given
+        UUID placeId = PlaceFixture.PLACE_ID;
+        UUID eventId = EventFixture.EVENT_ID;
+        int subwayId = SubwayFixture.SUBWAY_ID;
+        PlaceDetailResponse response = PlaceFixture.getPlaceDetailResponse();
+
+        // when
+        Mockito.when(placeService.getPlace(any(UUID.class), any(UUID.class), anyInt()))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/places/{placeId}", placeId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .queryParam("eventId", eventId.toString())
+                                .queryParam("subwayId", String.valueOf(subwayId))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("place/get-details",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Place API")
+                                                .description("장소 상세 정보를 조회한다.")
+                                                .pathParameters(
+                                                        parameterWithName("placeId").description("장소 ID (UUID)")
+                                                )
+                                                .queryParameters(
+                                                        parameterWithName("eventId").description("이벤트 ID (UUID)"),
+                                                        parameterWithName("subwayId").description("지하철 ID")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                                        fieldWithPath("data.id").type(JsonFieldType.STRING).description("장소 ID"),
+                                                        fieldWithPath("data.kakaoPlaceId").type(JsonFieldType.STRING).description("카카오 플레이스 ID"),
+                                                        fieldWithPath("data.category").type(JsonFieldType.STRING).description("장소 카테고리"),
+                                                        fieldWithPath("data.name").type(JsonFieldType.STRING).description("장소 이름"),
+                                                        fieldWithPath("data.images").type(JsonFieldType.ARRAY).description("장소 이미지 목록").optional(),
+                                                        fieldWithPath("data.openTime").type(JsonFieldType.STRING).description("영업 시작 시간").optional(),
+                                                        fieldWithPath("data.closeTime").type(JsonFieldType.STRING).description("영업 종료 시간").optional(),
+                                                        fieldWithPath("data.distance").type(JsonFieldType.NUMBER).description("거리"),
+                                                        fieldWithPath("data.averageRating").type(JsonFieldType.NUMBER).description("평균 평점").optional(),
+                                                        fieldWithPath("data.placeQuietnessResponse").type(JsonFieldType.OBJECT).description("장소 혼잡도 정보").optional(),
+                                                        fieldWithPath("data.reviews").type(JsonFieldType.ARRAY).description("사용자 리뷰 목록").optional(),
+                                                        fieldWithPath("data.googleReviews").type(JsonFieldType.ARRAY).description("구글 리뷰 목록").optional(),
+                                                        fieldWithPath("data.placeScore").type(JsonFieldType.OBJECT).description("장소 점수").optional(),
+                                                        fieldWithPath("data.placeScore.socket").type(JsonFieldType.NUMBER).description("콘센트 점수").optional(),
+                                                        fieldWithPath("data.placeScore.seat").type(JsonFieldType.NUMBER).description("좌석 점수").optional(),
+                                                        fieldWithPath("data.placeScore.quiet").type(JsonFieldType.NUMBER).description("한산함 점수").optional(),
+                                                        fieldWithPath("data.isConfirmed").type(JsonFieldType.BOOLEAN).description("확정 여부"),
+                                                        fieldWithPath("data.isChanged").type(JsonFieldType.BOOLEAN).description("변경 여부"),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .responseSchema(Schema.schema("PlaceDetailResponse"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("리뷰용 장소를 조회한다.")
+    @Test
+    void getPlaceForReview() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+        PlaceResponseList response = PlaceFixture.getPlaceResponseListForReview();
+
+        // when
+        Mockito.when(placeService.getPlaceForReview(any(UUID.class)))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/places/review")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .queryParam("eventId", eventId.toString())
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("place/get-for-review",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Place API")
+                                                .description("리뷰용 장소를 조회한다.")
+                                                .queryParameters(
+                                                        parameterWithName("eventId").description("이벤트 ID (UUID)")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                                        fieldWithPath("data.eventName").type(JsonFieldType.STRING).description("모임명"),
+                                                        fieldWithPath("data.middlePointName").type(JsonFieldType.STRING).description("중간지점명"),
+
+                                                        fieldWithPath("data.confirmedPlaceResponse").type(JsonFieldType.OBJECT).description("확정 장소"),
+                                                        fieldWithPath("data.confirmedPlaceResponse.id").type(JsonFieldType.STRING).description("장소 ID"),
+                                                        fieldWithPath("data.confirmedPlaceResponse.category").type(JsonFieldType.STRING).description("카테고리"),
+                                                        fieldWithPath("data.confirmedPlaceResponse.name").type(JsonFieldType.STRING).description("장소명"),
+                                                        fieldWithPath("data.confirmedPlaceResponse.image").type(JsonFieldType.STRING).description("이미지 URL").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.openTime").type(JsonFieldType.STRING).description("영업 시작 시간").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.closeTime").type(JsonFieldType.STRING).description("영업 종료 시간").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.distance").type(JsonFieldType.NUMBER).description("거리").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.averageRating").type(JsonFieldType.NUMBER).description("평균 평점").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.googleRating").type(JsonFieldType.NUMBER).description("구글 평점").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.placeScore").type(JsonFieldType.OBJECT).description("장소 점수").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.placeScore.socket").type(JsonFieldType.NUMBER).description("콘센트 점수").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.placeScore.seat").type(JsonFieldType.NUMBER).description("좌석 점수").optional(),
+                                                        fieldWithPath("data.confirmedPlaceResponse.placeScore.quiet").type(JsonFieldType.NUMBER).description("한산함 점수").optional(),
+
+                                                        fieldWithPath("data.placeResponses").type(JsonFieldType.ARRAY).description("추천 장소 리스트").optional(),
+                                                        fieldWithPath("data.placeResponses[].id").type(JsonFieldType.STRING).description("장소 ID").optional(),
+                                                        fieldWithPath("data.placeResponses[].category").type(JsonFieldType.STRING).description("카테고리").optional(),
+                                                        fieldWithPath("data.placeResponses[].name").type(JsonFieldType.STRING).description("장소명").optional(),
+                                                        fieldWithPath("data.placeResponses[].image").type(JsonFieldType.STRING).description("이미지 URL").optional(),
+                                                        fieldWithPath("data.placeResponses[].openTime").type(JsonFieldType.STRING).description("영업 시작 시간").optional(),
+                                                        fieldWithPath("data.placeResponses[].closeTime").type(JsonFieldType.STRING).description("영업 종료 시간").optional(),
+                                                        fieldWithPath("data.placeResponses[].distance").type(JsonFieldType.NUMBER).description("거리").optional(),
+                                                        fieldWithPath("data.placeResponses[].averageRating").type(JsonFieldType.NUMBER).description("평균 평점").optional(),
+                                                        fieldWithPath("data.placeResponses[].googleRating").type(JsonFieldType.NUMBER).description("구글 평점").optional(),
+                                                        fieldWithPath("data.placeResponses[].placeScore").type(JsonFieldType.OBJECT).description("장소 점수").optional(),
+                                                        fieldWithPath("data.placeResponses[].placeScore.socket").type(JsonFieldType.NUMBER).description("콘센트 점수").optional(),
+                                                        fieldWithPath("data.placeResponses[].placeScore.seat").type(JsonFieldType.NUMBER).description("좌석 점수").optional(),
+                                                        fieldWithPath("data.placeResponses[].placeScore.quiet").type(JsonFieldType.NUMBER).description("한산함 점수").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .responseSchema(Schema.schema("PlaceResponseList"))
+                                                .build())
+                        )
+                );
+    }
+}

--- a/src/test/java/com/meetup/server/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/meetup/server/review/presentation/ReviewControllerTest.java
@@ -10,6 +10,7 @@ import com.meetup.server.global.support.response.ResultType;
 import com.meetup.server.review.application.ReviewService;
 import com.meetup.server.review.dto.request.NonVisitedReviewRequest;
 import com.meetup.server.review.dto.request.VisitedReviewRequest;
+import com.meetup.server.support.ControllerTest;
 import com.meetup.server.support.ControllerTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ControllerTest(ReviewController.class)
 class ReviewControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/meetup/server/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/com/meetup/server/review/presentation/ReviewControllerTest.java
@@ -1,0 +1,148 @@
+package com.meetup.server.review.presentation;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.meetup.server.fixture.EventFixture;
+import com.meetup.server.fixture.PlaceFixture;
+import com.meetup.server.fixture.ReviewFixture;
+import com.meetup.server.global.support.response.ResultType;
+import com.meetup.server.review.application.ReviewService;
+import com.meetup.server.review.dto.request.NonVisitedReviewRequest;
+import com.meetup.server.review.dto.request.VisitedReviewRequest;
+import com.meetup.server.support.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.UUID;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReviewControllerTest extends ControllerTestSupport {
+
+    @MockitoBean
+    private ReviewService reviewService;
+
+    @DisplayName("확정 장소 방문 리뷰를 작성한다.")
+    @Test
+    void createVisitedReview() throws Exception {
+        // given
+        UUID placeId = PlaceFixture.PLACE_ID;
+        UUID eventId = EventFixture.EVENT_ID;
+        VisitedReviewRequest request = ReviewFixture.getVisitedReviewRequest();
+
+        // when
+        Mockito.doNothing().when(reviewService).createVisitedReview(any(UUID.class), any(UUID.class), any(Long.class), any(VisitedReviewRequest.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/places/{placeId}/reviews/visited", placeId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .queryParam("eventId", eventId.toString())
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("review/create-visited",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Review API")
+                                                .description("확정 장소 방문 리뷰를 작성한다.")
+                                                .pathParameters(
+                                                        parameterWithName("placeId").description("장소 ID (UUID)")
+                                                )
+                                                .queryParameters(
+                                                        parameterWithName("eventId").description("이벤트 ID (UUID)")
+                                                )
+                                                .requestFields(
+                                                        fieldWithPath("visitedTime").type(JsonFieldType.STRING).description("방문 시간 (MORNING, LUNCH, NIGHT)"),
+                                                        fieldWithPath("socket").type(JsonFieldType.NUMBER).description("콘센트 점수 (1~5)"),
+                                                        fieldWithPath("seat").type(JsonFieldType.NUMBER).description("좌석 점수 (1~5)"),
+                                                        fieldWithPath("quiet").type(JsonFieldType.NUMBER).description("한산함 점수 (1~5)"),
+                                                        fieldWithPath("content").type(JsonFieldType.STRING).description("방문 후기").optional()
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .requestSchema(Schema.schema("VisitedReviewRequest"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("확정 장소 미방문 리뷰를 작성한다.")
+    @Test
+    void createNonVisitedReview() throws Exception {
+        // given
+        UUID placeId = PlaceFixture.PLACE_ID;
+        UUID eventId = EventFixture.EVENT_ID;
+        NonVisitedReviewRequest request = ReviewFixture.getNonVisitedReviewRequest();
+
+        // when
+        Mockito.doNothing().when(reviewService).createNonVisitedReview(any(UUID.class), any(UUID.class), any(Long.class), any(NonVisitedReviewRequest.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/places/{placeId}/reviews/non-visited", placeId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .queryParam("eventId", eventId.toString())
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("review/create-non-visited",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Review API")
+                                                .description("확정 장소 미방문 리뷰를 작성한다.")
+                                                .pathParameters(
+                                                        parameterWithName("placeId").description("장소 ID (UUID)")
+                                                )
+                                                .queryParameters(
+                                                        parameterWithName("eventId").description("이벤트 ID (UUID)")
+                                                )
+                                                .requestFields(
+                                                        fieldWithPath("categories").type(JsonFieldType.ARRAY).description("방문하지 않은 이유 목록").optional(),
+                                                        fieldWithPath("etcReason").type(JsonFieldType.STRING).description("기타 사유").optional(),
+                                                        fieldWithPath("placeName").type(JsonFieldType.STRING).description("출발지명").optional(),
+                                                        fieldWithPath("address").type(JsonFieldType.STRING).description("지번주소").optional(),
+                                                        fieldWithPath("roadAddress").type(JsonFieldType.STRING).description("도로명주소").optional(),
+                                                        fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도").optional(),
+                                                        fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도").optional()
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .requestSchema(Schema.schema("NonVisitedReviewRequest"))
+                                                .build())
+                        )
+                );
+    }
+}

--- a/src/test/java/com/meetup/server/startpoint/presentation/StartPointControllerTest.java
+++ b/src/test/java/com/meetup/server/startpoint/presentation/StartPointControllerTest.java
@@ -1,0 +1,263 @@
+package com.meetup.server.startpoint.presentation;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.response.EventStartPointResponse;
+import com.meetup.server.fixture.EventFixture;
+import com.meetup.server.fixture.StartPointFixture;
+import com.meetup.server.global.clients.kakao.local.KakaoLocalResponse;
+import com.meetup.server.global.support.response.ResultType;
+import com.meetup.server.startpoint.application.StartPointService;
+import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import com.meetup.server.support.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.UUID;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class StartPointControllerTest extends ControllerTestSupport {
+
+    @MockitoBean
+    private StartPointService startPointService;
+
+    @DisplayName("장소를 검색한다.")
+    @Test
+    void searchStartPoint() throws Exception {
+        // given
+        String textQuery = "선정릉역";
+        KakaoLocalResponse response = new KakaoLocalResponse();
+
+        // when
+        Mockito.when(startPointService.searchStartPoint(anyString()))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/start-points/search")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .queryParam("textQuery", textQuery)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("start-point/search",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("StartPoint API")
+                                                .description("장소를 검색한다.")
+                                                .queryParameters(
+                                                        parameterWithName("textQuery").description("검색할 장소명")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+
+                                                        fieldWithPath("data.meta").type(JsonFieldType.OBJECT).description("카카오 검색 메타데이터").optional(),
+                                                        fieldWithPath("data.documents").type(JsonFieldType.ARRAY).description("카카오 검색 결과 리스트").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .responseSchema(Schema.schema("KakaoLocalResponse"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("출발지를 생성한다.")
+    @Test
+    void createStartPoint() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+        UUID guestId = StartPointFixture.GUEST_ID;
+        StartPointRequest request = StartPointFixture.getStartPointRequest();
+
+        Event event = EventFixture.getEvent();
+        com.meetup.server.startpoint.domain.StartPoint startPoint = StartPointFixture.getStartPoint(event, null);
+        EventStartPointResponse response = EventStartPointResponse.of(event, startPoint);
+
+        // when
+        Mockito.when(startPointService.createStartPoint(any(UUID.class), nullable(Long.class), nullable(UUID.class), any(StartPointRequest.class)))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/events/{eventId}/start-points", eventId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .queryParam("guestId", guestId.toString())
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andExpect(jsonPath("$.data.eventId").value(EventFixture.EVENT_ID.toString()))
+                .andExpect(jsonPath("$.data.startPointId").value(StartPointFixture.START_POINT_ID.toString()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("start-point/create",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("StartPoint API")
+                                                .description("출발지를 생성한다. (회원 - JWT Token, 비회원 - guestId)")
+                                                .pathParameters(
+                                                        parameterWithName("eventId").description("이벤트 ID (UUID)")
+                                                )
+                                                .queryParameters(
+                                                        parameterWithName("guestId").description("비회원 ID (UUID)").optional()
+                                                )
+                                                .requestFields(
+                                                        fieldWithPath("username").type(JsonFieldType.STRING).description("사용자명 (1~5자)"),
+                                                        fieldWithPath("startPoint").type(JsonFieldType.STRING).description("출발지명"),
+                                                        fieldWithPath("address").type(JsonFieldType.STRING).description("지번주소"),
+                                                        fieldWithPath("roadAddress").type(JsonFieldType.STRING).description("도로명주소"),
+                                                        fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도"),
+                                                        fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
+                                                        fieldWithPath("isTransit").type(JsonFieldType.BOOLEAN).description("대중교통/자가용 선택 여부")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                                        fieldWithPath("data.eventId").type(JsonFieldType.STRING).description("이벤트 ID"),
+                                                        fieldWithPath("data.startPointId").type(JsonFieldType.STRING).description("출발지 ID"),
+                                                        fieldWithPath("data.guestId").type(JsonFieldType.STRING).description("비회원 ID").optional(),
+                                                        fieldWithPath("data.username").type(JsonFieldType.STRING).description("사용자명"),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .requestSchema(Schema.schema("StartPointRequest"))
+                                                .responseSchema(Schema.schema("EventStartPointResponse"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("출발지를 수정한다.")
+    @Test
+    void updateStartPoint() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+        UUID startPointId = StartPointFixture.START_POINT_ID;
+        StartPointRequest request = StartPointFixture.getStartPointRequest();
+
+        Event event = EventFixture.getEvent();
+        com.meetup.server.startpoint.domain.StartPoint startPoint = StartPointFixture.getStartPoint(event, null);
+        EventStartPointResponse response = EventStartPointResponse.of(event, startPoint);
+
+        // when
+        Mockito.when(startPointService.updateStartPoint(any(UUID.class), any(UUID.class), any(StartPointRequest.class)))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.patch("/events/{eventId}/start-points/{startPointId}", eventId, startPointId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andExpect(jsonPath("$.data.eventId").value(EventFixture.EVENT_ID.toString()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("start-point/update",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("StartPoint API")
+                                                .description("출발지를 수정한다.")
+                                                .pathParameters(
+                                                        parameterWithName("eventId").description("이벤트 ID (UUID)"),
+                                                        parameterWithName("startPointId").description("출발지 ID (UUID)")
+                                                )
+                                                .requestFields(
+                                                        fieldWithPath("username").type(JsonFieldType.STRING).description("사용자명 (1~5자)"),
+                                                        fieldWithPath("startPoint").type(JsonFieldType.STRING).description("출발지명"),
+                                                        fieldWithPath("address").type(JsonFieldType.STRING).description("지번주소"),
+                                                        fieldWithPath("roadAddress").type(JsonFieldType.STRING).description("도로명주소"),
+                                                        fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도"),
+                                                        fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
+                                                        fieldWithPath("isTransit").type(JsonFieldType.BOOLEAN).description("대중교통/자가용 선택 여부")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                                        fieldWithPath("data.eventId").type(JsonFieldType.STRING).description("이벤트 ID"),
+                                                        fieldWithPath("data.startPointId").type(JsonFieldType.STRING).description("출발지 ID"),
+                                                        fieldWithPath("data.guestId").type(JsonFieldType.STRING).description("비회원 ID").optional(),
+                                                        fieldWithPath("data.username").type(JsonFieldType.STRING).description("사용자명"),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .requestSchema(Schema.schema("StartPointRequest"))
+                                                .responseSchema(Schema.schema("EventStartPointResponse"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("출발지를 삭제한다.")
+    @Test
+    void deleteStartPoint() throws Exception {
+        // given
+        UUID eventId = EventFixture.EVENT_ID;
+        UUID startPointId = StartPointFixture.START_POINT_ID;
+
+        // when
+        Mockito.doNothing().when(startPointService).deleteStartPoint(any(UUID.class), any(UUID.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/events/{eventId}/start-points/{startPointId}", eventId, startPointId)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("start-point/delete",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("StartPoint API")
+                                                .description("출발지를 삭제한다.")
+                                                .pathParameters(
+                                                        parameterWithName("eventId").description("이벤트 ID (UUID)"),
+                                                        parameterWithName("startPointId").description("출발지 ID (UUID)")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .build())
+                        )
+                );
+    }
+}

--- a/src/test/java/com/meetup/server/startpoint/presentation/StartPointControllerTest.java
+++ b/src/test/java/com/meetup/server/startpoint/presentation/StartPointControllerTest.java
@@ -11,6 +11,7 @@ import com.meetup.server.global.clients.kakao.local.KakaoLocalResponse;
 import com.meetup.server.global.support.response.ResultType;
 import com.meetup.server.startpoint.application.StartPointService;
 import com.meetup.server.startpoint.dto.request.StartPointRequest;
+import com.meetup.server.support.ControllerTest;
 import com.meetup.server.support.ControllerTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ControllerTest(StartPointController.class)
 class StartPointControllerTest extends ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/com/meetup/server/support/ControllerTest.java
+++ b/src/test/java/com/meetup/server/support/ControllerTest.java
@@ -1,0 +1,39 @@
+package com.meetup.server.support;
+
+import com.meetup.server.auth.presentation.filter.JwtAuthenticationFilter;
+import com.meetup.server.auth.presentation.filter.ResponseContextFilter;
+import com.meetup.server.global.presentation.ApiControllerAdvice;
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@WebMvcTest(
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class,
+                OAuth2ClientAutoConfiguration.class
+        },
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                        JwtAuthenticationFilter.class,
+                        ResponseContextFilter.class,
+                        ApiControllerAdvice.class
+                })
+        }
+)
+public @interface ControllerTest {
+
+    @AliasFor(annotation = WebMvcTest.class, attribute = "controllers")
+    Class<?>[] value() default {};
+}

--- a/src/test/java/com/meetup/server/support/ControllerTestSupport.java
+++ b/src/test/java/com/meetup/server/support/ControllerTestSupport.java
@@ -19,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-public abstract class ControllerTestSupport extends IntegrationTestContainer {
+public abstract class ControllerTestSupport {
 
     protected MockMvc mockMvc;
 

--- a/src/test/java/com/meetup/server/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/meetup/server/user/presentation/UserControllerTest.java
@@ -1,0 +1,260 @@
+package com.meetup.server.user.presentation;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.meetup.server.fixture.UserFixture;
+import com.meetup.server.global.support.response.ResultType;
+import com.meetup.server.support.ControllerTestSupport;
+import com.meetup.server.user.application.UserService;
+import com.meetup.server.user.dto.request.UserAgreementRequest;
+import com.meetup.server.user.dto.response.UserEventHistoryResponseList;
+import com.meetup.server.user.dto.response.UserProfileInfoResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.UUID;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class UserControllerTest extends ControllerTestSupport {
+
+    @MockitoBean
+    private UserService userService;
+
+    @DisplayName("사용자 프로필 정보를 조회한다.")
+    @Test
+    void getUserProfileInfo() throws Exception {
+        // given
+        UserProfileInfoResponse response = UserFixture.getUserProfileInfoResponse();
+
+        // when
+        Mockito.when(userService.getUserProfileInfo(nullable(Long.class)))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/users")
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andExpect(jsonPath("$.data.nickname").value(UserFixture.TEST_NICKNAME))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("user/get-profile",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("User API")
+                                                .description("사용자 프로필 정보를 조회한다.")
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                                        fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("사용자 ID"),
+                                                        fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
+                                                        fieldWithPath("data.profileImageUrl").type(JsonFieldType.STRING).description("프로필 이미지 URL").optional(),
+                                                        fieldWithPath("data.email").type(JsonFieldType.STRING).description("사용자 이메일"),
+                                                        fieldWithPath("data.personalInfoAgreement").type(JsonFieldType.BOOLEAN).description("개인정보 동의 여부"),
+                                                        fieldWithPath("data.marketingAgreement").type(JsonFieldType.BOOLEAN).description("마케팅 동의 여부"),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .responseSchema(Schema.schema("UserProfileInfoResponse"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("사용자 약관 동의를 저장한다.")
+    @Test
+    void saveUserAgreement() throws Exception {
+        // given
+        UserAgreementRequest request = UserFixture.getUserAgreementRequest();
+
+        // when
+        Mockito.doNothing().when(userService).saveUserAgreement(nullable(Long.class), any(Boolean.class), any(Boolean.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/users/agreement")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("user/save-agreement",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("User API")
+                                                .description("사용자 약관 동의를 저장한다.")
+                                                .requestFields(
+                                                        fieldWithPath("isPersonalInfoAgreement").type(JsonFieldType.BOOLEAN).description("개인정보 동의 여부"),
+                                                        fieldWithPath("isMarketingAgreement").type(JsonFieldType.BOOLEAN).description("마케팅 동의 여부")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .requestSchema(Schema.schema("UserAgreementRequest"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("모임 히스토리 리스트를 조회한다.")
+    @Test
+    void getUserEventHistory() throws Exception {
+        // given
+        int size = 10;
+        UUID lastViewedEventId = UUID.randomUUID();
+        UserEventHistoryResponseList response = UserFixture.getUserEventHistoryResponseList();
+
+        // when
+        Mockito.when(userService.getUserEventHistory(nullable(Long.class), nullable(UUID.class), anyInt()))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/users/events")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .queryParam("size", String.valueOf(size))
+                                .queryParam("lastViewedEventId", lastViewedEventId.toString())
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andExpect(jsonPath("$.data.userEventHistoryResponses").isArray())
+                .andExpect(jsonPath("$.data.hasNextPage").value(false))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("user/get-event-history",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("User API")
+                                                .description("모임 히스토리 리스트를 조회한다.")
+                                                .queryParameters(
+                                                        parameterWithName("lastViewedEventId").description("마지막으로 조회한 이벤트 ID").optional(),
+                                                        parameterWithName("size").description("조회할 크기")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+
+                                                        fieldWithPath("data.userEventHistoryResponses").type(JsonFieldType.ARRAY).description("이벤트 목록"),
+                                                        fieldWithPath("data.userEventHistoryResponses[].eventId").type(JsonFieldType.STRING).description("이벤트 ID").optional(),
+                                                        fieldWithPath("data.userEventHistoryResponses[].eventName").type(JsonFieldType.STRING).description("이벤트 이름").optional(),
+                                                        fieldWithPath("data.userEventHistoryResponses[].eventDate").type(JsonFieldType.STRING).description("이벤트 날짜").optional(),
+                                                        fieldWithPath("data.userEventHistoryResponses[].eventTime").type(JsonFieldType.STRING).description("이벤트 시간").optional(),
+                                                        fieldWithPath("data.userEventHistoryResponses[].placeName").type(JsonFieldType.STRING).description("장소 이름").optional(),
+                                                        fieldWithPath("data.userEventHistoryResponses[].subwayName").type(JsonFieldType.STRING).description("지하철 역 이름").optional(),
+
+                                                        fieldWithPath("data.hasNextPage").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
+                                                        fieldWithPath("data.lastEventId").type(JsonFieldType.STRING).description("마지막 조회 이벤트 ID").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .responseSchema(Schema.schema("UserEventHistoryResponseList"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("사용자 닉네임을 수정한다.")
+    @Test
+    void updateNickname() throws Exception {
+        // given
+        String nickname = UserFixture.NEW_NICKNAME;
+
+        // when
+        Mockito.doNothing().when(userService).updateNickname(nullable(Long.class), anyString());
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.patch("/users")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .queryParam("nickname", nickname)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("user/update-nickname",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("User API")
+                                                .description("사용자 닉네임을 수정한다.")
+                                                .queryParameters(
+                                                        parameterWithName("nickname").description("새 닉네임 (1~5자)")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("사용자를 탈퇴한다.")
+    @Test
+    void withdrawUser() throws Exception {
+        // when
+        Mockito.doNothing().when(userService).withdraw(nullable(Long.class));
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.delete("/users")
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("user/withdraw",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("User API")
+                                                .description("사용자를 탈퇴한다.")
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .build())
+                        )
+                );
+    }
+}

--- a/src/test/java/com/meetup/server/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/meetup/server/user/presentation/UserControllerTest.java
@@ -5,6 +5,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.meetup.server.fixture.UserFixture;
 import com.meetup.server.global.support.response.ResultType;
+import com.meetup.server.support.ControllerTest;
 import com.meetup.server.support.ControllerTestSupport;
 import com.meetup.server.user.application.UserService;
 import com.meetup.server.user.dto.request.UserAgreementRequest;
@@ -28,6 +29,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ControllerTest(UserController.class)
 class UserControllerTest extends ControllerTestSupport {
 
     @MockitoBean


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 기존 Controller 테스트 진행 시, 통합 테스트 환경에서 진행되어 시간이 오래 걸렸음
  - TestContainer를 띄우는 과정에서 시간이 오래 걸림 + Controller 테스트는 Mocking하여 테스트하기 때문에 통합 테스트 환경 필요 X
- EventController, LogController 이외 테스트 코드 부재

## ✅ What - 무엇이 변경됐나요?

- `@ContainerTest` 애노테이션을 만들어 SpringSecurity, JwtFilter 등 `@WebMvcTest`에서 로드하지만 불필요한 클래스 제외
- AuthController, PlaceController, ReviewController, StartPointController, UserController 테스트 코드 추가 완료
- Fixture 개선 (요청, 응답 값 추가 / ID 상수화 등)

## 🛠️ How - 어떻게 해결했나요?

-  `@ContainerTest` 애노테이션 추가

## 🖼️ Attachment

### AS-IS 

<img width="1055" height="113" alt="스크린샷 2026-02-15 오후 10 46 34" src="https://github.com/user-attachments/assets/a4eca72e-053e-4245-94f7-4ed414fd69ce" />
- Controller 테스트: 46s

### TO-BE

<img width="1056" height="115" alt="스크린샷 2026-02-15 오후 10 48 20" src="https://github.com/user-attachments/assets/11a1e78b-41de-4c45-9bec-b0ca740e20a4" />
- Controller 테스트: 12s

## 💬 기타 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 인증, 장소, 리뷰, 출발지, 사용자 컨트롤러 테스트 추가로 API 안정성 강화.

* **Chores**
  * 내부 API 문서화 주석 정리.
  * 테스트 기반 구조 최적화 및 테스트 픽스처 개선.
  * 출발지 생성 엔드포인트에 게스트 ID 매개변수 지원 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->