### PR TITLE
[MOISAM-253] Activation, Retention 통계용 페이지를 구현한다

### DIFF
--- a/src/main/java/com/meetup/server/admin/application/AdminService.java
+++ b/src/main/java/com/meetup/server/admin/application/AdminService.java
@@ -132,7 +132,7 @@ public class AdminService {
                                 p.getDate(),
                                 p.getTotalEvents(),
                                 p.getConfirmedEvents(),
-                                p.getConfirmedWithKakao()
+                                p.getConfirmedEventsWithKakao()
                         )
                 ));
 

--- a/src/main/java/com/meetup/server/admin/application/AdminService.java
+++ b/src/main/java/com/meetup/server/admin/application/AdminService.java
@@ -1,19 +1,18 @@
 package com.meetup.server.admin.application;
 
 import com.meetup.server.admin.dto.request.AdminRegisterRequest;
-import com.meetup.server.admin.dto.response.AdminEventResponse;
-import com.meetup.server.admin.dto.response.AdminUserResponse;
-import com.meetup.server.admin.dto.response.DailyEventStatsResponse;
-import com.meetup.server.admin.dto.response.DailyUserStatsResponse;
+import com.meetup.server.admin.dto.response.*;
 import com.meetup.server.admin.implement.AdminValidator;
 import com.meetup.server.admin.implement.AdminWriter;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.implement.EventReader;
+import com.meetup.server.event.infrastructure.jpa.projection.ActivationStat;
 import com.meetup.server.log.domain.type.InflowType;
 import com.meetup.server.log.implement.LogEventInflowReader;
 import com.meetup.server.log.implement.LogUserLoginReader;
 import com.meetup.server.log.infrastructure.jpa.projection.EventInflowCount;
 import com.meetup.server.startpoint.implement.StartPointReader;
+import com.meetup.server.startpoint.infrastructure.jpa.projection.RetentionStat;
 import com.meetup.server.startpoint.infrastructure.querydsl.projection.ParticipantCount;
 import com.meetup.server.user.domain.User;
 import com.meetup.server.user.implement.UserReader;
@@ -25,6 +24,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,6 +35,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminService {
+
+    private static final int RETENTION_PERIOD_DAYS = 30;
 
     private final AdminValidator adminValidator;
     private final AdminWriter adminWriter;
@@ -114,5 +117,45 @@ public class AdminService {
         long dailyRegisterUserCount = userReader.readDailyRegisterUserCount(todayDate);
 
         return DailyUserStatsResponse.of(dailyLoginUserCount, dailyRegisterUserCount);
+    }
+
+    public PeriodStatsResponse getPeriodStats(LocalDate startDate, LocalDate endDate) {
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+        LocalDateTime thirtyDaysAgo = startDate.minusDays(RETENTION_PERIOD_DAYS).atStartOfDay();
+
+        List<ActivationStat> activationProjections = eventReader.readDailyActivationStats(startDateTime, endDateTime);
+        Map<LocalDate, DailyActivationStatsResponse> activationMap = activationProjections.stream()
+                .collect(Collectors.toMap(
+                        ActivationStat::getDate,
+                        p -> DailyActivationStatsResponse.of(
+                                p.getDate(),
+                                p.getTotalEvents(),
+                                p.getConfirmedEvents(),
+                                p.getConfirmedWithKakao()
+                        )
+                ));
+
+        List<RetentionStat> retentionProjections = startPointReader.readDailyRetentionStats(startDateTime, endDateTime, thirtyDaysAgo);
+        Map<LocalDate, DailyRetentionStatsResponse> retentionMap = retentionProjections.stream()
+                .collect(Collectors.toMap(
+                        RetentionStat::getDate,
+                        p -> DailyRetentionStatsResponse.of(
+                                p.getDate(),
+                                p.getTotalUsers(),
+                                p.getRetainedUsers(),
+                                p.getRetainedUsersWithKakao()
+                        )
+                ));
+
+        List<DailyActivationStatsResponse> activationStats = startDate.datesUntil(endDate.plusDays(1))
+                .map(date -> activationMap.getOrDefault(date, DailyActivationStatsResponse.of(date, 0, 0, 0)))
+                .toList();
+
+        List<DailyRetentionStatsResponse> retentionStats = startDate.datesUntil(endDate.plusDays(1))
+                .map(date -> retentionMap.getOrDefault(date, DailyRetentionStatsResponse.of(date, 0, 0, 0)))
+                .toList();
+
+        return PeriodStatsResponse.of(activationStats, retentionStats);
     }
 }

