### PR TITLE
[MOISAM-265] CloudWatch 로그 파싱을 위한 Logstash JSON 인코더를 적용한다

### DIFF
--- a/gradle/util.gradle
+++ b/gradle/util.gradle
@@ -4,4 +4,5 @@ dependencies {
     implementation 'com.opencsv:opencsv:5.10'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.174'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'net.logstash.logback:logstash-logback-encoder:9.0'
 }

--- a/src/main/java/com/meetup/server/global/util/LoggingUtil.java
+++ b/src/main/java/com/meetup/server/global/util/LoggingUtil.java
@@ -22,10 +22,8 @@ public class LoggingUtil {
         String queryString = request.getQueryString() != null ? "?" + request.getQueryString() : "";
         String requestBody = getRequestBody(request);
 
-        String msg = """
-                [Request] Method=%s, Path=%s
-                QueryString=%s
-                Body=%s""".formatted(method, path, queryString, requestBody);
+        String msg = "[Request] Method=%s, Path=%s, QueryString=%s, Body=%s"
+                .formatted(method, path, queryString, requestBody);
         log.info(msg);
     }
 
@@ -44,17 +42,11 @@ public class LoggingUtil {
         String message = errorType.getMessage();
         String exceptionType = e.getClass().getSimpleName();
 
-        String errorBody = """
-                {
-                  "errorCode": "%s",
-                  "message": "%s",
-                  "type": "%s"
-                }""".formatted(errorCode, message, exceptionType);
+        String errorBody = "{\"errorCode\": \"%s\", \"message\": \"%s\", \"type\": \"%s\"}"
+                .formatted(errorCode, message, exceptionType);
 
-        String logMsg = """
-                %s ErrorCode=%d
-                Message=%s
-                Body=%s""".formatted(logTag, errorType.getStatus().value(), message, errorBody);
+        String logMsg = "%s ErrorCode=%d, Message=%s, Body=%s"
+                .formatted(logTag, errorType.getStatus().value(), message, errorBody);
 
         log.error(logMsg, e);
     }

--- a/src/main/resources/logback-appenders.xml
+++ b/src/main/resources/logback-appenders.xml
@@ -1,0 +1,22 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] [%X{TRACE_ID}] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>true</includeContext>
+            <includeCallerData>false</includeCallerData>
+            <fieldNames>
+                <timestamp>@timestamp</timestamp>
+                <level>level</level>
+                <thread>thread</thread>
+                <logger>logger</logger>
+                <message>message</message>
+                <stackTrace>stack_trace</stackTrace>
+            </fieldNames>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,9 +1,5 @@
 <configuration>
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] [%X{TRACE_ID}] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
+    <include resource="logback-appenders.xml"/>
 
     <logger name="org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver" level="OFF"/>
     <springProfile name="local">
@@ -16,14 +12,14 @@
 
     <springProfile name="stg">
         <root level="info">
-            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="JSON_CONSOLE"/>
         </root>
         <logger name="com.meetup.server" level="debug"/>
     </springProfile>
 
     <springProfile name="prod">
         <root level="info">
-            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="JSON_CONSOLE"/>
         </root>
     </springProfile>
 </configuration>


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

<img width="715" height="391" alt="스크린샷 2026-04-02 오후 8 35 40" src="https://github.com/user-attachments/assets/50e08e8c-93a0-41ae-8b4d-2bb25484a0fe" />

- 기존에는 로깅할 때 줄 마다 개행해서 찍었었는데, CloudWatch에서 로그가 위와 같이 전부 개행돼서 찍히는 문제 발생

## ✅ What - 무엇이 변경됐나요?

- 로그 포맷을 JSON으로 변경

## 🛠️ How - 어떻게 해결했나요?

- logstash-logback-encoder을 사용해 로그를 JSON으로 파싱

## 🖼️ Attachment

```json
{"@timestamp":"2026-04-02T20:27:35.159636+09:00","@version":"1","message":"[Request] Method=POST, Path=/events, QueryString=, Body={\n  \"eventName\": \"모임핑\",\n  \"eventDate\": \"2025-10-01\",\n  \"eventTime\": \"10:00:00\",\n  \"username\": \"땡수팟\",\n  \"startPoint\": \"선정릉역 수인분당선\",\n  \"address\": \"서울특별시 강남구 삼성동 111-114\",\n  \"roadAddress\": \"서울특별시 강남구 선릉로 지하580\",\n  \"longitude\": 127.043999,\n  \"latitude\": 37.510297,\n  \"isTransit\": true\n}","logger":"com.meetup.server.global.util.LoggingUtil","thread":"http-nio-8080-exec-10","level":"INFO","level_value":20000,"TRACE_ID":"15092969"}
{"@timestamp":"2026-04-02T20:27:35.159808+09:00","@version":"1","message":"[Response] StatusCode=200, Duration=184ms","logger":"com.meetup.server.global.util.LoggingUtil","thread":"http-nio-8080-exec-10","level":"INFO","level_value":20000,"TRACE_ID":"15092969"}

```

## 💬 기타 코멘트

- `리뷰어에게 전하고 싶은 말, 테스트 방법, 주의할 점 등`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로덕션 및 스테이징 환경에서 구조화된 JSON 형식의 로깅 지원 추가

* **개선사항**
  * 로그 메시지 형식 단순화로 더욱 간결한 로그 출력 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->