### PR TITLE
[MOISAM-258] Layered JAR를 이용해 Docker Build를 개선한다

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -57,6 +57,8 @@ jobs:
           push: true
           tags: |
             ${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deploy:
     needs: build

--- a/.github/workflows/stg-deploy.yml
+++ b/.github/workflows/stg-deploy.yml
@@ -59,6 +59,8 @@ jobs:
           push: true
           tags: |
             ${{ secrets.NCP_CONTAINER_REGISTRY }}/spot-backend:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deploy:
     needs: build

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,15 @@
-FROM eclipse-temurin:21-alpine
-
+FROM eclipse-temurin:21-jre-alpine AS builder
+WORKDIR /app
 ARG JAR_FILE=./*.jar
-COPY ${JAR_FILE} spot.jar
+COPY ${JAR_FILE} app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
 
-ENTRYPOINT ["java", "-jar", "spot.jar"]
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+COPY --from=builder /app/dependencies/ ./
+COPY --from=builder /app/spring-boot-loader/ ./
+COPY --from=builder /app/snapshot-dependencies/ ./
+COPY --from=builder /app/application/ ./
+
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- Github Actions에서 이미 Jar를 만들고 있지만 DockerFile에서 JDK를 사용. (JDK는 JRE보다 무거움)
- `COPY ${JAR_FILE} spot.jar`를 통해 jar 전체 파일을 도커 이미지로 말아 올림.
-  변하지 않는 부분 (Spring 프레임워크, 라이브러리 등)을 매번 새 이미지로 만드는 문제.

## ✅ What - 무엇이 변경됐나요?

<img width="942" height="594" alt="image" src="https://github.com/user-attachments/assets/c098b9d7-2c19-4d7f-8392-ec73cb4e8249" />

- JRE로 변경하여 불필요한 무게 제거
- `-Djarmode=layertools`, export를 통해 Layered Jar로 추출
- `docker Image build`를 사용하면 단계(layer) 별로 캐시를 생성하기 때문에 변경이 잘 되지 않는 것부터 COPY 함으로써 캐시가 깨지지 않도록 함.

## 🛠️ How - 어떻게 해결했나요?

- What 참고.

## 🖼️ Attachment

## 💬 기타 코멘트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 컨테이너 이미지를 다단계로 재구성해 빌드 효율성과 런타임 성능을 개선했습니다. 애플리케이션 계층 분리를 통해 이미지 크기와 시작 시간이 줄어듭니다.
  * CI 빌드에 캐시 구성을 추가해 이미지 빌드/배포 시간이 단축됩니다.
  * 저장소의 하위 모듈 참조를 갱신해 코드베이스 연계를 최신 상태로 유지했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->