--- a/src/main/java/com/meetup/server/admin/dto/response/DailyActivationStatsResponse.java
+++ b/src/main/java/com/meetup/server/admin/dto/response/DailyActivationStatsResponse.java
@@ -1,0 +1,30 @@
+package com.meetup.server.admin.dto.response;
+
+import java.time.LocalDate;
+
+public record DailyActivationStatsResponse(
+        LocalDate date,
+        long totalEvents,
+        long confirmedPlaceEvents,
+        long confirmedEventsWithKakao,
+        double activationRate,
+        double activationRateWithKakao
+) {
+    public static DailyActivationStatsResponse of(
+            LocalDate date, 
+            long totalEvents, 
+            long confirmedPlaceEvents,
+            long confirmedEventsWithKakao
+    ) {
+        double rate = totalEvents > 0 ? (double) confirmedPlaceEvents / totalEvents * 100 : 0.0;
+        double rateWithKakao = totalEvents > 0 ? (double) confirmedEventsWithKakao / totalEvents * 100 : 0.0;
+        return new DailyActivationStatsResponse(
+                date, 
+                totalEvents, 
+                confirmedPlaceEvents,
+                confirmedEventsWithKakao,
+                Math.round(rate * 100.0) / 100.0,
+                Math.round(rateWithKakao * 100.0) / 100.0
+        );
+    }
+}

--- a/src/main/java/com/meetup/server/admin/dto/response/DailyRetentionStatsResponse.java
+++ b/src/main/java/com/meetup/server/admin/dto/response/DailyRetentionStatsResponse.java
@@ -1,0 +1,18 @@
+package com.meetup.server.admin.dto.response;
+
+import java.time.LocalDate;
+
+public record DailyRetentionStatsResponse(
+        LocalDate date,
+        long totalUsersWithEvents,
+        long retainedUsers,
+        long retainedUsersWithKakao,
+        double retentionRate,
+        double retentionRateWithKakao
+) {
+    public static DailyRetentionStatsResponse of(LocalDate date, long totalUsersWithEvents, long retainedUsers, long retainedUsersWithKakao) {
+        double retentionRate = totalUsersWithEvents > 0 ? (double) retainedUsers / totalUsersWithEvents * 100 : 0.0;
+        double retentionRateWithKakao = totalUsersWithEvents > 0 ? (double) retainedUsersWithKakao / totalUsersWithEvents * 100 : 0.0;
+        return new DailyRetentionStatsResponse(date, totalUsersWithEvents, retainedUsers, retainedUsersWithKakao, Math.round(retentionRate * 100.0) / 100.0, Math.round(retentionRateWithKakao * 100.0) / 100.0);
+    }
+}

--- a/src/main/java/com/meetup/server/admin/dto/response/PeriodStatsResponse.java
+++ b/src/main/java/com/meetup/server/admin/dto/response/PeriodStatsResponse.java
@@ -1,0 +1,31 @@
+package com.meetup.server.admin.dto.response;
+
+import java.util.List;
+
+public record PeriodStatsResponse(
+        List<DailyActivationStatsResponse> activationStats,
+        List<DailyRetentionStatsResponse> retentionStats,
+        long overallActivationRate,
+        long overallActivationRateWithKakao,
+        long overallRetentionRate,
+        long overallRetentionRateWithKakao
+) {
+    public static PeriodStatsResponse of(
+            List<DailyActivationStatsResponse> activationStats,
+            List<DailyRetentionStatsResponse> retentionStats
+    ) {
+        long totalEvents = activationStats.stream().mapToLong(DailyActivationStatsResponse::totalEvents).sum();
+        long confirmedEvents = activationStats.stream().mapToLong(DailyActivationStatsResponse::confirmedPlaceEvents).sum();
+        long confirmedEventsWithKakao = activationStats.stream().mapToLong(DailyActivationStatsResponse::confirmedEventsWithKakao).sum();
+        long overallActivationRate = totalEvents > 0 ? (long) ((double) confirmedEvents / totalEvents * 100) : 0;
+        long overallActivationRateWithKakao = totalEvents > 0 ? (long) ((double) confirmedEventsWithKakao / totalEvents * 100) : 0;
+
+        long totalUsers = retentionStats.stream().mapToLong(DailyRetentionStatsResponse::totalUsersWithEvents).sum();
+        long retainedUsers = retentionStats.stream().mapToLong(DailyRetentionStatsResponse::retainedUsers).sum();
+        long retainedUsersWithKakao = retentionStats.stream().mapToLong(DailyRetentionStatsResponse::retainedUsersWithKakao).sum();
+        long overallRetentionRate = totalUsers > 0 ? (long) ((double) retainedUsers / totalUsers * 100) : 0;
+        long overallRetentionRateWithKakao = totalUsers > 0 ? (long) ((double) retainedUsersWithKakao / totalUsers * 100) : 0;
+
+        return new PeriodStatsResponse(activationStats, retentionStats, overallActivationRate, overallActivationRateWithKakao, overallRetentionRate, overallRetentionRateWithKakao);
+    }
+}

