### PR TITLE
[MOISAM-260] Activation 통계에서 출발지가 2개 이상인 모임부터 조회하도록 변경한다

### DIFF
--- a/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
+++ b/src/main/java/com/meetup/server/event/infrastructure/jpa/EventRepository.java
@@ -37,6 +37,12 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
                     SELECT 1 FROM log_event_inflow l WHERE l.event_id = e.event_id AND l.inflow_type = 'KAKAO'
                 ) THEN 1 END) as confirmedEventsWithKakao
             FROM event e
+            JOIN (
+                SELECT event_id
+                FROM start_point
+                GROUP BY event_id
+                HAVING COUNT(*) >= 2
+            ) active_events ON e.event_id = active_events.event_id
             WHERE e.created_at BETWEEN :startDateTime AND :endDateTime
             GROUP BY date
             ORDER BY date


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

현재 Activation에서 장소 확정률을 조회하는데, 이때 모든 모임으로 나누고 있어 장소 확정을 하지 못하는 1인 모임도 포함되어 있습니다.
장소 확정률이 너무 낮게 나와 장소 확정을 할 수 있는 최소 기준인 출발지 2개 이상인 모임으로 나누도록 변경했습니다.

## ✅ What - 무엇이 변경됐나요?

Why 참고

## 🛠️ How - 어떻게 해결했나요?

- StartPoint와 조인하여 처리

## 🖼️ Attachment

❌

## 💬 기타 코멘트

❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이벤트 통계 조회에서 2개 이상의 시작 지점 기록을 가진 이벤트만 포함되도록 필터링 조건 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->