### PR TITLE
[MOISAM-259] 중간지점 주변 장소의 사진 1장을 조회한다

### DIFF
--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -3,6 +3,7 @@ package com.meetup.server.auth.support.handler;
 import com.meetup.server.auth.dto.CustomOAuth2User;
 import com.meetup.server.auth.support.CookieUtil;
 import com.meetup.server.global.support.jwt.JwtTokenProvider;
+import com.meetup.server.global.util.ProfileUtil;
 import com.meetup.server.log.domain.type.LoginStatus;
 import com.meetup.server.log.implement.LogUserLoginWriter;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,6 +27,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     private final JwtTokenProvider tokenProvider;
     private final CookieUtil cookieUtil;
     private final LogUserLoginWriter logUserLoginWriter;
+    private final ProfileUtil profileUtil;
 
     @Value("${app.oauth2.successRedirectUri}")
     private String successRedirectUri;
@@ -68,7 +70,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     }
 
     private String resolveBaseUrl(StateParams stateParams) {
-        if ("local".equals(stateParams.env)) {
+        if ("local".equals(stateParams.env) && profileUtil.isStg()) {
             return "http://localhost:5173";
         }
         return successRedirectUri;

--- a/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/meetup/server/auth/support/handler/OAuth2LoginSuccessHandler.java
@@ -53,17 +53,25 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     private String createRedirectUrlWithTokens(HttpServletRequest request) {
         StateParams stateParams = parseState(request.getParameter("state"));
+        String baseUrl = resolveBaseUrl(stateParams);
 
         String redirectUrl;
         if ("visited".equals(stateParams.to) && stateParams.eventId != null && stateParams.placeId != null) {
-            redirectUrl = buildVisitedRedirectUrl(stateParams.eventId, stateParams.placeId);
+            redirectUrl = buildVisitedRedirectUrl(baseUrl, stateParams.eventId, stateParams.placeId);
         } else if ("notvisited".equals(stateParams.to) && stateParams.eventId != null && stateParams.placeId != null) {
-            redirectUrl = buildNotVisitedRedirectUrl(stateParams.eventId, stateParams.placeId);
+            redirectUrl = buildNotVisitedRedirectUrl(baseUrl, stateParams.eventId, stateParams.placeId);
         } else {
-            redirectUrl = buildDefaultCallbackUrl(stateParams.eventId, stateParams.to);
+            redirectUrl = buildDefaultCallbackUrl(baseUrl, stateParams.eventId, stateParams.to);
         }
 
         return redirectUrl;
+    }
+
+    private String resolveBaseUrl(StateParams stateParams) {
+        if ("local".equals(stateParams.env)) {
+            return "http://localhost:5173";
+        }
+        return successRedirectUri;
     }
 
     private StateParams parseState(String state) {
@@ -80,14 +88,15 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
                     case "to" -> params.to = keyValue[1];
                     case "eventId" -> params.eventId = keyValue[1];
                     case "placeId" -> params.placeId = keyValue[1];
+                    case "env" -> params.env = keyValue[1];
                 }
             }
         }
         return params;
     }
 