--- a/src/main/java/com/meetup/server/admin/presentation/AdminController.java
+++ b/src/main/java/com/meetup/server/admin/presentation/AdminController.java
@@ -3,10 +3,7 @@ package com.meetup.server.admin.presentation;
 import com.meetup.server.admin.application.AdminService;
 import com.meetup.server.admin.dto.request.AdminLoginRequest;
 import com.meetup.server.admin.dto.request.AdminRegisterRequest;
-import com.meetup.server.admin.dto.response.AdminEventResponse;
-import com.meetup.server.admin.dto.response.AdminUserResponse;
-import com.meetup.server.admin.dto.response.DailyEventStatsResponse;
-import com.meetup.server.admin.dto.response.DailyUserStatsResponse;
+import com.meetup.server.admin.dto.response.*;
 import com.meetup.server.admin.exception.AdminErrorType;
 import com.meetup.server.admin.exception.AdminException;
 import jakarta.validation.Valid;
@@ -16,13 +13,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @Controller
 @RequiredArgsConstructor
@@ -93,5 +90,26 @@ public class AdminController {
         model.addAttribute("userPages", userPages);
         model.addAttribute("dailyUserStats", dailyUserStats);
         return "admin/users";
+    }
+
+    @GetMapping("/stats")
+    public String getStats(
+            Model model,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        if (startDate == null) {
+            startDate = LocalDate.now().minusDays(30);
+        }
+        if (endDate == null) {
+            endDate = LocalDate.now();
+        }
+
+        PeriodStatsResponse stats = adminService.getPeriodStats(startDate, endDate);
+
+        model.addAttribute("stats", stats);
+        model.addAttribute("startDate", startDate);
+        model.addAttribute("endDate", endDate);
+        return "admin/stats";
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/EventReader.java
+++ b/src/main/java/com/meetup/server/event/implement/EventReader.java
@@ -4,6 +4,7 @@ import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.exception.EventErrorType;
 import com.meetup.server.event.exception.EventException;
 import com.meetup.server.event.infrastructure.jpa.EventRepository;
+import com.meetup.server.event.infrastructure.jpa.projection.ActivationStat;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -42,5 +43,9 @@ public class EventReader {
         LocalDateTime startDateTime = todayDate.atStartOfDay();
         LocalDateTime endDateTime = todayDate.atTime(LocalTime.MAX);
         return eventRepository.countByCreatedAtBetween(startDateTime, endDateTime);
+    }
+
+    public List<ActivationStat> readDailyActivationStats(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return eventRepository.findDailyActivationStats(startDateTime, endDateTime);
     }
 }

--- a/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
+++ b/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
@@ -2,6 +2,7 @@ package com.meetup.server.event.infrastructure.jpa;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.domain.value.MeetingPointRouteGroups;
+import com.meetup.server.event.infrastructure.jpa.projection.ActivationStat;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -26,4 +27,22 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
     List<Event> findAllByEventDateTimeWithPlace(@Param("eventDateTime") LocalDateTime eventDateTime);
 
     long countByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    @Query(value = """
+            SELECT
+                e.created_at::date as date,
+                COUNT(*) as total_events,
+                COUNT(e.place_id) as confirmed_events,
+                COUNT(CASE WHEN e.place_id IS NOT NULL AND EXISTS (
+                    SELECT 1 FROM log_event_inflow l WHERE l.event_id = e.event_id AND l.inflow_type = 'KAKAO'
+                ) THEN 1 END) as confirmed_with_kakao
+            FROM event e
+            WHERE e.created_at BETWEEN :startDateTime AND :endDateTime
+            GROUP BY date
+            ORDER BY date
+            """, nativeQuery = true)
+    List<ActivationStat> findDailyActivationStats(
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
 }