-    private String buildDefaultCallbackUrl(String eventId, String to) {
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(successRedirectUri).pathSegment("oauth", "kakao", "callback");
+    private String buildDefaultCallbackUrl(String baseUrl, String eventId, String to) {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(baseUrl).pathSegment("oauth", "kakao", "callback");
         if (eventId != null && !eventId.isBlank()) {
             uriBuilder.queryParam("eventId", eventId);
         }
@@ -97,15 +106,15 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         return uriBuilder.build().toUriString();
     }
 
-    private String buildVisitedRedirectUrl(String eventId, String placeId) {
-        return UriComponentsBuilder.fromUriString(successRedirectUri)
+    private String buildVisitedRedirectUrl(String baseUrl, String eventId, String placeId) {
+        return UriComponentsBuilder.fromUriString(baseUrl)
                 .pathSegment("visited", eventId, placeId)
                 .build()
                 .toUriString();
     }
 
-    private String buildNotVisitedRedirectUrl(String eventId, String placeId) {
-        return UriComponentsBuilder.fromUriString(successRedirectUri)
+    private String buildNotVisitedRedirectUrl(String baseUrl, String eventId, String placeId) {
+        return UriComponentsBuilder.fromUriString(baseUrl)
                 .pathSegment("notvisited", eventId, placeId)
                 .build()
                 .toUriString();
@@ -115,5 +124,6 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String to;
         String eventId;
         String placeId;
+        String env;
     }
 }

--- a/src/main/java/com/meetup/server/auth/support/resolver/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/meetup/server/auth/support/resolver/CustomAuthorizationRequestResolver.java
@@ -37,12 +37,19 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
         String to = request.getParameter("to");
         String eventId = request.getParameter("eventId");
         String placeId = request.getParameter("placeId");
+        String env = request.getParameter("env");
 
-        if (to == null && eventId == null && placeId == null) {
+        if (to == null && eventId == null && placeId == null && env == null) {
             return req;
         }
 
-        String stateValue = "to=" + to + "&eventId=" + eventId + "&placeId=" + placeId;
+        StringBuilder stateBuilder = new StringBuilder();
+        if (to != null) stateBuilder.append("to=").append(to).append("&");
+        if (eventId != null) stateBuilder.append("eventId=").append(eventId).append("&");
+        if (placeId != null) stateBuilder.append("placeId=").append(placeId).append("&");
+        if (env != null) stateBuilder.append("env=").append(env);
+
+        String stateValue = stateBuilder.toString().replaceAll("&$", "");
         stateValue = URLEncoder.encode(stateValue, StandardCharsets.UTF_8);
 
         return OAuth2AuthorizationRequest.from(req)

--- a/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRoutesResponse.java
@@ -4,9 +4,9 @@ import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.util.UsernameExtractor;
 import com.meetup.server.global.util.TimeUtil;
 import com.meetup.server.place.domain.Place;
+import com.meetup.server.place.domain.value.Image;
 import com.meetup.server.startpoint.domain.StartPoint;
 
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +17,7 @@ public record MeetingPointRoutesResponse(
         String eventTime,
         String eventMaker,
         String placeName,
+        String placeImage,
         int peopleCount,
         List<MeetingPointRouteGroup> meetingPointRouteGroups
 ) {
@@ -28,6 +29,7 @@ public record MeetingPointRoutesResponse(
                 TimeUtil.formatAsTime(event.getEventDateTime()),
                 extractEventMaker(startPoints),
                 extractPlaceName(event),
+                extractPlaceImage(event),
                 startPoints.size(),
                 meetingPointRouteGroups
         );
@@ -39,22 +41,18 @@ public record MeetingPointRoutesResponse(
                 .orElse(null);
     }
 
+    private static String extractPlaceImage(Event event) {
+        return Optional.ofNullable(event.getPlace())
+                .map(Place::getImages)
+                .map(List::getFirst)
+                .map(Image::photoUri)
+                .orElse(null);
+    }
+
     private static String extractEventMaker(List<StartPoint> startPoints) {
         return startPoints.stream()
                 .min(Comparator.comparing(StartPoint::getCreatedAt))
                 .map(UsernameExtractor::extractDisplayName)
                 .orElse(null);
-    }
-
-    public MeetingPointRoutesResponse withEvent(String eventName, LocalDateTime eventDateTime) {
-        return new MeetingPointRoutesResponse(
-                eventName,
-                TimeUtil.formatAsDashDate(eventDateTime),
-                TimeUtil.formatAsTime(eventDateTime),
-                this.eventMaker(),
-                this.placeName(),
-                this.peopleCount(),
-                this.meetingPointRouteGroups()
-        );
     }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRoutesResponse.java
@@ -44,6 +44,7 @@ public record MeetingPointRoutesResponse(
     private static String extractPlaceImage(Event event) {
         return Optional.ofNullable(event.getPlace())
                 .map(Place::getImages)
+                .filter(images -> !images.isEmpty())
                 .map(List::getFirst)
                 .map(Image::photoUri)
                 .orElse(null);

--- a/src/main/java/com/meetup/server/global/support/error/discord/DiscordAlarmSender.java
+++ b/src/main/java/com/meetup/server/global/support/error/discord/DiscordAlarmSender.java
@@ -1,16 +1,15 @@
 package com.meetup.server.global.support.error.discord;
 
+import com.meetup.server.global.util.ProfileUtil;
 import com.meetup.server.global.util.TimeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Component
@@ -22,15 +21,14 @@ public class DiscordAlarmSender {
 
     private static final RestClient restClient = RestClient.create();
 
-    private final Environment environment;
+    private final ProfileUtil profileUtil;
 
     public void sendErrorAlert(Exception exception) {
-        String env = getEnvironment();
-        if (!List.of("PROD", "STG").contains(env)) {
+        if (profileUtil.isLocal()) {
             return;
         }
 
-        String content = ":rotating_light: [" + getEnvironment() + "] 서버 예외 발생";
+        String content = ":rotating_light: [" + profileUtil.getActiveProfile() + "] 서버 예외 발생";
         List<DiscordRequest.Embed> embeds = List.of(
                 DiscordRequest.Embed.of("Exception", exception.getClass().getSimpleName()),
                 DiscordRequest.Embed.of("Message", exception.getMessage()),
@@ -49,10 +47,6 @@ public class DiscordAlarmSender {
         } catch (Exception e) {
             log.warn("[DiscordAlarmSender] Discord 메시지 전송 실패: {}", e.getMessage());
         }
-    }
-
-    private String getEnvironment() {
-        return Optional.ofNullable(environment.getActiveProfiles()[0]).map(String::toUpperCase).orElse("-");
     }
 
     private String parseStackTrace(Exception exception) {

--- a/src/main/java/com/meetup/server/global/support/error/discord/DiscordAlarmSender.java
+++ b/src/main/java/com/meetup/server/global/support/error/discord/DiscordAlarmSender.java
@@ -24,7 +24,7 @@ public class DiscordAlarmSender {
     private final ProfileUtil profileUtil;
 
     public void sendErrorAlert(Exception exception) {
-        if (profileUtil.isLocal()) {
+        if (!(profileUtil.isProd() || profileUtil.isStg())) {
             return;
         }
 

--- a/src/main/java/com/meetup/server/global/util/ProfileUtil.java
+++ b/src/main/java/com/meetup/server/global/util/ProfileUtil.java
@@ -1,0 +1,35 @@
+package com.meetup.server.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileUtil {
+
+    private final Environment environment;
+
+    public boolean isProd() {
+        return isProfileActive("prod");
+    }
+
+    public boolean isStg() {
+        return isProfileActive("stg");
+    }
+
+    public boolean isLocal() {
+        return isProfileActive("local");
+    }
+
+    public String getActiveProfile() {
+        String[] profiles = environment.getActiveProfiles();
+        return (profiles.length > 0) ? profiles[0].toUpperCase() : "DEFAULT";
+    }
+
+    private boolean isProfileActive(String profile) {
+        return Arrays.asList(environment.getActiveProfiles()).contains(profile);
+    }
+}

--- a/src/main/java/com/meetup/server/place/application/PlaceService.java
+++ b/src/main/java/com/meetup/server/place/application/PlaceService.java
@@ -90,4 +90,18 @@ public class PlaceService {
         PlaceWithRating placeWithRating = reviewReader.readPlaceRatingsAsMap(List.of(place.getId())).get(place);
         return PlaceResponseList.of(event, subway, PlaceResponse.of(placeWithDistance, placeWithRating), null);
     }
+
+    public PlaceImageResponse getPlaceImage(int subwayId) {
+        Subway subway = subwayReader.read(subwayId);
+        List<PlaceWithDistance> nearbyPlaces = placeReader.readAllWithinRadius(subway.getPoint(), RADIUS);
+
+        return nearbyPlaces.stream()
+                .map(PlaceWithDistance::place)
+                .filter(place -> place.getImages() != null && !place.getImages().isEmpty())
+                .map(place -> place.getImages().getFirst().photoUri())
+                .filter(uri -> uri != null && !uri.isBlank())
+                .findFirst()
+                .map(PlaceImageResponse::from)
+                .orElse(null);
+    }
 }

--- a/src/main/java/com/meetup/server/place/application/PlaceService.java
+++ b/src/main/java/com/meetup/server/place/application/PlaceService.java
@@ -99,7 +99,7 @@ public class PlaceService {
                 .map(PlaceWithDistance::place)
                 .filter(place -> place.getImages() != null && !place.getImages().isEmpty())
                 .map(place -> place.getImages().getFirst().photoUri())
-                .filter(uri -> uri != null && !uri.isBlank())
+                .filter(image -> image != null && !image.isBlank())
                 .findFirst()
                 .map(PlaceImageResponse::from)
                 .orElse(null);

--- a/src/main/java/com/meetup/server/place/dto/response/PlaceImageResponse.java
+++ b/src/main/java/com/meetup/server/place/dto/response/PlaceImageResponse.java
@@ -1,0 +1,9 @@
+package com.meetup.server.place.dto.response;
+
+public record PlaceImageResponse(
+        String imageUrl
+) {
+    public static PlaceImageResponse from(String imageUrl) {
+        return new PlaceImageResponse(imageUrl);
+    }
+}

--- a/src/main/java/com/meetup/server/place/dto/response/PlaceImageResponse.java
+++ b/src/main/java/com/meetup/server/place/dto/response/PlaceImageResponse.java
@@ -1,9 +1,9 @@
 package com.meetup.server.place.dto.response;
 
 public record PlaceImageResponse(
-        String imageUrl
+        String image
 ) {
-    public static PlaceImageResponse from(String imageUrl) {
-        return new PlaceImageResponse(imageUrl);
+    public static PlaceImageResponse from(String image) {
+        return new PlaceImageResponse(image);
     }
 }

--- a/src/main/java/com/meetup/server/place/presentation/PlaceController.java
+++ b/src/main/java/com/meetup/server/place/presentation/PlaceController.java
@@ -3,6 +3,7 @@ package com.meetup.server.place.presentation;
 import com.meetup.server.global.support.response.ApiResponse;
 import com.meetup.server.place.application.PlaceService;
 import com.meetup.server.place.dto.response.PlaceDetailResponse;
+import com.meetup.server.place.dto.response.PlaceImageResponse;
 import com.meetup.server.place.dto.response.PlaceResponseList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -36,5 +37,10 @@ public class PlaceController {
     @GetMapping("/review")
     public ApiResponse<PlaceResponseList> getPlaceForReview(@RequestParam UUID eventId) {
         return ApiResponse.success(placeService.getPlaceForReview(eventId));
+    }
+
+    @GetMapping("/image")
+    public ApiResponse<PlaceImageResponse> getPlaceImage(@RequestParam int subwayId) {
+        return ApiResponse.success(placeService.getPlaceImage(subwayId));
     }
 }

--- a/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
+++ b/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
@@ -242,6 +242,7 @@ class EventControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data.eventTime").value("10:00"))
                 .andExpect(jsonPath("$.data.eventMaker").value("땡수팟"))
                 .andExpect(jsonPath("$.data.placeName").value("놀숲 건대점"))
+                .andExpect(jsonPath("$.data.placeImage").value("https://example.com/place-image.jpg"))
                 .andExpect(jsonPath("$.data.peopleCount").value(1))
                 .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].subwayId").value(240))
                 .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].averageTime").value(0))
@@ -311,7 +312,8 @@ class EventControllerTest extends ControllerTestSupport {
                                                         fieldWithPath("data.eventDate").type(JsonFieldType.STRING).description("모임 날짜 (YYYY-MM-DD)"),
                                                         fieldWithPath("data.eventTime").type(JsonFieldType.STRING).description("모임 시간 (HH:MM)"),
                                                         fieldWithPath("data.eventMaker").type(JsonFieldType.STRING).description("모임 생성자"),
-                                                        fieldWithPath("data.placeName").type(JsonFieldType.STRING).description("장소 이름"),
+                                                        fieldWithPath("data.placeName").type(JsonFieldType.STRING).description("장소 이름").optional(),
+                                                        fieldWithPath("data.placeImage").type(JsonFieldType.STRING).description("장소 이미지").optional(),
                                                         fieldWithPath("data.peopleCount").type(JsonFieldType.NUMBER).description("모임 참여자 수"),
 
                                                         fieldWithPath("data.meetingPointRouteGroups").type(JsonFieldType.ARRAY).description("중간 지점별 경로 그룹 목록"),

--- a/src/test/java/com/meetup/server/fixture/PlaceFixture.java
+++ b/src/test/java/com/meetup/server/fixture/PlaceFixture.java
@@ -4,6 +4,7 @@ import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.place.domain.type.PlaceCategory;
 import com.meetup.server.place.dto.response.PlaceDetailResponse;
+import com.meetup.server.place.dto.response.PlaceImageResponse;
 import com.meetup.server.place.dto.response.PlaceResponse;
 import com.meetup.server.place.dto.response.PlaceResponseList;
 import com.meetup.server.review.domain.value.PlaceScore;
@@ -87,5 +88,9 @@ public class PlaceFixture {
                 .isConfirmed(true)
                 .isChanged(false)
                 .build();
+    }
+
+    public static PlaceImageResponse getPlaceImageResponse() {
+        return PlaceImageResponse.from("https://example.com/image.jpg");
     }
 }

--- a/src/test/java/com/meetup/server/fixture/PlaceFixture.java
+++ b/src/test/java/com/meetup/server/fixture/PlaceFixture.java
@@ -3,6 +3,7 @@ package com.meetup.server.fixture;
 import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.place.domain.Place;
 import com.meetup.server.place.domain.type.PlaceCategory;
+import com.meetup.server.place.domain.value.Image;
 import com.meetup.server.place.dto.response.PlaceDetailResponse;
 import com.meetup.server.place.dto.response.PlaceImageResponse;
 import com.meetup.server.place.dto.response.PlaceResponse;
@@ -18,6 +19,7 @@ public class PlaceFixture {
 
     public static final UUID PLACE_ID = UUID.fromString("019c5b90-7e80-7875-857a-51bcf5db482a");
     public static final String PLACE_NAME = "스타벅스 선정릉역점";
+    public static final String PLACE_IMAGE_URL = "https://example.com/place-image.jpg";
     public static final PlaceCategory PLACE_CATEGORY = PlaceCategory.CAFE;
     public static final int DISTANCE = 250;
     public static final double AVERAGE_RATING = 4.3;
@@ -32,7 +34,7 @@ public class PlaceFixture {
                 .category(PlaceCategory.CAFE)
                 .name("놀숲 건대점")
                 .googleRating(null)
-                .images(List.of())
+                .images(List.of(Image.from(PLACE_IMAGE_URL)))
                 .openingHours(List.of())
                 .googleReviews(List.of())
                 .location(Location.of(37.5406181573079, 127.06798560729))
@@ -45,7 +47,7 @@ public class PlaceFixture {
                 .id(PLACE_ID)
                 .category(PLACE_CATEGORY)
                 .name(PLACE_NAME)
-                .image("https://example.com/image.jpg")
+                .image(PLACE_IMAGE_URL)
                 .openTime(OPEN_TIME)
                 .closeTime(CLOSE_TIME)
                 .distance(DISTANCE)
@@ -79,7 +81,7 @@ public class PlaceFixture {
                 .kakaoPlaceId("1337065720")
                 .category(PLACE_CATEGORY)
                 .name(PLACE_NAME)
-                .images(List.of("https://example.com/image.jpg"))
+                .images(List.of(PLACE_IMAGE_URL))
                 .openTime(OPEN_TIME)
                 .closeTime(CLOSE_TIME)
                 .distance(DISTANCE)
@@ -91,6 +93,6 @@ public class PlaceFixture {
     }
 
     public static PlaceImageResponse getPlaceImageResponse() {
-        return PlaceImageResponse.from("https://example.com/image.jpg");
+        return PlaceImageResponse.from(PLACE_IMAGE_URL);
     }
 }

--- a/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
@@ -300,7 +300,7 @@ class PlaceControllerTest extends ControllerTestSupport {
                                                 .responseFields(
                                                         fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
                                                         fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
-                                                        fieldWithPath("data.imageUrl").type(JsonFieldType.STRING).description("장소 이미지 URL").optional(),
+                                                        fieldWithPath("data.image").type(JsonFieldType.STRING).description("장소 이미지 URL").optional(),
 
                                                         fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
                                                         fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),

--- a/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
@@ -9,6 +9,7 @@ import com.meetup.server.fixture.SubwayFixture;
 import com.meetup.server.global.support.response.ResultType;
 import com.meetup.server.place.application.PlaceService;
 import com.meetup.server.place.dto.response.PlaceDetailResponse;
+import com.meetup.server.place.dto.response.PlaceImageResponse;
 import com.meetup.server.place.dto.response.PlaceResponseList;
 import com.meetup.server.support.ControllerTest;
 import com.meetup.server.support.ControllerTestSupport;
@@ -262,5 +263,74 @@ class PlaceControllerTest extends ControllerTestSupport {
                                                 .build())
                         )
                 );
+    }
+
+    @DisplayName("중간지점 주변 장소 사진 1장을 조회한다.")
+    @Test
+    void getPlaceImage_Success() throws Exception {
+        // given
+        int subwayId = SubwayFixture.SUBWAY_ID;
+        PlaceImageResponse response = PlaceFixture.getPlaceImageResponse();
+
+        // when
+        Mockito.when(placeService.getPlaceImage(anyInt()))
+                .thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/places/image")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .queryParam("subwayId", String.valueOf(subwayId))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andExpect(jsonPath("$.data.imageUrl").value("https://example.com/image.jpg"))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document("place/get-image",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Place API")
+                                                .description("중간지점 주변 장소 사진 1장을 조회한다.")
+                                                .queryParameters(
+                                                        parameterWithName("subwayId").description("지하철 ID")
+                                                )
+                                                .responseFields(
+                                                        fieldWithPath("result").type(JsonFieldType.STRING).description("API 호출 결과"),
+                                                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터").optional(),
+                                                        fieldWithPath("data.imageUrl").type(JsonFieldType.STRING).description("장소 이미지 URL").optional(),
+
+                                                        fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
+                                                        fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                                        fieldWithPath("error.message").type(JsonFieldType.STRING).description("에러 메시지").optional()
+                                                )
+                                                .responseSchema(Schema.schema("PlaceImageResponse"))
+                                                .build())
+                        )
+                );
+    }
+
+    @DisplayName("중간지점 주변에 사진이 있는 장소가 없으면 null 응답 데이터를 반환한다.")
+    @Test
+    void getPlaceImage_Null() throws Exception {
+        // given
+        int subwayId = SubwayFixture.SUBWAY_ID;
+
+        // when
+        Mockito.when(placeService.getPlaceImage(anyInt()))
+                .thenReturn(null);
+
+        // then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders.get("/places/image")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .queryParam("subwayId", String.valueOf(subwayId))
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
+                .andExpect(jsonPath("$.data").isEmpty());
     }
 }

--- a/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/com/meetup/server/place/presentation/PlaceControllerTest.java
@@ -285,7 +285,7 @@ class PlaceControllerTest extends ControllerTestSupport {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result").value(ResultType.SUCCESS.name()))
-                .andExpect(jsonPath("$.data.imageUrl").value("https://example.com/image.jpg"))
+                .andExpect(jsonPath("$.data.image").value("https://example.com/place-image.jpg"))
                 .andDo(
                         MockMvcRestDocumentationWrapper.document("place/get-image",
                                 preprocessRequest(prettyPrint()),


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- MP "장소를 정해주세요" 에서 카페 사진을 보여주도록 추가되어 중간지점 반경의 장소 데이터의 사진을 조회하는 API를 구현했습니다.

## ✅ What - 무엇이 변경됐나요?

- 중간지점 주변 장소 사진 1장 조회하는 API 구현
- Response DTO 추가
- PL 데이터 리스트 조회하는 로직 재사용

## 🛠️ How - 어떻게 해결했나요?

- 중간지점 반경의 장소 데이터가 없거나 이미지가 없을 경우, null을 반환하도록 프론트와 논의되어 null을 반환합니다.

## 🖼️ Attachment


## 💬 기타 코멘트



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 지하철 역 ID로 주변 장소 이미지를 조회하는 새 API 엔드포인트 추가
  * 장소 이미지(이미지 URL)를 반환하는 응답 타입 제공

* **변경 사항**
  * 모임 경로 응답(payload)에 선택적 장소 이미지(placeImage) 필드 추가
  * OAuth2 로그인 리디렉션이 실행 환경(env)에 따라 다른 기본 URL을 사용하도록 개선
  * 권한 요청에 env 전달 지원 추가

* **테스트**
  * 이미지 조회 성공/실패 케이스 및 관련 API 문서화 테스트 추가 및 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->