--- a/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
+++ b/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
@@ -31,11 +31,11 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
     @Query(value = """
             SELECT
                 e.created_at::date as date,
-                COUNT(*) as total_events,
-                COUNT(e.place_id) as confirmed_events,
+                COUNT(*) as totalEvents,
+                COUNT(e.place_id) as confirmedEvents,
                 COUNT(CASE WHEN e.place_id IS NOT NULL AND EXISTS (
                     SELECT 1 FROM log_event_inflow l WHERE l.event_id = e.event_id AND l.inflow_type = 'KAKAO'
-                ) THEN 1 END) as confirmed_with_kakao
+                ) THEN 1 END) as confirmedEventsWithKakao
             FROM event e
             WHERE e.created_at BETWEEN :startDateTime AND :endDateTime
             GROUP BY date

--- a/src/main/java/com/meetup/server/event/infrastructure/jpa/projection/ActivationStat.java
+++ b/src/main/java/com/meetup/server/event/infrastructure/jpa/projection/ActivationStat.java
@@ -6,5 +6,5 @@ public interface ActivationStat {
     LocalDate getDate();
     Long getTotalEvents();
     Long getConfirmedEvents();
-    Long getConfirmedWithKakao();
+    Long getConfirmedEventsWithKakao();
 }

--- a/src/main/java/com/meetup/server/event/infrastructure/jpa/projection/ActivationStat.java
+++ b/src/main/java/com/meetup/server/event/infrastructure/jpa/projection/ActivationStat.java
@@ -1,0 +1,10 @@
+package com.meetup.server.event.infrastructure.jpa.projection;
+
+import java.time.LocalDate;
+
+public interface ActivationStat {
+    LocalDate getDate();
+    Long getTotalEvents();
+    Long getConfirmedEvents();
+    Long getConfirmedWithKakao();
+}

--- a/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
+++ b/src/main/java/com/meetup/server/startpoint/implement/StartPointReader.java
@@ -8,6 +8,7 @@ import com.meetup.server.startpoint.infrastructure.jpa.StartPointRepository;
 import com.meetup.server.startpoint.infrastructure.querydsl.projection.EventHistory;
 import com.meetup.server.startpoint.infrastructure.querydsl.projection.Participant;
 import com.meetup.server.startpoint.infrastructure.querydsl.projection.ParticipantCount;
+import com.meetup.server.startpoint.infrastructure.jpa.projection.RetentionStat;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -52,5 +53,9 @@ public class StartPointReader {
         LocalDateTime startDateTime = todayDate.atStartOfDay();
         LocalDateTime endDateTime = todayDate.atTime(LocalTime.MAX);
         return startPointRepository.countByCreatedAtBetween(startDateTime, endDateTime);
+    }
+
+    public List<RetentionStat> readDailyRetentionStats(LocalDateTime startDateTime, LocalDateTime endDateTime, LocalDateTime thirtyDaysAgo) {
+        return startPointRepository.findDailyRetentionStats(startDateTime, endDateTime, thirtyDaysAgo);
     }
 }

--- a/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/StartPointRepository.java
+++ b/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/StartPointRepository.java
@@ -2,6 +2,7 @@ package com.meetup.server.startpoint.infrastructure.jpa;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.startpoint.domain.StartPoint;
+import com.meetup.server.startpoint.infrastructure.jpa.projection.RetentionStat;
 import com.meetup.server.startpoint.infrastructure.querydsl.StartPointCustomRepository;
 import com.meetup.server.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -32,4 +33,46 @@ public interface StartPointRepository extends JpaRepository<StartPoint, UUID>, S
     void deleteAllByUser(@Param("user") User user);
 
     long countByCreatedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    @Query(value = """
+            SELECT
+                date_trunc('day', sp.created_at)::date as date,
+                COUNT(DISTINCT sp.user_id) as totalUsers,
+                -- 1. 장소 확정 리텐션 유저
+                COUNT(DISTINCT ru.user_id) as retainedUsers,
+                -- 2. 카카오 유입 + 장소 확정 리텐션 유저
+                COUNT(DISTINCT rku.user_id) as retainedUsersWithKakao
+            FROM start_point sp
+            -- [POOL 1] 장소 확정 2회 이상 경험 유저
+            LEFT JOIN (
+                SELECT s.user_id
+                FROM start_point s
+                JOIN event e ON s.event_id = e.event_id
+                WHERE s.created_at BETWEEN :thirtyDaysAgo AND :endDateTime
+                  AND e.place_id IS NOT NULL
+                GROUP BY s.user_id
+                HAVING COUNT(DISTINCT s.event_id) >= 2
+            ) ru ON sp.user_id = ru.user_id
+            -- [POOL 2] 카카오 유입 & 장소 확정 2회 이상 경험 유저
+            LEFT JOIN (
+                SELECT s.user_id
+                FROM start_point s
+                JOIN event e ON s.event_id = e.event_id
+                JOIN log_event_inflow lei ON e.event_id = lei.event_id
+                WHERE s.created_at BETWEEN :thirtyDaysAgo AND :endDateTime
+                  AND e.place_id IS NOT NULL
+                  AND lei.inflow_type = 'KAKAO'
+                GROUP BY s.user_id
+                HAVING COUNT(DISTINCT s.event_id) >= 2
+            ) rku ON sp.user_id = rku.user_id
+            WHERE sp.created_at BETWEEN :startDateTime AND :endDateTime
+              AND sp.is_user = true
+            GROUP BY date
+            ORDER BY date
+            """, nativeQuery = true)
+    List<RetentionStat> findDailyRetentionStats(
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime,
+            @Param("thirtyDaysAgo") LocalDateTime thirtyDaysAgo
+    );
 }

--- a/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/projection/RetentionStat.java
+++ b/src/main/java/com/meetup/server/startpoint/infrastructure/jpa/projection/RetentionStat.java
@@ -1,0 +1,10 @@
+package com.meetup.server.startpoint.infrastructure.jpa.projection;
+
+import java.time.LocalDate;
+
+public interface RetentionStat {
+    LocalDate getDate();
+    Long getTotalUsers();
+    Long getRetainedUsers();
+    Long getRetainedUsersWithKakao();
+}

--- a/src/main/resources/templates/admin/fragments/common.html
+++ b/src/main/resources/templates/admin/fragments/common.html
@@ -135,6 +135,12 @@
                     <span class="text">사용자</span>
                 </a>
             </li>
+            <li>
+                <a th:href="@{/admins/stats}" th:classappend="${activeMenu == 'stats' ? 'active' : ''}">
+                    <span class="icon">📊</span>
+                    <span class="text">통계</span>
+                </a>
+            </li>
         </ul>
     </div>
 

--- a/src/main/resources/templates/admin/stats.html
+++ b/src/main/resources/templates/admin/stats.html
@@ -322,7 +322,7 @@
 
             <div class="chart-container">
                 <div class="chart-box">
-                    <h3>장소 확정 재경험 추이 (Retention)</h3>
+                    <h3>장소 확정 재경험 추이</h3>
                     <div class="chart-wrapper">
                         <canvas id="retentionChart"></canvas>
                     </div>
@@ -330,7 +330,7 @@
             </div>
 
             <div class="table-container">
-                <h3>Retention 상세 데이터 (유저 기준)</h3>
+                <h3>Retention 상세 데이터</h3>
                 <table>
                     <thead>
                     <tr>

--- a/src/main/resources/templates/admin/stats.html
+++ b/src/main/resources/templates/admin/stats.html
@@ -232,7 +232,7 @@
     <div class="main-content">
         <h2>Statistics</h2>
 
-        <form class="date-filter" th:action="@{/admins/stats}" method="get">
+        <form class="date-filter" th:action="@{/admins/stats}" method="get" onsubmit="return validateDates()">
             <label for="startDate">시작일:</label>
             <input type="date" id="startDate" name="startDate" th:value="${startDate}">
 
@@ -240,6 +240,7 @@
             <input type="date" id="endDate" name="endDate" th:value="${endDate}">
 
             <button type="submit">조회</button>
+            <span id="dateError" style="color: red; margin-left: 10px; display: none;">시작일은 종료일보다 뒤일 수 없습니다.</span>
         </form>
 
         <div class="tabs">
@@ -358,6 +359,19 @@
 </div>
 
 <script th:inline="javascript">
+    function validateDates() {
+        const startDate = document.getElementById('startDate').value;
+        const endDate = document.getElementById('endDate').value;
+        const errorSpan = document.getElementById('dateError');
+
+        if (startDate && endDate && startDate > endDate) {
+            errorSpan.style.display = 'inline';
+            return false;
+        }
+        errorSpan.style.display = 'none';
+        return true;
+    }
+
     function showTab(tabName) {
         document.querySelectorAll('.tab-content').forEach(tab => tab.classList.remove('active'));
         document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));

--- a/src/main/resources/templates/admin/stats.html
+++ b/src/main/resources/templates/admin/stats.html
@@ -1,0 +1,474 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>MOISAM Admin</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: Arial, sans-serif;
+        }
+
+        .main-content {
+            flex-grow: 1;
+            padding: 30px;
+            background-color: #ffffff;
+        }
+
+        h2 {
+            border-bottom: 2px solid #ccc;
+            padding-bottom: 10px;
+            margin-bottom: 20px;
+        }
+
+        .date-filter {
+            display: flex;
+            gap: 15px;
+            align-items: center;
+            margin-bottom: 30px;
+            padding: 15px;
+            background-color: #f8f9fa;
+            border-radius: 6px;
+        }
+
+        .date-filter label {
+            font-weight: bold;
+            color: #495057;
+        }
+
+        .date-filter input {
+            padding: 8px 12px;
+            border: 1px solid #ced4da;
+            border-radius: 4px;
+            font-size: 14px;
+        }
+
+        .date-filter button {
+            padding: 8px 20px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+        }
+
+        .date-filter button:hover {
+            background-color: #0056b3;
+        }
+
+        .tabs {
+            display: flex;
+            border-bottom: 2px solid #dee2e6;
+            margin-bottom: 25px;
+        }
+
+        .tab-btn {
+            padding: 12px 25px;
+            background: none;
+            border: none;
+            cursor: pointer;
+            font-size: 15px;
+            font-weight: 600;
+            color: #6c757d;
+            position: relative;
+            transition: color 0.2s;
+        }
+
+        .tab-btn:hover {
+            color: #007bff;
+        }
+
+        .tab-btn.active {
+            color: #007bff;
+        }
+
+        .tab-btn.active::after {
+            content: '';
+            position: absolute;
+            bottom: -2px;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background-color: #007bff;
+        }
+
+        .tab-content {
+            display: none;
+        }
+
+        .tab-content.active {
+            display: block;
+        }
+
+        .stats-container {
+            display: flex;
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+
+        .stat-card {
+            background-color: #fff;
+            border: 1px solid #dee2e6;
+            border-left: 5px solid #17a2b8;
+            padding: 15px 25px;
+            border-radius: 6px;
+            min-width: 180px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+        }
+
+        .stat-card.activation {
+            border-left-color: #28a745;
+        }
+
+        .stat-card.activation-kakao {
+            border-left-color: #FEE500;
+        }
+
+        .stat-card.retention {
+            border-left-color: #ffc107;
+        }
+
+        .stat-card.kakao-retention {
+            border-left-color: #faa2c1;
+        }
+
+        .stat-card .label {
+            display: block;
+            font-size: 0.85em;
+            color: #6c757d;
+            margin-bottom: 8px;
+            font-weight: bold;
+        }
+
+        .stat-card .value {
+            font-size: 1.6em;
+            font-weight: bold;
+            color: #212529;
+        }
+
+        .stat-card .unit {
+            font-size: 0.6em;
+            margin-left: 4px;
+            color: #495057;
+        }
+
+        .chart-container {
+            display: flex;
+            gap: 30px;
+            margin-bottom: 40px;
+        }
+
+        .chart-box {
+            flex: 1;
+            background-color: #fff;
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            padding: 20px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+        }
+
+        .chart-box h3 {
+            margin-top: 0;
+            margin-bottom: 15px;
+            color: #343a40;
+            font-size: 1.1em;
+            border-bottom: 1px solid #dee2e6;
+            padding-bottom: 10px;
+        }
+
+        .chart-wrapper {
+            position: relative;
+            height: 300px;
+        }
+
+        .table-container {
+            margin-top: 30px;
+            max-height: 400px;
+            overflow-y: auto;
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+        }
+
+        .table-container h3 {
+            padding: 15px;
+            margin: 0;
+            background-color: #f8f9fa;
+            border-bottom: 1px solid #dee2e6;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background-color: #fff;
+        }
+
+        th, td {
+            border: 1px solid #ddd;
+            padding: 12px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #f2f2f2;
+            font-weight: bold;
+            position: sticky;
+            top: 0;
+            z-index: 1;
+        }
+
+        tr:hover {
+            background-color: #f9f9f9;
+        }
+    </style>
+</head>
+<body>
+
+<div class="admin-wrapper">
+    <div th:replace="~{admin/fragments/common :: sidebar('stats')}"></div>
+
+    <div class="main-content">
+        <h2>Statistics</h2>
+
+        <form class="date-filter" th:action="@{/admins/stats}" method="get">
+            <label for="startDate">시작일:</label>
+            <input type="date" id="startDate" name="startDate" th:value="${startDate}">
+
+            <label for="endDate">종료일:</label>
+            <input type="date" id="endDate" name="endDate" th:value="${endDate}">
+
+            <button type="submit">조회</button>
+        </form>
+
+        <div class="tabs">
+            <button class="tab-btn active" onclick="showTab('activation')">Activation</button>
+            <button class="tab-btn" onclick="showTab('retention')">Retention</button>
+        </div>
+
+        <div id="activation-tab" class="tab-content active" th:if="${stats != null}">
+            <div class="stats-container">
+                <div class="stat-card activation">
+                    <span class="label">🎯 장소 확정률 (전체)</span>
+                    <div class="value">
+                        <span th:text="${stats.overallActivationRate()}">0</span>
+                        <span class="unit">%</span>
+                    </div>
+                </div>
+                <div class="stat-card activation-kakao">
+                    <span class="label">🎯 장소 확정률 (카카오 유입 포함)</span>
+                    <div class="value">
+                        <span th:text="${stats.overallActivationRateWithKakao()}">0</span>
+                        <span class="unit">%</span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="chart-container">
+                <div class="chart-box">
+                    <h3>장소 확정 및 카카오 유입 추이</h3>
+                    <div class="chart-wrapper">
+                        <canvas id="activationChart"></canvas>
+                    </div>
+                </div>
+            </div>
+
+            <div class="table-container">
+                <h3>Activation 상세 데이터</h3>
+                <table>
+                    <thead>
+                    <tr>
+                        <th>날짜</th>
+                        <th>전체 모임 수</th>
+                        <th>장소 확정</th>
+                        <th>장소 확정 (+카카오 유입)</th>
+                        <th>확정률 (%)</th>
+                        <th>확정+유입률 (%)</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="activation : ${stats.activationStats()}">
+                        <td th:text="${activation.date()}">2025-01-01</td>
+                        <td th:text="${activation.totalEvents()}">0</td>
+                        <td th:text="${activation.confirmedPlaceEvents()}">0</td>
+                        <td th:text="${activation.confirmedEventsWithKakao()}">0</td>
+                        <td th:text="${activation.activationRate()}">0</td>
+                        <td th:text="${activation.activationRateWithKakao()}">0</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div id="retention-tab" class="tab-content" th:if="${stats != null}">
+            <div class="stats-container">
+                <div class="stat-card retention">
+                    <span class="label">🔄 장소 확정 재경험률 (일반)</span>
+                    <div class="value">
+                        <span th:text="${stats.overallRetentionRate()}">0</span>
+                        <span class="unit">%</span>
+                    </div>
+                </div>
+                <div class="stat-card kakao-retention">
+                    <span class="label">🔄 장소 확정 재경험률 (카카오 유입 포함)</span>
+                    <div class="value">
+                        <span th:text="${stats.overallRetentionRateWithKakao()}">0</span>
+                        <span class="unit">%</span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="chart-container">
+                <div class="chart-box">
+                    <h3>장소 확정 재경험 추이 (Retention)</h3>
+                    <div class="chart-wrapper">
+                        <canvas id="retentionChart"></canvas>
+                    </div>
+                </div>
+            </div>
+
+            <div class="table-container">
+                <h3>Retention 상세 데이터 (유저 기준)</h3>
+                <table>
+                    <thead>
+                    <tr>
+                        <th>날짜</th>
+                        <th>방문 유저 수</th>
+                        <th>확정 재경험 유저</th>
+                        <th>확정 재경험 (카카오)</th>
+                        <th>재경험률 (%)</th>
+                        <th>카카오 재경험률 (%)</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="retention : ${stats.retentionStats()}">
+                        <td th:text="${retention.date()}">2026-02-22</td>
+                        <td th:text="${retention.totalUsersWithEvents()}">0</td>
+                        <td th:text="${retention.retainedUsers()}">0</td>
+                        <td th:text="${retention.retainedUsersWithKakao()}">0</td>
+                        <td th:text="${retention.retentionRate()}">0</td>
+                        <td th:text="${retention.retentionRateWithKakao()}">0</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script th:inline="javascript">
+    function showTab(tabName) {
+        document.querySelectorAll('.tab-content').forEach(tab => tab.classList.remove('active'));
+        document.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
+
+        document.getElementById(tabName + '-tab').classList.add('active');
+        document.querySelector(`button[onclick="showTab('${tabName}')"]`).classList.add('active');
+
+        window.dispatchEvent(new Event('resize'));
+    }
+
+    /*<![CDATA[*/
+    const activationStats = /*[[${stats.activationStats()}]]*/ [];
+    const retentionStats = /*[[${stats.retentionStats()}]]*/ [];
+
+    const labels = activationStats.map(s => s.date);
+    const activationData = activationStats.map(s => s.activationRate);
+    const activationRateWithKakaoData = activationStats.map(s => s.activationRateWithKakao);
+    const retentionData = retentionStats.map(s => s.retentionRate);
+    const retentionRateWithKakaoData = retentionStats.map(s => s.retentionRateWithKakao);
+
+    const activationCtx = document.getElementById('activationChart').getContext('2d');
+    new Chart(activationCtx, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: '장소 확정률 (%)',
+                    data: activationData,
+                    borderColor: '#28a745',
+                    backgroundColor: 'rgba(40, 167, 69, 0.1)',
+                    fill: true,
+                    tension: 0.3,
+                    pointRadius: labels.length > 15 ? 2 : 4,
+                    pointHoverRadius: 5
+                },
+                {
+                    label: '장소 확정률 (카카오 포함) (%)',
+                    data: activationRateWithKakaoData,
+                    borderColor: '#FEE500',
+                    backgroundColor: 'rgba(254, 229, 0, 0.1)',
+                    fill: true,
+                    tension: 0.3,
+                    pointRadius: labels.length > 15 ? 2 : 4,
+                    pointHoverRadius: 5
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    max: 100,
+                    ticks: {
+                        callback: function (value) {
+                            return value + '%';
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    const retentionCtx = document.getElementById('retentionChart').getContext('2d');
+    new Chart(retentionCtx, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: '장소 확정 재경험률 (%)',
+                    data: retentionData,
+                    borderColor: '#ffc107',
+                    backgroundColor: 'rgba(255, 193, 7, 0.1)',
+                    fill: true,
+                    tension: 0.3,
+                    pointRadius: labels.length > 15 ? 2 : 4,
+                    pointHoverRadius: 5
+                },
+                {
+                    label: '장소 확정 재경험률 (카카오 포함) (%)',
+                    data: retentionRateWithKakaoData,
+                    borderColor: '#faa2c1',
+                    backgroundColor: 'rgba(250, 162, 193, 0.1)',
+                    fill: true,
+                    tension: 0.3,
+                    pointRadius: labels.length > 15 ? 2 : 4,
+                    pointHoverRadius: 5
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    max: 100,
+                    ticks: {
+                        callback: function (value) {
+                            return value + '%';
+                        }
+                    }
+                }
+            }
+        }
+    });
+    /*]]>*/
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

<img width="713" height="586" alt="스크린샷 2026-02-22 오후 4 02 25" src="https://github.com/user-attachments/assets/b95fe80b-bc69-435d-a9a7-672e897bc269" />

[참고 블로그](https://brunch.co.kr/@seongminyoo/98)

- 회의 때 나왔던 내용으로, AARRR 중 Activation과 Retention 수치를 기간 별로 확인이 필요했습니다. 매번 요청 받아 데이터를 전달하는 것보다,  관리자 페이지에서 기간 별로 조회하는 것이 낫다고 판단하여 관리자 페이지에 통계용 페이지를 추가했습니다.

### Activation

a) 장소 확정한 모임의 수 / 전체 모임 수
b) 장소 확정 + 카카오 유입까지 진행된 모임의 수 / 전체 모임 수

### Retention

> 기준: 서비스를 1회 이상 사용한 사용자가 30일 내에 모임을 생성하고 Activation 단계를 반복

a) 한달 내 재접속 해 Activation의 a 플로우를 반복한 수 / 전체 유저 수
b) 한달 내 재접속 해 Activation의 b 플로우를 반복한 수 / 전체 유저 수

## ✅ What - 무엇이 변경됐나요?

- 통계 view 생성 (`stats.html`)
- Activation, Retention 쿼리 작성

## 🛠️ How - 어떻게 해결했나요?

- Chart.js를 사용해 그래프로 데이터를 확인할 수 있도록 구현
- Activation, Retention을 탭으로 구분
- 쿼리 부분은 주석을 확인해주세요.

## 🖼️ Attachment

<img width="1900" height="927" alt="스크린샷 2026-02-22 오후 4 43 16" src="https://github.com/user-attachments/assets/61c76661-445e-499a-b458-7613c909e955" />


## 💬 기타 코멘트

- `리뷰어에게 전하고 싶은 말, 테스트 방법, 주의할 점 등`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 페이지에 통계 대시보드 추가(사이드바 메뉴 포함)
  * 날짜 범위 필터로 기간별(기본 30일) 활성화·유지율 조회 가능(ISO 날짜 입력)
  * 활성화/유지율 탭으로 구분된 상세 뷰 제공
  * 전일별 시계열 차트(Chart.js)와 데이터 테이블로 시각화
  * 전체 및 채널별(카카오 포함/제외) 비율·요약 수치 및 기간별 목록 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->