### PR TITLE
[MOISAM-267] 인기 기반 중간 지점을 제공한다

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -55,7 +55,9 @@ jobs:
           file: ./deploy/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -1,11 +1,12 @@
 package com.meetup.server.event.application;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.domain.value.MeetingPointRouteGroups;
 import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.request.UpdateEventRequest;
 import com.meetup.server.event.dto.request.UpdatePlaceRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
-import com.meetup.server.event.dto.response.route.MeetingPointResult;
+import com.meetup.server.event.dto.response.route.CategorizedMeetingPointResult;
 import com.meetup.server.event.dto.response.route.MeetingPointRouteGroup;
 import com.meetup.server.event.dto.response.route.MeetingPointRoutesResponse;
 import com.meetup.server.event.implement.EventLockManager;
@@ -30,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -56,46 +58,46 @@ public class EventService {
 
     @Performance
     public MeetingPointRoutesResponse getMeetingPointRoutes(UUID eventId, Long userId, UUID guestId) {
-        List<MeetingPointRouteGroup> meetingPointRouteGroups = getRouteGroups(eventId);
+        MeetingPointRouteGroups meetingPointRoutes = getRouteGroups(eventId);
 
         Event event = eventReader.read(eventId);
         List<StartPoint> startPoints = startPointReader.readAllWithUserByEvent(event);
 
-        for (MeetingPointRouteGroup group : meetingPointRouteGroups) {
-            routeProcessor.prioritizeMyRoute(userId, guestId, group.routeResponse());
-        }
+        Stream.of(meetingPointRoutes.byCoordinate(), meetingPointRoutes.byPopularity())
+                .forEach(group -> prioritizeRouteGroup(group, userId, guestId));
 
-        return MeetingPointRoutesResponse.of(event, startPoints, meetingPointRouteGroups);
+        return MeetingPointRoutesResponse.of(event, startPoints, meetingPointRoutes);
     }
 
-    private List<MeetingPointRouteGroup> getRouteGroups(UUID eventId) {
-        List<MeetingPointRouteGroup> meetingPointRouteGroupsCache = routeReader.readRouteGroups(eventId);
+    private MeetingPointRouteGroups getRouteGroups(UUID eventId) {
+        MeetingPointRouteGroups cachedRoutes = routeReader.readMeetingPointRoutes(eventId);
 
-        if (!meetingPointRouteGroupsCache.isEmpty()) {
-            return meetingPointRouteGroupsCache;
+        if (isCacheValid(cachedRoutes)) {
+            return cachedRoutes;
         }
 
         return calculateAndSaveRouteGroups(eventId);
     }
 
-    private List<MeetingPointRouteGroup> calculateAndSaveRouteGroups(UUID eventId) {
-        ReentrantLock reentrantLock = eventLockManager.getLock(eventId);
-
-        reentrantLock.lock();
+    private MeetingPointRouteGroups calculateAndSaveRouteGroups(UUID eventId) {
+        ReentrantLock lock = eventLockManager.getLock(eventId);
+        lock.lock();
         try {
-            List<MeetingPointRouteGroup> meetingPointRouteGroupsCache = routeReader.readRouteGroups(eventId);
-
-            if (!meetingPointRouteGroupsCache.isEmpty()) {
-                return meetingPointRouteGroupsCache;
+            MeetingPointRouteGroups cachedRoutes = routeReader.readMeetingPointRoutes(eventId);
+            if (isCacheValid(cachedRoutes)) {
+                return cachedRoutes;
             }
 
-            List<MeetingPointResult> meetingPointResults = meetingPointCalculator.calculate(eventId);
-            List<MeetingPointRouteGroup> meetingPointRouteGroups = routeProcessor.buildRouteGroups(meetingPointResults);
-            routeProcessor.saveRouteGroups(eventId, meetingPointRouteGroups);
+            CategorizedMeetingPointResult result = meetingPointCalculator.calculate(eventId);
+            MeetingPointRouteGroup coordinateRoute = routeProcessor.buildRouteGroup(result.byCoordinate());
+            MeetingPointRouteGroup popularRoute = routeProcessor.buildRouteGroup(result.byPopularity());
 
-            return meetingPointRouteGroups;
+            MeetingPointRouteGroups calculatedRoutes = MeetingPointRouteGroups.of(coordinateRoute, popularRoute);
+            routeProcessor.saveRouteGroups(eventId, calculatedRoutes);
+
+            return calculatedRoutes;
         } finally {
-            reentrantLock.unlock();
+            lock.unlock();
         }
     }
 
@@ -122,5 +124,15 @@ public class EventService {
     public void deletePlace(UUID eventId) {
         Event event = eventReader.read(eventId);
         event.deletePlace();
+    }
+
+    private void prioritizeRouteGroup(MeetingPointRouteGroup group, Long userId, UUID guestId) {
+        if (group != null) {
+            routeProcessor.prioritizeMyRoute(userId, guestId, group.routeResponse());
+        }
+    }
+
+    private boolean isCacheValid(MeetingPointRouteGroups groups) {
+        return groups != null && groups.byCoordinate() != null && groups.byPopularity() != null;
     }
 }

--- a/src/main/java/com/meetup/server/event/application/EventService.java
+++ b/src/main/java/com/meetup/server/event/application/EventService.java
@@ -9,6 +9,7 @@ import com.meetup.server.event.dto.response.EventStartPointResponse;
 import com.meetup.server.event.dto.response.route.CategorizedMeetingPointResult;
 import com.meetup.server.event.dto.response.route.MeetingPointRouteGroup;
 import com.meetup.server.event.dto.response.route.MeetingPointRoutesResponse;
+import com.meetup.server.event.dto.response.route.RouteResponse;
 import com.meetup.server.event.implement.EventLockManager;
 import com.meetup.server.event.implement.EventProcessor;
 import com.meetup.server.event.implement.EventReader;
@@ -28,10 +29,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -63,10 +64,12 @@ public class EventService {
         Event event = eventReader.read(eventId);
         List<StartPoint> startPoints = startPointReader.readAllWithUserByEvent(event);
 
-        Stream.of(meetingPointRoutes.byCoordinate(), meetingPointRoutes.byPopularity())
-                .forEach(group -> prioritizeRouteGroup(group, userId, guestId));
+        MeetingPointRouteGroups personalizedRoutes = MeetingPointRouteGroups.of(
+                copyAndPrioritize(meetingPointRoutes.byCoordinate(), userId, guestId),
+                copyAndPrioritize(meetingPointRoutes.byPopularity(), userId, guestId)
+        );
 
-        return MeetingPointRoutesResponse.of(event, startPoints, meetingPointRoutes);
+        return MeetingPointRoutesResponse.of(event, startPoints, personalizedRoutes);
     }
 
     private MeetingPointRouteGroups getRouteGroups(UUID eventId) {
@@ -126,10 +129,20 @@ public class EventService {
         event.deletePlace();
     }
 
-    private void prioritizeRouteGroup(MeetingPointRouteGroup group, Long userId, UUID guestId) {
-        if (group != null) {
-            routeProcessor.prioritizeMyRoute(userId, guestId, group.routeResponse());
+    private MeetingPointRouteGroup copyAndPrioritize(MeetingPointRouteGroup group, Long userId, UUID guestId) {
+        if (group == null) {
+            return null;
         }
+
+        List<RouteResponse> copiedRoutes = new ArrayList<>(group.routeResponse());
+        routeProcessor.prioritizeMyRoute(userId, guestId, copiedRoutes);
+        return MeetingPointRouteGroup.builder()
+                .subwayId(group.subwayId())
+                .averageTime(group.averageTime())
+                .meetingPoint(group.meetingPoint())
+                .routeResponse(copiedRoutes)
+                .parkingLot(group.parkingLot())
+                .build();
     }
 
     private boolean isCacheValid(MeetingPointRouteGroups groups) {

--- a/src/main/java/com/meetup/server/event/domain/value/MeetingPointRouteGroups.java
+++ b/src/main/java/com/meetup/server/event/domain/value/MeetingPointRouteGroups.java
@@ -1,27 +1,13 @@
 package com.meetup.server.event.domain.value;
 
 import com.meetup.server.event.dto.response.route.MeetingPointRouteGroup;
-import lombok.Builder;
 
-import java.util.List;
-
-@Builder
 public record MeetingPointRouteGroups(
-        List<MeetingPointRouteGroup> meetingPointRouteGroups
+        MeetingPointRouteGroup byCoordinate,
+        MeetingPointRouteGroup byPopularity
 ) {
 
-    public static MeetingPointRouteGroups from(List<MeetingPointRouteGroup> meetingPointRouteGroupList) {
-        List<MeetingPointRouteGroup> meetingPointRouteGroups = meetingPointRouteGroupList.stream()
-                .map(group -> new MeetingPointRouteGroup(
-                        group.subwayId(),
-                        group.averageTime(),
-                        group.meetingPoint(),
-                        group.routeResponse(),
-                        group.parkingLot()
-                ))
-                .toList();
-
-        return new MeetingPointRouteGroups(meetingPointRouteGroups);
+    public static MeetingPointRouteGroups of(MeetingPointRouteGroup byCoordinate, MeetingPointRouteGroup byPopularity) {
+        return new MeetingPointRouteGroups(byCoordinate, byPopularity);
     }
 }
-

--- a/src/main/java/com/meetup/server/event/dto/response/route/CategorizedMeetingPointResult.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/CategorizedMeetingPointResult.java
@@ -1,0 +1,13 @@
+package com.meetup.server.event.dto.response.route;
+
+public record CategorizedMeetingPointResult(
+        MeetingPointResult byCoordinate,
+        MeetingPointResult byPopularity
+) {
+    public static CategorizedMeetingPointResult of(
+            MeetingPointResult byCoordinate,
+            MeetingPointResult byPopularity
+    ) {
+        return new CategorizedMeetingPointResult(byCoordinate, byPopularity);
+    }
+}

--- a/src/main/java/com/meetup/server/event/dto/response/route/DrivingRouteResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/DrivingRouteResponse.java
@@ -24,13 +24,13 @@ public record DrivingRouteResponse(
                         )
                         .map(road -> {
                             double[] vertexes = road.vertexes();
-                            List<Coordinate> coordinateList = new ArrayList<>();
+                            List<Coordinate> coordinates = new ArrayList<>();
                             if (vertexes != null) {
                                 for (int i = 0; i < vertexes.length - 1; i += 2) {
-                                    coordinateList.add(Coordinate.of(vertexes[i], vertexes[i + 1]));
+                                    coordinates.add(Coordinate.of(vertexes[i], vertexes[i + 1]));
                                 }
                             }
-                            return new DrivingRouteResponse(road.name(), coordinateList);
+                            return new DrivingRouteResponse(road.name(), coordinates);
                         })
                         .toList()
                 )

--- a/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointResult.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointResult.java
@@ -20,5 +20,12 @@ public record MeetingPointResult(
                 .subway(subway)
                 .build();
     }
+
+    public boolean isSameSubway(Subway other) {
+        if (other == null || this.subway == null) {
+            return false;
+        }
+        return this.subway.getSubwayId().equals(other.getSubwayId());
+    }
 }
 

--- a/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointResult.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointResult.java
@@ -6,6 +6,7 @@ import com.meetup.server.subway.domain.Subway;
 import lombok.Builder;
 
 import java.util.List;
+import java.util.Objects;
 
 @Builder
 public record MeetingPointResult(
@@ -25,7 +26,7 @@ public record MeetingPointResult(
         if (other == null || this.subway == null) {
             return false;
         }
-        return this.subway.getSubwayId().equals(other.getSubwayId());
+        return Objects.equals(this.subway.getSubwayId(), other.getSubwayId());
     }
 }
 

--- a/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRouteGroup.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRouteGroup.java
@@ -26,8 +26,10 @@ public record MeetingPointRouteGroup(
     }
 
     private static int calculateAverageTime(List<RouteResponse> routeResponse) {
-        return routeResponse.stream()
+        return (int) routeResponse.stream()
                 .mapToInt(RouteResponse::getTotalTime)
-                .sum() / routeResponse.size();
+                .filter(time -> time > 0)
+                .average()
+                .orElse(0);
     }
 }

--- a/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRoutesResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/MeetingPointRoutesResponse.java
@@ -1,6 +1,7 @@
 package com.meetup.server.event.dto.response.route;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.domain.value.MeetingPointRouteGroups;
 import com.meetup.server.event.util.UsernameExtractor;
 import com.meetup.server.global.util.TimeUtil;
 import com.meetup.server.place.domain.Place;
@@ -19,10 +20,11 @@ public record MeetingPointRoutesResponse(
         String placeName,
         String placeImage,
         int peopleCount,
-        List<MeetingPointRouteGroup> meetingPointRouteGroups
+        MeetingPointRouteGroup coordinate,
+        MeetingPointRouteGroup popularity
 ) {
 
-    public static MeetingPointRoutesResponse of(Event event, List<StartPoint> startPoints, List<MeetingPointRouteGroup> meetingPointRouteGroups) {
+    public static MeetingPointRoutesResponse of(Event event, List<StartPoint> startPoints, MeetingPointRouteGroups meetingPointRouteGroups) {
         return new MeetingPointRoutesResponse(
                 event.getEventName(),
                 TimeUtil.formatAsDashDate(event.getEventDateTime()),
@@ -31,7 +33,8 @@ public record MeetingPointRoutesResponse(
                 extractPlaceName(event),
                 extractPlaceImage(event),
                 startPoints.size(),
-                meetingPointRouteGroups
+                meetingPointRouteGroups.byCoordinate(),
+                meetingPointRouteGroups.byPopularity()
         );
     }
 

--- a/src/main/java/com/meetup/server/event/dto/response/route/TransitRouteResponse.java
+++ b/src/main/java/com/meetup/server/event/dto/response/route/TransitRouteResponse.java
@@ -30,7 +30,7 @@ public record TransitRouteResponse(
         return Optional.ofNullable(response)
                 .map(OdsayTransitRouteSearchResponse::data)
                 .map(data -> Optional.ofNullable(data.path()).orElse(List.of()))
-                .filter(pathList -> !pathList.isEmpty())
+                .filter(paths -> !paths.isEmpty())
                 .map(List::getFirst)
                 .map(firstPath -> Optional.ofNullable(firstPath.subPath()).orElse(List.of()).stream()
                         .map(subPath -> {
@@ -66,11 +66,11 @@ public record TransitRouteResponse(
                 ).orElse(null);
     }
 
-    private static List<Stations> convertToDomainStations(List<OdsayTransitRouteSearchResponse.TransitData.Station> odsayStations) {
-        if (odsayStations == null || odsayStations.isEmpty()) {
+    private static List<Stations> convertToDomainStations(List<OdsayTransitRouteSearchResponse.TransitData.Station> stations) {
+        if (stations == null || stations.isEmpty()) {
             return List.of();
         }
-        return odsayStations.stream()
+        return stations.stream()
                 .map(station -> new Stations(
                         station.index(),
                         station.stationName(),

--- a/src/main/java/com/meetup/server/event/implement/route/MeetingPointCalculator.java
+++ b/src/main/java/com/meetup/server/event/implement/route/MeetingPointCalculator.java
@@ -1,6 +1,7 @@
 package com.meetup.server.event.implement.route;
 
 import com.meetup.server.event.domain.Event;
+import com.meetup.server.event.dto.response.route.CategorizedMeetingPointResult;
 import com.meetup.server.event.dto.response.route.MeetingPointResult;
 import com.meetup.server.event.exception.EventErrorType;
 import com.meetup.server.event.exception.EventException;
@@ -10,6 +11,7 @@ import com.meetup.server.global.util.CoordinateUtil;
 import com.meetup.server.startpoint.domain.StartPoint;
 import com.meetup.server.startpoint.implement.StartPointReader;
 import com.meetup.server.subway.domain.Subway;
+import com.meetup.server.subway.implement.processor.PopularityScorer;
 import com.meetup.server.subway.implement.processor.SubwayPathResult;
 import com.meetup.server.subway.implement.processor.SubwayProcessor;
 import com.meetup.server.subway.implement.reader.SubwayReader;
@@ -32,31 +34,46 @@ public class MeetingPointCalculator {
     private final SubwayProcessor subwayProcessor;
     private final SubwayReader subwayReader;
     private final EventValidator eventValidator;
+    private final PopularityScorer popularityScorer;
 
-    public List<MeetingPointResult> calculate(UUID eventId) {
+    public CategorizedMeetingPointResult calculate(UUID eventId) {
         Event event = eventReader.read(eventId);
         List<StartPoint> startPoints = startPointReader.readAllWithUserByEvent(event);
         eventValidator.validateMinimumStartPoints(startPoints);
 
-        Map<StartPoint, Subway> startPointToSubwayMap = subwayProcessor.mapStartPointsToClosestSubway(startPoints);
-        eventValidator.validateStartPointsNotAllSameSubway(startPointToSubwayMap);
+        Map<StartPoint, Subway> startPointsToSubway = subwayProcessor.mapStartPointsToClosestSubway(startPoints);
+        eventValidator.validateStartPointsNotAllSameSubway(startPointsToSubway);
 
         Point centerPoint = CoordinateUtil.calculateCenterPoint(startPoints.stream().map(StartPoint::getPoint).toList());
         List<Subway> nearbySubways = subwayReader.readNearbySubways(centerPoint);
         eventValidator.validateNearbySubwaysExist(nearbySubways);
 
-        Map<StartPoint, List<SubwayPathResult>> startPointToSubwayPathsMap = subwayProcessor.mapStartPointsToDestinationSubways(startPoints, startPointToSubwayMap, nearbySubways);
+        MeetingPointResult coordinateCandidate = calculateCoordinateCandidate(event, startPoints, startPointsToSubway, nearbySubways);
+        MeetingPointResult popularityCandidate = calculatePopularityCandidate(event, startPoints, centerPoint, coordinateCandidate, nearbySubways);
+        event.updateSubway(coordinateCandidate.subway());
 
-        List<Subway> topFairSubways = subwayProcessor.findTopFairSubways(startPointToSubwayPathsMap);
-        if (topFairSubways.isEmpty()) {
-            throw new EventException(EventErrorType.PATH_CALCULATION_FAILED);
-        }
+        return CategorizedMeetingPointResult.of(coordinateCandidate, popularityCandidate);
+    }
 
-        Subway firstSubway = topFairSubways.getFirst();
-        event.updateSubway(firstSubway);
+    private MeetingPointResult calculateCoordinateCandidate(Event event, List<StartPoint> startPoints, Map<StartPoint, Subway> startPointsToSubway, List<Subway> nearbySubways) {
+        Map<StartPoint, List<SubwayPathResult>> subwayPaths = subwayProcessor.mapStartPointsToDestinationSubways(startPoints, startPointsToSubway, nearbySubways);
+        Subway mostFairSubway = subwayProcessor.findTopFairSubway(subwayPaths)
+                .orElseThrow(() -> new EventException(EventErrorType.PATH_CALCULATION_FAILED));
 
-        return topFairSubways.stream()
-                .map(subway -> MeetingPointResult.of(event, startPoints, subway))
-                .toList();
+        return MeetingPointResult.of(event, startPoints, mostFairSubway);
+    }
+
+    private MeetingPointResult calculatePopularityCandidate(Event event, List<StartPoint> startPoints, Point centerPoint, MeetingPointResult coordinateCandidate, List<Subway> nearbySubways) {
+        List<Subway> popularCandidates = subwayReader.readSubwaysForPopularity(centerPoint);
+        List<Subway> topPopularCandidates = popularityScorer.scoreAndRank(popularCandidates, centerPoint);
+
+        Subway selectedSubway = topPopularCandidates.stream()
+                .filter(subway -> !coordinateCandidate.isSameSubway(subway))
+                .findFirst()
+                .or(() -> topPopularCandidates.stream().findFirst())
+                .or(() -> nearbySubways.stream().filter(subway -> !coordinateCandidate.isSameSubway(subway)).findFirst())
+                .orElse(coordinateCandidate.subway());
+
+        return MeetingPointResult.of(event, startPoints, selectedSubway);
     }
 }

--- a/src/main/java/com/meetup/server/event/implement/route/RouteProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/route/RouteProcessor.java
@@ -14,10 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -28,49 +25,28 @@ public class RouteProcessor {
     private final CachedRouteRepository cachedRouteRepository;
     private final EventProcessor eventProcessor;
 
-    public List<MeetingPointRouteGroup> buildRouteGroups(List<MeetingPointResult> meetingPointResults) {
-        List<CompletableFuture<MeetingPointRouteGroup>> routeGroupFutures = meetingPointResults.stream()
-                .map(meetingPointResult -> routeAssembler.assemble(meetingPointResult.startPoints(), meetingPointResult.subway()))
-                .toList();
-
-        CompletableFuture<Void> allCompletedFuture = CompletableFuture.allOf(routeGroupFutures.toArray(new CompletableFuture[0]));
+    public MeetingPointRouteGroup buildRouteGroup(MeetingPointResult meetingPointResult) {
         try {
-            List<MeetingPointRouteGroup> routeGroups = allCompletedFuture.thenApply(v -> routeGroupFutures.stream()
-                            .map(routeGroupFuture -> {
-                                try {
-                                    return routeGroupFuture.get();
-                                } catch (Exception e) {
-                                    log.warn("[RouteProcessor] Failed building MeetingPointRouteGroup", e);
-                                    return null;
-                                }
-                            })
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toList()))
-                    .get();
-
-            if (routeGroups == null || routeGroups.isEmpty()) {
-                throw new EventException(EventErrorType.ROUTE_FETCH_FAILED);
-            }
-            return routeGroups;
+            return routeAssembler.assemble(meetingPointResult.startPoints(), meetingPointResult.subway()).get();
         } catch (Exception e) {
+            log.warn("[RouteProcessor] Failed building MeetingPointRouteGroup", e);
             throw new EventException(EventErrorType.ROUTE_FETCH_FAILED);
         }
     }
 
-    public void saveRouteGroups(UUID eventId, List<MeetingPointRouteGroup> routeGroups) {
-        MeetingPointRouteGroups groupedRoutes = new MeetingPointRouteGroups(routeGroups);
+    public void saveRouteGroups(UUID eventId, MeetingPointRouteGroups groupedRoutes) {
         eventProcessor.saveRoute(eventId, groupedRoutes);
         cachedRouteRepository.save(eventId, groupedRoutes);
     }
 
-    public void prioritizeMyRoute(Long userId, UUID guestId, List<RouteResponse> routeList) {
-        routeList.forEach(route -> {
+    public void prioritizeMyRoute(Long userId, UUID guestId, List<RouteResponse> routes) {
+        routes.forEach(route -> {
             boolean isMine = (userId != null && userId.equals(route.getUserId()))
                     || (guestId != null && guestId.equals(route.getGuestId()));
             route.updateIsMe(isMine);
         });
 
-        routeList.sort(Comparator.comparing((RouteResponse route) -> route.getTotalTime() == 0)
+        routes.sort(Comparator.comparing((RouteResponse route) -> route.getTotalTime() == 0)
                 .thenComparing(RouteResponse::getIsMe, Comparator.reverseOrder())
         );
     }

--- a/src/main/java/com/meetup/server/event/implement/route/RouteProcessor.java
+++ b/src/main/java/com/meetup/server/event/implement/route/RouteProcessor.java
@@ -28,6 +28,9 @@ public class RouteProcessor {
     public MeetingPointRouteGroup buildRouteGroup(MeetingPointResult meetingPointResult) {
         try {
             return routeAssembler.assemble(meetingPointResult.startPoints(), meetingPointResult.subway()).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new EventException(EventErrorType.ROUTE_FETCH_FAILED);
         } catch (Exception e) {
             log.warn("[RouteProcessor] Failed building MeetingPointRouteGroup", e);
             throw new EventException(EventErrorType.ROUTE_FETCH_FAILED);

--- a/src/main/java/com/meetup/server/event/implement/route/RouteReader.java
+++ b/src/main/java/com/meetup/server/event/implement/route/RouteReader.java
@@ -2,14 +2,11 @@ package com.meetup.server.event.implement.route;
 
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.domain.value.MeetingPointRouteGroups;
-import com.meetup.server.event.dto.response.route.MeetingPointRouteGroup;
 import com.meetup.server.event.implement.EventReader;
 import com.meetup.server.event.infrastructure.redis.CachedRouteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,10 +17,9 @@ public class RouteReader {
     private final EventReader eventReader;
     private final CachedRouteRepository cachedRouteRepository;
 
-    public List<MeetingPointRouteGroup> readRouteGroups(UUID eventId) {
+    public MeetingPointRouteGroups readMeetingPointRoutes(UUID eventId) {
         return readByEventId(eventId)
-                .map(MeetingPointRouteGroups::meetingPointRouteGroups)
-                .orElse(Collections.emptyList());
+                .orElse(MeetingPointRouteGroups.of(null, null));
     }
 
     public Optional<MeetingPointRouteGroups> readByEventId(UUID eventId) {
@@ -38,9 +34,12 @@ public class RouteReader {
             return Optional.empty();
         }
 
-        MeetingPointRouteGroups meetingPointRouteGroups = MeetingPointRouteGroups.from(event.getRoutes().meetingPointRouteGroups());
-        cachedRouteRepository.save(eventId, meetingPointRouteGroups);
+        MeetingPointRouteGroups routes = MeetingPointRouteGroups.of(
+                event.getRoutes().byCoordinate(),
+                event.getRoutes().byPopularity()
+        );
+        cachedRouteRepository.save(eventId, routes);
 
-        return Optional.of(meetingPointRouteGroups);
+        return Optional.of(routes);
     }
 }

--- a/src/main/java/com/meetup/server/global/config/ConfigurationPropertiesConfig.java
+++ b/src/main/java/com/meetup/server/global/config/ConfigurationPropertiesConfig.java
@@ -8,10 +8,11 @@ import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityProperties;
 import com.meetup.server.global.clients.odsay.OdsayProperties;
 import com.meetup.server.global.clients.simplestorage.SimpleStorageProperties;
 import com.meetup.server.global.support.jwt.JwtProperties;
+import com.meetup.server.subway.infrastructure.api.SeoulSubwayProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(value = {JwtProperties.class, KakaoLocalProperties.class, OdsayProperties.class, KakaoMobilityProperties.class, GooglePlaceProperties.class, CookieProperties.class, ClovaProperties.class, SimpleStorageProperties.class})
+@EnableConfigurationProperties(value = {JwtProperties.class, KakaoLocalProperties.class, OdsayProperties.class, KakaoMobilityProperties.class, GooglePlaceProperties.class, CookieProperties.class, ClovaProperties.class, SimpleStorageProperties.class, SeoulSubwayProperties.class})
 public class ConfigurationPropertiesConfig {
 }

--- a/src/main/java/com/meetup/server/global/config/RestClientConfig.java
+++ b/src/main/java/com/meetup/server/global/config/RestClientConfig.java
@@ -4,6 +4,7 @@ import com.meetup.server.global.clients.clova.ClovaProperties;
 import com.meetup.server.global.clients.google.place.GooglePlaceProperties;
 import com.meetup.server.global.clients.kakao.local.KakaoLocalProperties;
 import com.meetup.server.global.clients.kakao.mobility.KakaoMobilityProperties;
+import com.meetup.server.subway.infrastructure.api.SeoulSubwayProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,11 +21,14 @@ public class RestClientConfig {
     private static final int ODSAY_READ_TIMEOUT = 2000;
     private static final int KAKAO_MOBILITY_CONNECT_TIMEOUT = 1500;
     private static final int KAKAO_MOBILITY_READ_TIMEOUT = 2000;
+    private static final int SEOUL_SUBWAY_CONNECT_TIMEOUT = 5000;
+    private static final int SEOUL_SUBWAY_READ_TIMEOUT = 5000;
 
     private final KakaoLocalProperties kakaoLocalProperties;
     private final KakaoMobilityProperties kakaoMobilityProperties;
     private final GooglePlaceProperties googlePlaceProperties;
     private final ClovaProperties clovaProperties;
+    private final SeoulSubwayProperties seoulSubwayProperties;
 
     @Bean
     public RestClient kakaoLocalRestClient() {
@@ -77,6 +81,18 @@ public class RestClientConfig {
                 .defaultHeader("Authorization", "Bearer " + clovaProperties.studioApiKey())
                 .defaultHeader("X-NCP-CLOVASTUDIO-REQUEST-ID", clovaProperties.requestId())
                 .baseUrl(clovaProperties.baseUrl())
+                .build();
+    }
+
+    @Bean
+    public RestClient seoulSubwayRestClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(SEOUL_SUBWAY_CONNECT_TIMEOUT);
+        requestFactory.setReadTimeout(SEOUL_SUBWAY_READ_TIMEOUT);
+
+        return RestClient.builder()
+                .requestFactory(requestFactory)
+                .baseUrl(seoulSubwayProperties.url())
                 .build();
     }
 }

--- a/src/main/java/com/meetup/server/global/util/CoordinateUtil.java
+++ b/src/main/java/com/meetup/server/global/util/CoordinateUtil.java
@@ -18,6 +18,19 @@ public class CoordinateUtil {
         return geometryFactory.createPoint(coordinate);
     }
 
+    public static double calculateDistanceInMeters(Point p1, Point p2) {
+        double lat1 = Math.toRadians(p1.getY());
+        double lat2 = Math.toRadians(p2.getY());
+        double dLat = Math.toRadians(p2.getY() - p1.getY());
+        double dLon = Math.toRadians(p2.getX() - p1.getX());
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return 6371000 * c;
+    }
+
     public static Point calculateCenterPoint(List<Point> points) {
         if (points == null || points.isEmpty()) {
             throw new IllegalArgumentException("중간 좌표를 계산할 좌표 리스트가 존재하지 않습니다.");

--- a/src/main/java/com/meetup/server/global/util/TimeUtil.java
+++ b/src/main/java/com/meetup/server/global/util/TimeUtil.java
@@ -3,6 +3,7 @@ package com.meetup.server.global.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -17,6 +18,8 @@ public class TimeUtil {
 
     private static final DateTimeFormatter YYYY_MM_DD_DASH_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
+    private static final DateTimeFormatter YYYY_MM_DD_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
     private static final DateTimeFormatter HH_MM_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     public static int calculateDaysAgo(LocalDateTime createdAt) {
@@ -30,8 +33,13 @@ public class TimeUtil {
     public static String formatAsDateTime(LocalDateTime dateTime) {
         return dateTime.format(YYYY_MM_DD_HH_MM_SS_FORMATTER);
     }
+
     public static String formatAsDashDate(LocalDateTime dateTime) {
         return dateTime.format(YYYY_MM_DD_DASH_FORMATTER);
+    }
+
+    public static String formatAsDate(LocalDate dateTime) {
+        return dateTime.format(YYYY_MM_DD_FORMATTER);
     }
 
     public static String formatAsTime(LocalDateTime dateTime) {

--- a/src/main/java/com/meetup/server/subway/domain/SubwayPassengerStats.java
+++ b/src/main/java/com/meetup/server/subway/domain/SubwayPassengerStats.java
@@ -1,0 +1,50 @@
+package com.meetup.server.subway.domain;
+
+import com.meetup.server.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "subway_passenger_stats", uniqueConstraints = @UniqueConstraint(columnNames = {"station_name", "line_name", "use_date"}))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SubwayPassengerStats extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stats_id")
+    private Long id;
+
+    @Column(name = "station_name", length = 30, nullable = false)
+    private String stationName;
+
+    @Column(name = "line_name", length = 20, nullable = false)
+    private String lineName;
+
+    @Column(name = "boarding_count", nullable = false)
+    private Long boardingCount;
+
+    @Column(name = "alighting_count", nullable = false)
+    private Long alightingCount;
+
+    @Column(name = "total_count", nullable = false)
+    private Long totalCount;
+
+    @Column(name = "use_date", nullable = false)
+    private LocalDate useDate;
+
+    @Builder
+    public SubwayPassengerStats(String stationName, String lineName, Long boardingCount, Long alightingCount, LocalDate useDate) {
+        this.stationName = stationName;
+        this.lineName = lineName;
+        this.boardingCount = boardingCount;
+        this.alightingCount = alightingCount;
+        this.totalCount = boardingCount + alightingCount;
+        this.useDate = useDate;
+    }
+}

--- a/src/main/java/com/meetup/server/subway/exception/SubwayErrorType.java
+++ b/src/main/java/com/meetup/server/subway/exception/SubwayErrorType.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum SubwayErrorType implements ErrorType {
-    SUBWAY_NOT_FOUND(HttpStatus.NOT_FOUND, "지하철역을 찾을 수 없습니다.");
+    SUBWAY_NOT_FOUND(HttpStatus.NOT_FOUND, "지하철역을 찾을 수 없습니다."),
+    SEOUL_API_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서울 Open API 데이터 조회에 실패했습니다."),
+    ;
 
     private final HttpStatus status;
 

--- a/src/main/java/com/meetup/server/subway/implement/batch/SubwayPassengerStatsBatchJob.java
+++ b/src/main/java/com/meetup/server/subway/implement/batch/SubwayPassengerStatsBatchJob.java
@@ -67,7 +67,7 @@ public class SubwayPassengerStatsBatchJob {
     }
 
     /**
-     * 보관 기간(7일) 이전 데이터 삭제
+     * 보관 기간(14일) 이전 데이터 삭제
      */
     private void cleanupOldData() {
         LocalDate cutoffDate = LocalDate.now().minusDays(DATA_RETENTION_DAYS);

--- a/src/main/java/com/meetup/server/subway/implement/batch/SubwayPassengerStatsBatchJob.java
+++ b/src/main/java/com/meetup/server/subway/implement/batch/SubwayPassengerStatsBatchJob.java
@@ -1,0 +1,77 @@
+package com.meetup.server.subway.implement.batch;
+
+import com.meetup.server.global.util.TimeUtil;
+import com.meetup.server.subway.domain.SubwayPassengerStats;
+import com.meetup.server.subway.infrastructure.api.SeoulOpenApiClient;
+import com.meetup.server.subway.infrastructure.api.dto.SeoulSubwayApiResponse;
+import com.meetup.server.subway.infrastructure.jpa.SubwayPassengerStatsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubwayPassengerStatsBatchJob {
+
+    private static final String EVERY_3AM = "0 0 3 * * *";
+    private static final int DATA_DELAY_DAYS = 5;
+    private static final int DATA_RETENTION_DAYS = 14;
+
+    private final SeoulOpenApiClient seoulOpenApiClient;
+    private final SubwayPassengerStatsRepository statsRepository;
+
+    /**
+     * 매일 새벽 3시에 실행
+     * 서울시 API는 3일 전 데이터를 갱신하므로, 5일 전 날짜 데이터를 수집
+     */
+    @Scheduled(cron = EVERY_3AM, zone = "Asia/Seoul")
+    @Transactional
+    public void collectDailyStats() {
+        LocalDate targetDate = LocalDate.now().minusDays(DATA_DELAY_DAYS);
+
+        if (statsRepository.existsByUseDate(targetDate)) {
+            log.info("[승하차 배치] 이미 수집된 날짜입니다: {}", targetDate);
+            return;
+        }
+
+        String useYmd = TimeUtil.formatAsDate(targetDate);
+        log.info("[승하차 배치] 수집 시작: {}", useYmd);
+
+        List<SeoulSubwayApiResponse.Row> rows = seoulOpenApiClient.fetchAllByDate(useYmd);
+
+        if (rows.isEmpty()) {
+            log.warn("[승하차 배치] 수집된 데이터가 없습니다: {}", useYmd);
+            return;
+        }
+
+        List<SubwayPassengerStats> stats = rows.stream()
+                .map(row -> SubwayPassengerStats.builder()
+                        .stationName(row.stationName())
+                        .lineName(row.lineName())
+                        .boardingCount(row.boardingCount())
+                        .alightingCount(row.alightingCount())
+                        .useDate(targetDate)
+                        .build())
+                .toList();
+
+        statsRepository.saveAll(stats);
+        log.info("[승하차 배치] 저장 완료: {}건", stats.size());
+
+        cleanupOldData();
+    }
+
+    /**
+     * 보관 기간(7일) 이전 데이터 삭제
+     */
+    private void cleanupOldData() {
+        LocalDate cutoffDate = LocalDate.now().minusDays(DATA_RETENTION_DAYS);
+        statsRepository.deleteByUseDateBefore(cutoffDate);
+        log.info("[승하차 배치] {} 이전 데이터 정리 완료", cutoffDate);
+    }
+}

--- a/src/main/java/com/meetup/server/subway/implement/processor/PopularityScorer.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/PopularityScorer.java
@@ -77,7 +77,7 @@ public class PopularityScorer {
                     double avgPassenger = averagePassengers.getOrDefault(stationName, 0.0);
                     double distance = distances.getOrDefault(subway.getSubwayId(), maxDistance);
 
-                    double normalizedPassenger = (avgPassenger - minPassenger) / passengerRange;
+                    double normalizedPassenger = Math.max(0, (avgPassenger - minPassenger) / passengerRange);
                     double normalizedDistance = (distance - minDistance) / distanceRange;
 
                     double score = POPULARITY_WEIGHT * normalizedPassenger + PROXIMITY_WEIGHT * (1 - normalizedDistance);

--- a/src/main/java/com/meetup/server/subway/implement/processor/PopularityScorer.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/PopularityScorer.java
@@ -1,0 +1,111 @@
+package com.meetup.server.subway.implement.processor;
+
+import com.meetup.server.global.util.CoordinateUtil;
+import com.meetup.server.subway.domain.Subway;
+import com.meetup.server.subway.infrastructure.jpa.SubwayPassengerStatsRepository;
+import com.meetup.server.subway.infrastructure.jpa.projection.SubwayAveragePassenger;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PopularityScorer {
+
+    private static final double POPULARITY_WEIGHT = 0.7;
+    private static final double PROXIMITY_WEIGHT = 0.3;
+    private static final int STATS_DAYS = 14;
+    private static final int MAX_POPULAR_COUNT = 3;
+
+    private final SubwayPassengerStatsRepository statsRepository;
+
+    /**
+     * 후보 역 리스트에서 인기별(승하차 인원 + 좌표 근접도) 상위 역들을 선정
+     *
+     * @param candidateSubways 후보 역 리스트 (centerPoint 주변 역들)
+     * @param centerPoint      중간 지점 좌표
+     * @return 인기 점수 상위 3개 역
+     */
+    public List<Subway> scoreAndRank(List<Subway> candidateSubways, Point centerPoint) {
+        if (candidateSubways == null || candidateSubways.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 1. 후보 역들의 역명 리스트 추출
+        List<String> stationNames = candidateSubways.stream()
+                .map(SubwayNameMapper::toApiStationName)
+                .distinct()
+                .toList();
+
+        // 2. DB에서 최근 평균 승하차 조회
+        LocalDate fromDate = LocalDate.now().minusDays(STATS_DAYS);
+        Map<String, Double> averagePassengers = fetchAveragePassengers(stationNames, fromDate);
+
+        if (averagePassengers.isEmpty()) {
+            log.warn("[인기별 스코어링] 승하차 데이터가 없습니다. 좌표 근접도만으로 정렬합니다.");
+            return candidateSubways.stream()
+                    .sorted(Comparator.comparingDouble(s -> CoordinateUtil.calculateDistanceInMeters(s.getPoint(), centerPoint)))
+                    .limit(MAX_POPULAR_COUNT)
+                    .toList();
+        }
+
+        // 3. 거리 계산
+        Map<Integer, Double> distances = candidateSubways.stream()
+                .collect(Collectors.toMap(
+                        Subway::getSubwayId,
+                        s -> CoordinateUtil.calculateDistanceInMeters(s.getPoint(), centerPoint)
+                ));
+
+        // 4. 복합 점수 계산 및 정렬
+        double maxPassenger = averagePassengers.values().stream().mapToDouble(d -> d).max().orElse(1);
+        double minPassenger = averagePassengers.values().stream().mapToDouble(d -> d).min().orElse(0);
+        double passengerRange = Math.max(maxPassenger - minPassenger, 1.0);
+
+        double maxDistance = distances.values().stream().mapToDouble(d -> d).max().orElse(1);
+        double minDistance = distances.values().stream().mapToDouble(d -> d).min().orElse(0);
+        double distanceRange = Math.max(maxDistance - minDistance, 1.0);
+
+        List<ScoredSubway> ranked = candidateSubways.stream()
+                .map(subway -> {
+                    String stationName = SubwayNameMapper.toApiStationName(subway);
+                    double avgPassenger = averagePassengers.getOrDefault(stationName, 0.0);
+                    double distance = distances.getOrDefault(subway.getSubwayId(), maxDistance);
+
+                    double normalizedPassenger = (avgPassenger - minPassenger) / passengerRange;
+                    double normalizedDistance = (distance - minDistance) / distanceRange;
+
+                    double score = POPULARITY_WEIGHT * normalizedPassenger + PROXIMITY_WEIGHT * (1 - normalizedDistance);
+
+                    return new ScoredSubway(subway, score);
+                })
+                .sorted(Comparator.comparingDouble(ScoredSubway::score).reversed())
+                .toList();
+
+        // 5. 동일 역명 중복 제거 후 상위 3개 반환
+        Set<String> selectedNames = new HashSet<>();
+        return ranked.stream()
+                .filter(scored -> selectedNames.add(scored.subway().getName()))
+                .limit(MAX_POPULAR_COUNT)
+                .map(ScoredSubway::subway)
+                .toList();
+    }
+
+    private Map<String, Double> fetchAveragePassengers(List<String> stationNames, LocalDate fromDate) {
+        List<SubwayAveragePassenger> averagePassengers = statsRepository.findAverageTotalByStationNames(stationNames, fromDate);
+        return averagePassengers.stream()
+                .collect(Collectors.toMap(
+                        SubwayAveragePassenger::getStationName,
+                        SubwayAveragePassenger::getAverageCount,
+                        (existing, replacement) -> existing
+                ));
+    }
+
+    private record ScoredSubway(Subway subway, double score) {
+    }
+}

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayNameMapper.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayNameMapper.java
@@ -17,11 +17,14 @@ public class SubwayNameMapper {
             return "";
         }
 
-        String withoutParentheses = PARENTHESES_PATTERN.matcher(name).replaceAll("");
-        return STATION_SUFFIX_PATTERN.matcher(withoutParentheses).replaceAll("").trim();
+        String withoutParentheses = PARENTHESES_PATTERN.matcher(name).replaceAll("").trim();
+        return STATION_SUFFIX_PATTERN.matcher(withoutParentheses).replaceAll("");
     }
 
     public static String toApiStationName(Subway subway) {
+        if (subway == null) {
+            return "";
+        }
         return normalizeStationName(subway.getName());
     }
 }

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayNameMapper.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayNameMapper.java
@@ -1,0 +1,27 @@
+package com.meetup.server.subway.implement.processor;
+
+import com.meetup.server.subway.domain.Subway;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.regex.Pattern;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SubwayNameMapper {
+
+    private static final Pattern PARENTHESES_PATTERN = Pattern.compile("\\(.*?\\)");
+    private static final Pattern STATION_SUFFIX_PATTERN = Pattern.compile("역$");
+
+    public static String normalizeStationName(String name) {
+        if (name == null) {
+            return "";
+        }
+
+        String withoutParentheses = PARENTHESES_PATTERN.matcher(name).replaceAll("");
+        return STATION_SUFFIX_PATTERN.matcher(withoutParentheses).replaceAll("").trim();
+    }
+
+    public static String toApiStationName(Subway subway) {
+        return normalizeStationName(subway.getName());
+    }
+}

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathProcessor.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathProcessor.java
@@ -28,11 +28,11 @@ public class SubwayPathProcessor {
     private final SubwayConnectionRepository subwayConnectionRepository;
     private final TransferInfoRepository transferInfoRepository;
 
-    private Map<Integer, Subway> subwayMap;
+    private Map<Integer, Subway> subways;
 
     // 인덱스 변환용 맵 및 배열
-    private Map<Integer, Integer> subwayIdToIndex;
-    private int[] indexToSubwayId;
+    private Map<Integer, Integer> subwayIndices;
+    private int[] subwayIds;
 
     // 플로이드-워셜 결과 저장 배열
     private int[][] shortestTime; // [출발][도착] = 최소 소요 시간
@@ -44,19 +44,19 @@ public class SubwayPathProcessor {
      */
     @PostConstruct
     public void init() {
-        this.subwayMap = subwayRepository.findAll()
+        this.subways = subwayRepository.findAll()
                 .stream()
                 .collect(Collectors.toMap(Subway::getSubwayId, Function.identity()));
 
         // 1. 역 ID를 연속된 배열 인덱스(0 ~ N-1)로 변환
-        List<Integer> subwayIds = new ArrayList<>(subwayMap.keySet());
-        Collections.sort(subwayIds);
-        int totalStationCount = subwayIds.size();
-        subwayIdToIndex = new HashMap<>();
-        indexToSubwayId = new int[totalStationCount];
+        List<Integer> sortedIds = new ArrayList<>(subways.keySet());
+        Collections.sort(sortedIds);
+        int totalStationCount = sortedIds.size();
+        subwayIndices = new HashMap<>();
+        subwayIds = new int[totalStationCount];
         for (int i = 0; i < totalStationCount; i++) {
-            subwayIdToIndex.put(subwayIds.get(i), i);
-            indexToSubwayId[i] = subwayIds.get(i);
+            subwayIndices.put(sortedIds.get(i), i);
+            subwayIds[i] = sortedIds.get(i);
         }
 
         // 2. 2차원 거리 행렬과 다음 노드 행렬을 초기화 (가장 큰 값인 UNREACHABLE_TIME, 경로는 -1 로 설정)
@@ -73,8 +73,8 @@ public class SubwayPathProcessor {
 
         // 3. 역과 역 사이의 소요 시간을 저장
         for (SubwayConnection connection : subwayConnectionRepository.findAllWithSubways()) {
-            Integer fromIdx = subwayIdToIndex.get(connection.getFromSubway().getSubwayId());
-            Integer toIdx = subwayIdToIndex.get(connection.getToSubway().getSubwayId());
+            Integer fromIdx = subwayIndices.get(connection.getFromSubway().getSubwayId());
+            Integer toIdx = subwayIndices.get(connection.getToSubway().getSubwayId());
             if (fromIdx == null || toIdx == null) continue;
 
             int time = connection.getSectionTimeSec();
@@ -86,8 +86,8 @@ public class SubwayPathProcessor {
 
         // 4. 환승역 간의 도보 이동 지연 시간(DEFAULT_TRANSFER_DELAY)을 저장
         for (TransferInfo transferInfo : transferInfoRepository.findAllWithSubways()) {
-            Integer fromIdx = subwayIdToIndex.get(transferInfo.getFromSubway().getSubwayId());
-            Integer toIdx = subwayIdToIndex.get(transferInfo.getToSubway().getSubwayId());
+            Integer fromIdx = subwayIndices.get(transferInfo.getFromSubway().getSubwayId());
+            Integer toIdx = subwayIndices.get(transferInfo.getToSubway().getSubwayId());
             if (fromIdx == null || toIdx == null) continue;
 
             if (DEFAULT_TRANSFER_DELAY < shortestTime[fromIdx][toIdx]) {
@@ -128,8 +128,8 @@ public class SubwayPathProcessor {
      * @return 최단 경로 결과 객체 (경로가 끊긴 곳이라면 null을 반환)
      */
     public SubwayPathResult findShortestPath(int startSubwayId, int endSubwayId) {
-        Integer startIdx = subwayIdToIndex.get(startSubwayId);
-        Integer endIdx = subwayIdToIndex.get(endSubwayId);
+        Integer startIdx = subwayIndices.get(startSubwayId);
+        Integer endIdx = subwayIndices.get(endSubwayId);
 
         if (startIdx == null || endIdx == null || nextNode[startIdx][endIdx] == -1) {
             log.warn("[유효하지 않은 경로 데이터] 출발역ID={} → 도착역ID={}", startSubwayId, endSubwayId);
@@ -142,7 +142,7 @@ public class SubwayPathProcessor {
         int current = startIdx;
 
         while (current != endIdx) {
-            path.add(indexToSubwayId[current]);
+            path.add(subwayIds[current]);
             current = nextNode[current][endIdx];
 
             if (current == -1) {
@@ -150,12 +150,12 @@ public class SubwayPathProcessor {
                 return null;
             }
         }
-        path.add(indexToSubwayId[endIdx]);
+        path.add(subwayIds[endIdx]);
 
-        List<String> pathNames = path.stream()
-                .map(id -> subwayMap.get(id).getName())
+        List<String> stationNames = path.stream()
+                .map(id -> subways.get(id).getName())
                 .toList();
 
-        return new SubwayPathResult(totalTime, path, pathNames);
+        return new SubwayPathResult(totalTime, path, stationNames);
     }
 }

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathResult.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayPathResult.java
@@ -5,6 +5,6 @@ import java.util.List;
 public record SubwayPathResult(
         int totalTime,
         List<Integer> path,
-        List<String> pathNames
+        List<String> stationNames
 ) {
 }

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayProcessor.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayProcessor.java
@@ -44,9 +44,14 @@ public class SubwayProcessor {
     }
 
     private Optional<Integer> findOptimalSubwayId(Map<Integer, List<Integer>> destinationSubwayTimes) {
+        Comparator<Map.Entry<Integer, List<Integer>>> comparator =
+                Comparator.<Map.Entry<Integer, List<Integer>>>comparingInt(entry -> entry.getValue().size())
+                        .reversed()
+                        .thenComparingDouble(entry -> calculateFairnessScore(entry.getValue()));
+
         Optional<Integer> bestSubwayId = destinationSubwayTimes.entrySet().stream()
                 .filter(entry -> entry.getValue().size() >= MINIMUM_PEOPLE_REQUIRED)
-                .min(Comparator.comparingDouble(entry -> calculateFairnessScore(entry.getValue())))
+                .min(comparator)
                 .map(Map.Entry::getKey);
 
         if (bestSubwayId.isPresent()) {
@@ -54,7 +59,7 @@ public class SubwayProcessor {
         }
 
         return destinationSubwayTimes.entrySet().stream()
-                .min(Comparator.comparingDouble(entry -> calculateFairnessScore(entry.getValue())))
+                .min(comparator)
                 .map(Map.Entry::getKey);
     }
 

--- a/src/main/java/com/meetup/server/subway/implement/processor/SubwayProcessor.java
+++ b/src/main/java/com/meetup/server/subway/implement/processor/SubwayProcessor.java
@@ -17,61 +17,45 @@ import java.util.stream.Collectors;
 public class SubwayProcessor {
 
     private static final int MINIMUM_PEOPLE_REQUIRED = 2;
-    private static final int MAX_SUBWAY_COUNT = 3;
     private static final double FAIRNESS_WEIGHT = 0.6;
     private static final double EFFICIENCY_WEIGHT = 0.4;
 
     private final SubwayReader subwayReader;
     private final SubwayPathProcessor subwayPathProcessor;
 
-    public List<Subway> findTopFairSubways(Map<StartPoint, List<SubwayPathResult>> startPointToSubwayPaths) {
-        Map<Integer, List<Integer>> destinationSubwayTimeMap = new HashMap<>();
+    public Optional<Subway> findTopFairSubway(Map<StartPoint, List<SubwayPathResult>> subwayPaths) {
+        Map<Integer, List<Integer>> destinationSubwayTimes = new HashMap<>();
 
-        startPointToSubwayPaths.forEach((startPoint, subwayPaths) ->
-                subwayPaths.forEach(subwayPath -> {
+        subwayPaths.forEach((startPoint, paths) ->
+                paths.forEach(subwayPath -> {
                     int destinationId = subwayPath.path().getLast();
-                    destinationSubwayTimeMap
+                    destinationSubwayTimes
                             .computeIfAbsent(destinationId, k -> new ArrayList<>())
                             .add(subwayPath.totalTime());
                 })
         );
 
-        List<Subway> allSubways = subwayReader.readAllOrderByIds(new ArrayList<>(destinationSubwayTimeMap.keySet()));
-        Map<Integer, String> subwayNames = allSubways.stream()
-                .collect(Collectors.toMap(Subway::getSubwayId, Subway::getName));
+        if (destinationSubwayTimes.isEmpty()) {
+            return Optional.empty();
+        }
 
-        Set<String> selectedNames = new HashSet<>();
-        List<Integer> result = destinationSubwayTimeMap.entrySet().stream()
+        return findOptimalSubwayId(destinationSubwayTimes)
+                .map(subwayReader::read);
+    }
+
+    private Optional<Integer> findOptimalSubwayId(Map<Integer, List<Integer>> destinationSubwayTimes) {
+        Optional<Integer> bestSubwayId = destinationSubwayTimes.entrySet().stream()
                 .filter(entry -> entry.getValue().size() >= MINIMUM_PEOPLE_REQUIRED)
-                .sorted(Comparator.comparingDouble(entry -> calculateFairnessScore(entry.getValue())))
-                .filter(entry -> selectedNames.add(subwayNames.get(entry.getKey())))
-                .limit(MAX_SUBWAY_COUNT)
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                .min(Comparator.comparingDouble(entry -> calculateFairnessScore(entry.getValue())))
+                .map(Map.Entry::getKey);
 
-        if (result.size() < MAX_SUBWAY_COUNT && !destinationSubwayTimeMap.isEmpty()) {
-            int needCount = MAX_SUBWAY_COUNT - result.size();
-            log.debug("[후보역 추가] 부족한 {}개 역 추가", needCount);
-
-            List<Integer> additionalCandidates = destinationSubwayTimeMap.entrySet().stream()
-                    .filter(entry -> entry.getValue().size() < MINIMUM_PEOPLE_REQUIRED)
-                    .sorted(Comparator.comparingDouble(entry -> calculateFairnessScore(entry.getValue())))
-                    .filter(entry -> selectedNames.add(subwayNames.get(entry.getKey())))
-                    .limit(needCount)
-                    .map(Map.Entry::getKey)
-                    .toList();
-
-            result.addAll(additionalCandidates);
+        if (bestSubwayId.isPresent()) {
+            return bestSubwayId;
         }
 
-        if (result.isEmpty()) {
-            log.warn("[후보역 없음] 지하철로 도달 가능한 중간지점을 찾을 수 없습니다. | 전체 후보역ID={}",
-                    destinationSubwayTimeMap.keySet());
-            return Collections.emptyList();
-        } else {
-            log.debug("[중간지점 확정] 최종 후보역 목록 생성 완료 | 후보군: {}", result);
-            return subwayReader.readAllOrderByIds(result);
-        }
+        return destinationSubwayTimes.entrySet().stream()
+                .min(Comparator.comparingDouble(entry -> calculateFairnessScore(entry.getValue())))
+                .map(Map.Entry::getKey);
     }
 
     /**
@@ -106,7 +90,7 @@ public class SubwayProcessor {
 
     public Map<StartPoint, List<SubwayPathResult>> mapStartPointsToDestinationSubways(
             List<StartPoint> startPoints,
-            Map<StartPoint, Subway> startPointsToClosestSubway,
+            Map<StartPoint, Subway> closestSubways,
             List<Subway> destinationSubways
     ) {
         return startPoints.stream()
@@ -115,7 +99,7 @@ public class SubwayProcessor {
                         startPoint -> destinationSubways.stream()
                                 .map(destinationSubway ->
                                         subwayPathProcessor.findShortestPath(
-                                                startPointsToClosestSubway.get(startPoint).getSubwayId(),
+                                                closestSubways.get(startPoint).getSubwayId(),
                                                 destinationSubway.getSubwayId())
                                 )
                                 .filter(Objects::nonNull)

--- a/src/main/java/com/meetup/server/subway/implement/reader/SubwayReader.java
+++ b/src/main/java/com/meetup/server/subway/implement/reader/SubwayReader.java
@@ -9,25 +9,24 @@ import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class SubwayReader {
 
-    private static final double NEAREST_SUBWAY_RADIUS_M = 1500;
+    private static final double NEARBY_SUBWAY_RADIUS_M = 1500;
+    private static final double POPULARITY_RADIUS_M = 4000;
     private static final double MAX_SEARCH_RADIUS_M = 10000;
     private static final double RADIUS_INCREMENT_M = 500;
-    private static final int MIN_CANDIDATE_COUNT = 5;
+    private static final int MIN_NEARBY_COUNT = 5;
+    private static final int MIN_POPULARITY_COUNT = 15;
 
     private final SubwayRepository subwayRepository;
 
     public Subway read(int subwayId) {
         return subwayRepository.findById(subwayId).orElseThrow(() -> new SubwayException(SubwayErrorType.SUBWAY_NOT_FOUND));
-    }
-
-    public List<Subway> readAllOrderByIds(List<Integer> subwayIds) {
-        return subwayRepository.findAllBySubwayIdInOrderByIds(subwayIds.toArray(new Integer[0]));
     }
 
     public Subway readClosestSubway(Point startPoint) {
@@ -39,20 +38,21 @@ public class SubwayReader {
     }
 
     public List<Subway> readNearbySubways(Point centerPoint) {
-        double radius = NEAREST_SUBWAY_RADIUS_M;
+        return expandUntilMinCount(centerPoint, NEARBY_SUBWAY_RADIUS_M, MIN_NEARBY_COUNT);
+    }
 
-        List<Subway> nearbySubways = new ArrayList<>();
+    public List<Subway> readSubwaysForPopularity(Point centerPoint) {
+        return expandUntilMinCount(centerPoint, POPULARITY_RADIUS_M, MIN_POPULARITY_COUNT);
+    }
 
+    private List<Subway> expandUntilMinCount(Point centerPoint, double initialRadius, int minCount) {
+        double radius = initialRadius;
+        List<Subway> subways = new ArrayList<>();
         while (radius <= MAX_SEARCH_RADIUS_M) {
-            nearbySubways = readAllWithinRadius(centerPoint, radius);
-
-            if (nearbySubways.size() >= MIN_CANDIDATE_COUNT) {
-                break;
-            }
-
+            subways = readAllWithinRadius(centerPoint, radius);
+            if (subways.size() >= minCount) break;
             radius += RADIUS_INCREMENT_M;
         }
-
-        return nearbySubways;
+        return subways;
     }
 }

--- a/src/main/java/com/meetup/server/subway/infrastructure/api/SeoulOpenApiClient.java
+++ b/src/main/java/com/meetup/server/subway/infrastructure/api/SeoulOpenApiClient.java
@@ -1,0 +1,87 @@
+package com.meetup.server.subway.infrastructure.api;
+
+import com.meetup.server.subway.infrastructure.api.dto.SeoulSubwayApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Component
+public class SeoulOpenApiClient {
+
+    private static final String API_URL_TEMPLATE = "/%s/json/CardSubwayStatsNew/%d/%d/%s";
+    private static final int PAGE_SIZE = 1000;
+
+    private final RestClient seoulSubwayRestClient;
+    private final SeoulSubwayProperties seoulSubwayProperties;
+
+    public SeoulOpenApiClient(
+            RestClient seoulSubwayRestClient,
+            SeoulSubwayProperties seoulSubwayProperties
+    ) {
+        this.seoulSubwayRestClient = seoulSubwayRestClient;
+        this.seoulSubwayProperties = seoulSubwayProperties;
+    }
+
+    /**
+     * 특정 날짜의 전체 지하철 승하차 데이터를 페이징하여 조회
+     *
+     * @param useYmd 조회 날짜 (yyyyMMdd)
+     * @return 전체 Row 리스트
+     */
+    public List<SeoulSubwayApiResponse.Row> fetchAllByDate(String useYmd) {
+        if (seoulSubwayProperties.key() == null || seoulSubwayProperties.key().isBlank()) {
+            log.warn("[서울 Open API] API 키가 설정되지 않았습니다. seoul.open-api.key를 확인하세요.");
+            return Collections.emptyList();
+        }
+
+        List<SeoulSubwayApiResponse.Row> allRows = new ArrayList<>();
+        int startIndex = 1;
+
+        while (true) {
+            int endIndex = startIndex + PAGE_SIZE - 1;
+            String url = String.format(API_URL_TEMPLATE, seoulSubwayProperties.key(), startIndex, endIndex, useYmd);
+
+            try {
+                SeoulSubwayApiResponse response = seoulSubwayRestClient.get()
+                        .uri(url)
+                        .retrieve()
+                        .body(SeoulSubwayApiResponse.class);
+
+                if (response == null || response.cardSubwayStatsNew() == null) {
+                    log.warn("[서울 Open API] 응답이 null입니다. useYmd={}, startIndex={}", useYmd, startIndex);
+                    break;
+                }
+
+                SeoulSubwayApiResponse.CardSubwayStatsNew data = response.cardSubwayStatsNew();
+
+                if (!"INFO-000".equals(data.result().code())) {
+                    log.warn("[서울 Open API] 에러 응답: code={}, message={}", data.result().code(), data.result().message());
+                    break;
+                }
+
+                if (data.row() == null || data.row().isEmpty()) {
+                    break;
+                }
+
+                allRows.addAll(data.row());
+
+                if (allRows.size() >= data.listTotalCount()) {
+                    break;
+                }
+
+                startIndex += PAGE_SIZE;
+            } catch (Exception e) {
+                log.error("[서울 Open API] 호출 실패: useYmd={}, startIndex={}", useYmd, startIndex, e);
+                break;
+            }
+        }
+
+        log.info("[서울 Open API] 조회 완료: useYmd={}, 총 {}건", useYmd, allRows.size());
+        return allRows;
+    }
+}

--- a/src/main/java/com/meetup/server/subway/infrastructure/api/SeoulOpenApiClient.java
+++ b/src/main/java/com/meetup/server/subway/infrastructure/api/SeoulOpenApiClient.java
@@ -1,5 +1,7 @@
 package com.meetup.server.subway.infrastructure.api;
 
+import com.meetup.server.subway.exception.SubwayErrorType;
+import com.meetup.server.subway.exception.SubwayException;
 import com.meetup.server.subway.infrastructure.api.dto.SeoulSubwayApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -53,15 +55,20 @@ public class SeoulOpenApiClient {
                         .body(SeoulSubwayApiResponse.class);
 
                 if (response == null || response.cardSubwayStatsNew() == null) {
-                    log.warn("[서울 Open API] 응답이 null입니다. useYmd={}, startIndex={}", useYmd, startIndex);
-                    break;
+                    log.error("[서울 Open API] 응답이 null입니다. useYmd={}, startIndex={}", useYmd, startIndex);
+                    throw new SubwayException(SubwayErrorType.SEOUL_API_FETCH_FAILED);
                 }
 
                 SeoulSubwayApiResponse.CardSubwayStatsNew data = response.cardSubwayStatsNew();
 
+                if (data.result() == null) {
+                    log.error("[서울 Open API] result가 null입니다. useYmd={}, startIndex={}", useYmd, startIndex);
+                    throw new SubwayException(SubwayErrorType.SEOUL_API_FETCH_FAILED);
+                }
+
                 if (!"INFO-000".equals(data.result().code())) {
-                    log.warn("[서울 Open API] 에러 응답: code={}, message={}", data.result().code(), data.result().message());
-                    break;
+                    log.error("[서울 Open API] 에러 응답: code={}, message={}", data.result().code(), data.result().message());
+                    throw new SubwayException(SubwayErrorType.SEOUL_API_FETCH_FAILED);
                 }
 
                 if (data.row() == null || data.row().isEmpty()) {
@@ -75,9 +82,11 @@ public class SeoulOpenApiClient {
                 }
 
                 startIndex += PAGE_SIZE;
+            } catch (SubwayException e) {
+                throw e;
             } catch (Exception e) {
                 log.error("[서울 Open API] 호출 실패: useYmd={}, startIndex={}", useYmd, startIndex, e);
-                break;
+                throw new SubwayException(SubwayErrorType.SEOUL_API_FETCH_FAILED);
             }
         }
 

--- a/src/main/java/com/meetup/server/subway/infrastructure/api/SeoulSubwayProperties.java
+++ b/src/main/java/com/meetup/server/subway/infrastructure/api/SeoulSubwayProperties.java
@@ -1,0 +1,10 @@
+package com.meetup.server.subway.infrastructure.api;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "seoul.open-api")
+public record SeoulSubwayProperties(
+        String key,
+        String url
+) {
+}

--- a/src/main/java/com/meetup/server/subway/infrastructure/api/dto/SeoulSubwayApiResponse.java
+++ b/src/main/java/com/meetup/server/subway/infrastructure/api/dto/SeoulSubwayApiResponse.java
@@ -1,0 +1,32 @@
+package com.meetup.server.subway.infrastructure.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record SeoulSubwayApiResponse(
+        @JsonProperty("CardSubwayStatsNew") CardSubwayStatsNew cardSubwayStatsNew
+) {
+
+    public record CardSubwayStatsNew(
+            @JsonProperty("list_total_count") int listTotalCount,
+            @JsonProperty("RESULT") Result result,
+            @JsonProperty("row") List<Row> row
+    ) {
+    }
+
+    public record Result(
+            @JsonProperty("CODE") String code,
+            @JsonProperty("MESSAGE") String message
+    ) {
+    }
+
+    public record Row(
+            @JsonProperty("USE_YMD") String useYmd,
+            @JsonProperty("SBWY_ROUT_LN_NM") String lineName,
+            @JsonProperty("SBWY_STNS_NM") String stationName,
+            @JsonProperty("GTON_TNOPE") long boardingCount,
+            @JsonProperty("GTOFF_TNOPE") long alightingCount
+    ) {
+    }
+}

--- a/src/main/java/com/meetup/server/subway/infrastructure/jpa/SubwayPassengerStatsRepository.java
+++ b/src/main/java/com/meetup/server/subway/infrastructure/jpa/SubwayPassengerStatsRepository.java
@@ -1,0 +1,32 @@
+package com.meetup.server.subway.infrastructure.jpa;
+
+import com.meetup.server.subway.domain.SubwayPassengerStats;
+import com.meetup.server.subway.infrastructure.jpa.projection.SubwayAveragePassenger;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SubwayPassengerStatsRepository extends JpaRepository<SubwayPassengerStats, Long> {
+
+    @Query("""
+            SELECT s.stationName as stationName, AVG(s.totalCount) as averageCount
+            FROM SubwayPassengerStats s
+            WHERE s.stationName IN :stationNames
+              AND s.useDate >= :fromDate
+            GROUP BY s.stationName
+    """)
+    List<SubwayAveragePassenger> findAverageTotalByStationNames(
+            @Param("stationNames") List<String> stationNames,
+            @Param("fromDate") LocalDate fromDate
+    );
+
+    boolean existsByUseDate(LocalDate useDate);
+
+    @Modifying
+    @Query("DELETE FROM SubwayPassengerStats s WHERE s.useDate < :cutoffDate")
+    void deleteByUseDateBefore(@Param("cutoffDate") LocalDate cutoffDate);
+}

--- a/src/main/java/com/meetup/server/subway/infrastructure/jpa/projection/SubwayAveragePassenger.java
+++ b/src/main/java/com/meetup/server/subway/infrastructure/jpa/projection/SubwayAveragePassenger.java
@@ -1,0 +1,6 @@
+package com.meetup.server.subway.infrastructure.jpa.projection;
+
+public interface SubwayAveragePassenger {
+    String getStationName();
+    Double getAverageCount();
+}

--- a/src/main/resources/templates/admin/events.html
+++ b/src/main/resources/templates/admin/events.html
@@ -494,7 +494,7 @@
                     <td th:text="${event.eventId}" style="font-family: monospace; font-size: 12px; color: #6c757d;">ID
                     </td>
                     <td>
-                        <a th:href="@{|${clientUrl}/mapview/${event.eventId}|}" class="event-link"
+                        <a th:href="@{|${clientUrl}/mapView/${event.eventId}|}" class="event-link"
                            th:text="${event.eventName}">모임명</a>
                         <div style="font-size: 12px; color: var(--text-muted); margin-top: 4px;">
                             <span th:text="${#temporals.format(event.createdDateTime, 'yyyy-MM-dd HH:mm')}">생성일</span>

--- a/src/test/java/com/meetup/server/event/implement/route/RouteProcessorTest.java
+++ b/src/test/java/com/meetup/server/event/implement/route/RouteProcessorTest.java
@@ -102,14 +102,14 @@ class RouteProcessorTest extends IntegrationTestContainer {
                 drivingStartPoints.stream().limit(drivingSize)
         ).toList();
 
-        MeetingPointResult meetingPointResult1 = MeetingPointResult.of(event, testStartPoints, subway);
-        MeetingPointResult meetingPointResult2 = MeetingPointResult.of(event, testStartPoints, subway);
-        MeetingPointResult meetingPointResult3 = MeetingPointResult.of(event, testStartPoints, subway);
-        List<MeetingPointResult> meetingPointResults = List.of(meetingPointResult1, meetingPointResult2, meetingPointResult3);
+        MeetingPointResult coordinateResult = MeetingPointResult.of(event, testStartPoints, subway);
+        MeetingPointResult popularResult = MeetingPointResult.of(event, testStartPoints, subway);
 
         long startTime = System.nanoTime();
-        routeProcessor.buildRouteGroups(meetingPointResults);
+        routeProcessor.buildRouteGroup(coordinateResult);
+        routeProcessor.buildRouteGroup(popularResult);
         long endTime = System.nanoTime();
-        System.out.printf("출발지 개수: %d → 소요 시간: %d ms%n", size, (endTime - startTime) / 1_000_000);
+        
+        System.out.printf("출발지 개수: %d → (좌표+인기 2건 순차적) 소요 시간: %d ms%n", size, (endTime - startTime) / 1_000_000);
     }
 }

--- a/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
+++ b/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
@@ -6,11 +6,11 @@ import com.epages.restdocs.apispec.Schema;
 import com.meetup.server.event.application.EventService;
 import com.meetup.server.event.domain.Event;
 import com.meetup.server.event.domain.type.TrafficType;
+import com.meetup.server.event.domain.value.MeetingPointRouteGroups;
 import com.meetup.server.event.dto.request.EventRequest;
 import com.meetup.server.event.dto.request.UpdateEventRequest;
 import com.meetup.server.event.dto.request.UpdatePlaceRequest;
 import com.meetup.server.event.dto.response.EventStartPointResponse;
-import com.meetup.server.event.dto.response.route.MeetingPointRouteGroup;
 import com.meetup.server.event.dto.response.route.MeetingPointRoutesResponse;
 import com.meetup.server.fixture.EventFixture;
 import com.meetup.server.fixture.StartPointFixture;
@@ -221,7 +221,7 @@ class EventControllerTest extends ControllerTestSupport {
 
         Event event = EventFixture.getEventWithRoute();
         StartPoint startPoint = StartPointFixture.getStartPoint(event, null);
-        List<MeetingPointRouteGroup> meetingPointRouteGroups = event.getRoutes().meetingPointRouteGroups();
+        MeetingPointRouteGroups meetingPointRouteGroups = event.getRoutes();
         MeetingPointRoutesResponse response = MeetingPointRoutesResponse.of(event, List.of(startPoint), meetingPointRouteGroups);
 
         // when
@@ -244,49 +244,49 @@ class EventControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data.placeName").value("놀숲 건대점"))
                 .andExpect(jsonPath("$.data.placeImage").value("https://example.com/place-image.jpg"))
                 .andExpect(jsonPath("$.data.peopleCount").value(1))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].subwayId").value(240))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].averageTime").value(0))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].meetingPoint.endStationName").value("논현"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].meetingPoint.endLongitude").value(127.021385))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].meetingPoint.endLatitude").value(37.511108))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse").isArray())
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].isTransit").value(true))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].isMe").value(false))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].id").value("0198c64a-5a06-7095-a692-3c5e1a2c294f"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].nickname").value("김아무개"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].startName").value("강남구 삼성동"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].startLongitude").value(127.043999))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].startLatitude").value(37.510297))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].totalTime").value(10))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].trafficType").value(TrafficType.SUBWAY.name()))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].startExitNo").value("3"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].endExitNo").value("5"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].distance").value(3500.0))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].laneName").value("2"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].startBoardName").value("강남"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].endBoardName").value("교대"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].stationCount").value(2))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].sectionTime").value(10))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations").isArray())
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations[0].index").value(0))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations[0].stationName").value("강남"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations[0].x").value("127.027636"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[0].transitRoute[0].passStopList.stations[0].y").value("37.497985"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].isTransit").value(false))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingInfo.taxi").value(10000))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingInfo.toll").value(3500))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingInfo.duration").value(30))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingInfo.distance").value(15500))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].name").value("테헤란로/강남대로"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates").isArray())
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates[0].x").value("127.043999"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates[0].y").value("37.510297"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates[2].x").value("127.021385"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].routeResponse[1].drivingRoute[0].coordinates[2].y").value("37.511108"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].parkingLot.name").value("강남대로150길(구)"))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].parkingLot.longitude").value(127.0201132))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].parkingLot.latitude").value(37.5156578))
-                .andExpect(jsonPath("$.data.meetingPointRouteGroups[0].parkingLot.distance").value(517.33672526))
+                .andExpect(jsonPath("$.data.coordinate.subwayId").value(240))
+                .andExpect(jsonPath("$.data.coordinate.averageTime").value(0))
+                .andExpect(jsonPath("$.data.coordinate.meetingPoint.endStationName").value("논현"))
+                .andExpect(jsonPath("$.data.coordinate.meetingPoint.endLongitude").value(127.021385))
+                .andExpect(jsonPath("$.data.coordinate.meetingPoint.endLatitude").value(37.511108))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse").isArray())
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].isTransit").value(true))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].isMe").value(false))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].id").value("0198c64a-5a06-7095-a692-3c5e1a2c294f"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].nickname").value("김아무개"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].startName").value("강남구 삼성동"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].startLongitude").value(127.043999))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].startLatitude").value(37.510297))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].totalTime").value(10))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].trafficType").value(TrafficType.SUBWAY.name()))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].startExitNo").value("3"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].endExitNo").value("5"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].distance").value(3500.0))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].laneName").value("2"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].startBoardName").value("강남"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].endBoardName").value("교대"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].stationCount").value(2))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].sectionTime").value(10))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].passStopList.stations").isArray())
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].passStopList.stations[0].index").value(0))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].passStopList.stations[0].stationName").value("강남"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].passStopList.stations[0].x").value("127.027636"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[0].transitRoute[0].passStopList.stations[0].y").value("37.497985"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].isTransit").value(false))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingInfo.taxi").value(10000))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingInfo.toll").value(3500))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingInfo.duration").value(30))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingInfo.distance").value(15500))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingRoute[0].name").value("테헤란로/강남대로"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingRoute[0].coordinates").isArray())
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingRoute[0].coordinates[0].x").value("127.043999"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingRoute[0].coordinates[0].y").value(37.510297))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingRoute[0].coordinates[2].x").value("127.021385"))
+                .andExpect(jsonPath("$.data.coordinate.routeResponse[1].drivingRoute[0].coordinates[2].y").value(37.511108))
+                .andExpect(jsonPath("$.data.coordinate.parkingLot.name").value("강남대로150길(구)"))
+                .andExpect(jsonPath("$.data.coordinate.parkingLot.longitude").value(127.0201132))
+                .andExpect(jsonPath("$.data.coordinate.parkingLot.latitude").value(37.5156578))
+                .andExpect(jsonPath("$.data.coordinate.parkingLot.distance").value(517.33672526))
                 .andDo(
                         MockMvcRestDocumentationWrapper.document("event/get-meeting-point-routes",
                                 preprocessRequest(prettyPrint()),
@@ -316,63 +316,107 @@ class EventControllerTest extends ControllerTestSupport {
                                                         fieldWithPath("data.placeImage").type(JsonFieldType.STRING).description("장소 이미지").optional(),
                                                         fieldWithPath("data.peopleCount").type(JsonFieldType.NUMBER).description("모임 참여자 수"),
 
-                                                        fieldWithPath("data.meetingPointRouteGroups").type(JsonFieldType.ARRAY).description("중간 지점별 경로 그룹 목록"),
+                                                        fieldWithPath("data.coordinate").type(JsonFieldType.OBJECT).description("좌표 기반 중간 지점 경로 그룹"),
+                                                        fieldWithPath("data.coordinate.subwayId").type(JsonFieldType.NUMBER).description("중간 지점의 지하철 ID"),
+                                                        fieldWithPath("data.coordinate.averageTime").type(JsonFieldType.NUMBER).description("모든 참여자 출발지로부터의 평균 소요 시간 (분)"),
+                                                        fieldWithPath("data.coordinate.meetingPoint").type(JsonFieldType.OBJECT).description("중간 지점 정보"),
+                                                        fieldWithPath("data.coordinate.meetingPoint.endStationName").type(JsonFieldType.STRING).description("중간 지점 이름의 지하철역"),
+                                                        fieldWithPath("data.coordinate.meetingPoint.endLongitude").type(JsonFieldType.NUMBER).description("중간 지점 경도"),
+                                                        fieldWithPath("data.coordinate.meetingPoint.endLatitude").type(JsonFieldType.NUMBER).description("중간 지점 위도"),
+                                                        fieldWithPath("data.coordinate.routeResponse").type(JsonFieldType.ARRAY).description("각 참여자의 출발지-중간 지점 경로 정보"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].isTransit").type(JsonFieldType.BOOLEAN).description("대중교통 경로 제공 여부 (false인 경우 자가용)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].isMe").type(JsonFieldType.BOOLEAN).description("경로 주인이 요청자 본인(guestId 또는 userId 일치)인지 여부"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].id").type(JsonFieldType.STRING).description("출발지 ID"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].userId").type(JsonFieldType.NUMBER).description("출발지 설정한 회원 ID (비회원인 경우 null)").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].guestId").type(JsonFieldType.STRING).description("출발지 설정한 비회원 ID (회원인 경우 null)").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].profileImage").type(JsonFieldType.STRING).description("프로필 이미지 URL").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].startName").type(JsonFieldType.STRING).description("출발지 이름"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].startLongitude").type(JsonFieldType.NUMBER).description("출발지 경도"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].startLatitude").type(JsonFieldType.NUMBER).description("출발지 위도"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].totalTime").type(JsonFieldType.NUMBER).description("총 소요 시간 (분)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute").type(JsonFieldType.ARRAY).description("대중교통 경로 상세 정보 (isTransit=true일 때만 제공)").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].trafficType").type(JsonFieldType.STRING).description("교통 수단 ('SUBWAY', 'BUS', 'WALKING)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].startExitNo").type(JsonFieldType.STRING).description("출발 정거장의 출구 번호").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].endExitNo").type(JsonFieldType.STRING).description("도착 정거장의 출구 번호").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].distance").type(JsonFieldType.NUMBER).description("이동 거리 (m)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].laneName").type(JsonFieldType.STRING).description("노선 이름"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].startBoardName").type(JsonFieldType.STRING).description("승차 정거장 이름"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].endBoardName").type(JsonFieldType.STRING).description("하차 정거장 이름"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].stationCount").type(JsonFieldType.NUMBER).description("이동 정거장 수"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].passStopList").type(JsonFieldType.OBJECT).description("경유 정류장/역 목록").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].passStopList.stations").type(JsonFieldType.ARRAY).description("경유 정류장/역 상세 목록").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].passStopList.stations[].index").type(JsonFieldType.NUMBER).description("인덱스"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].passStopList.stations[].stationName").type(JsonFieldType.STRING).description("역/정류장 이름"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].passStopList.stations[].x").type(JsonFieldType.STRING).description("경도"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].passStopList.stations[].y").type(JsonFieldType.STRING).description("위도"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].sectionTime").type(JsonFieldType.NUMBER).description("해당 구간 소요 시간 (분)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingInfo").type(JsonFieldType.OBJECT).description("자가용 경로 요약 정보 (isTransit=false일 때만 제공)").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingInfo.taxi").type(JsonFieldType.NUMBER).description("예상 택시 요금 (원)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingInfo.toll").type(JsonFieldType.NUMBER).description("예상 통행료 (원)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingInfo.duration").type(JsonFieldType.NUMBER).description("총 소요 시간 (초)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingInfo.distance").type(JsonFieldType.NUMBER).description("총 거리 (m)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingRoute").type(JsonFieldType.ARRAY).description("자가용 경로 상세 정보 (isTransit=false일 때만 제공)").optional(),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingRoute[].name").type(JsonFieldType.STRING).description("도로명"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingRoute[].coordinates").type(JsonFieldType.ARRAY).description("경로 좌표 목록"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingRoute[].coordinates[].x").type(JsonFieldType.STRING).description("경도"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].drivingRoute[].coordinates[].y").type(JsonFieldType.STRING).description("위도"),
+                                                        fieldWithPath("data.coordinate.parkingLot").type(JsonFieldType.OBJECT).description("중간 지점 근처 주차장 정보"),
+                                                        fieldWithPath("data.coordinate.parkingLot.name").type(JsonFieldType.STRING).description("주차장 이름"),
+                                                        fieldWithPath("data.coordinate.parkingLot.longitude").type(JsonFieldType.NUMBER).description("주차장 경도"),
+                                                        fieldWithPath("data.coordinate.parkingLot.latitude").type(JsonFieldType.NUMBER).description("주차장 위도"),
+                                                        fieldWithPath("data.coordinate.parkingLot.distance").type(JsonFieldType.NUMBER).description("중간 지점으로부터의 거리 (m)"),
 
-                                                        fieldWithPath("data.meetingPointRouteGroups[].subwayId").type(JsonFieldType.NUMBER).description("중간 지점의 지하철 ID"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].averageTime").type(JsonFieldType.NUMBER).description("모든 참여자 출발지로부터의 평균 소요 시간 (분)"),
-
-                                                        fieldWithPath("data.meetingPointRouteGroups[].meetingPoint").type(JsonFieldType.OBJECT).description("중간 지점 정보"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].meetingPoint.endStationName").type(JsonFieldType.STRING).description("중간 지점 이름의 지하철역"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].meetingPoint.endLongitude").type(JsonFieldType.NUMBER).description("중간 지점 경도"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].meetingPoint.endLatitude").type(JsonFieldType.NUMBER).description("중간 지점 위도"),
-
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse").type(JsonFieldType.ARRAY).description("각 참여자의 출발지-중간 지점 경로 정보"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].isTransit").type(JsonFieldType.BOOLEAN).description("대중교통 경로 제공 여부 (false인 경우 자가용)"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].isMe").type(JsonFieldType.BOOLEAN).description("경로 주인이 요청자 본인(guestId 또는 userId 일치)인지 여부"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].id").type(JsonFieldType.STRING).description("출발지 ID"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].userId").type(JsonFieldType.NUMBER).description("출발지 설정한 회원 ID (비회원인 경우 null)").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].guestId").type(JsonFieldType.STRING).description("출발지 설정한 비회원 ID (회원인 경우 null)").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].profileImage").type(JsonFieldType.STRING).description("프로필 이미지 URL").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].startName").type(JsonFieldType.STRING).description("출발지 이름"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].startLongitude").type(JsonFieldType.NUMBER).description("출발지 경도"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].startLatitude").type(JsonFieldType.NUMBER).description("출발지 위도"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].totalTime").type(JsonFieldType.NUMBER).description("총 소요 시간 (분)"),
-
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute").type(JsonFieldType.ARRAY).description("대중교통 경로 상세 정보 (isTransit=true일 때만 제공)").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].trafficType").type(JsonFieldType.STRING).description("교통 수단 ('SUBWAY', 'BUS', 'WALKING)"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].startExitNo").type(JsonFieldType.STRING).description("출발 정거장의 출구 번호").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].endExitNo").type(JsonFieldType.STRING).description("도착 정거장의 출구 번호").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].distance").type(JsonFieldType.NUMBER).description("이동 거리 (m)"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].laneName").type(JsonFieldType.STRING).description("노선 이름"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].startBoardName").type(JsonFieldType.STRING).description("승차 정거장 이름"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].endBoardName").type(JsonFieldType.STRING).description("하차 정거장 이름"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].stationCount").type(JsonFieldType.NUMBER).description("이동 정거장 수"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList").type(JsonFieldType.OBJECT).description("경유 정류장/역 목록").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations").type(JsonFieldType.ARRAY).description("경유 정류장/역 상세 목록").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations[].index").type(JsonFieldType.NUMBER).description("인덱스"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations[].stationName").type(JsonFieldType.STRING).description("역/정류장 이름"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations[].x").type(JsonFieldType.STRING).description("경도"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].passStopList.stations[].y").type(JsonFieldType.STRING).description("위도"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].transitRoute[].sectionTime").type(JsonFieldType.NUMBER).description("해당 구간 소요 시간 (분)"),
-
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo").type(JsonFieldType.OBJECT).description("자가용 경로 요약 정보 (isTransit=false일 때만 제공)").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo.taxi").type(JsonFieldType.NUMBER).description("예상 택시 요금 (원)"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo.toll").type(JsonFieldType.NUMBER).description("예상 통행료 (원)"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo.duration").type(JsonFieldType.NUMBER).description("총 소요 시간 (초)"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingInfo.distance").type(JsonFieldType.NUMBER).description("총 거리 (m)"),
-
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute").type(JsonFieldType.ARRAY).description("자가용 경로 상세 정보 (isTransit=false일 때만 제공)").optional(),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute[].name").type(JsonFieldType.STRING).description("도로명"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute[].coordinates").type(JsonFieldType.ARRAY).description("경로 좌표 목록"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute[].coordinates[].x").type(JsonFieldType.STRING).description("경도"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].routeResponse[].drivingRoute[].coordinates[].y").type(JsonFieldType.STRING).description("위도"),
-
-                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot").type(JsonFieldType.OBJECT).description("중간 지점 근처 주차장 정보"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot.name").type(JsonFieldType.STRING).description("주차장 이름"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot.longitude").type(JsonFieldType.NUMBER).description("주차장 경도"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot.latitude").type(JsonFieldType.NUMBER).description("주차장 위도"),
-                                                        fieldWithPath("data.meetingPointRouteGroups[].parkingLot.distance").type(JsonFieldType.NUMBER).description("중간 지점으로부터의 거리 (m)"),
+                                                        fieldWithPath("data.popularity").type(JsonFieldType.OBJECT).description("인기 장소 기반 중간 지점 경로 그룹"),
+                                                        fieldWithPath("data.popularity.subwayId").type(JsonFieldType.NUMBER).description("중간 지점의 지하철 ID"),
+                                                        fieldWithPath("data.popularity.averageTime").type(JsonFieldType.NUMBER).description("모든 참여자 출발지로부터의 평균 소요 시간 (분)"),
+                                                        fieldWithPath("data.popularity.meetingPoint").type(JsonFieldType.OBJECT).description("중간 지점 정보"),
+                                                        fieldWithPath("data.popularity.meetingPoint.endStationName").type(JsonFieldType.STRING).description("중간 지점 이름의 지하철역"),
+                                                        fieldWithPath("data.popularity.meetingPoint.endLongitude").type(JsonFieldType.NUMBER).description("중간 지점 경도"),
+                                                        fieldWithPath("data.popularity.meetingPoint.endLatitude").type(JsonFieldType.NUMBER).description("중간 지점 위도"),
+                                                        fieldWithPath("data.popularity.routeResponse").type(JsonFieldType.ARRAY).description("각 참여자의 출발지-중간 지점 경로 정보"),
+                                                        fieldWithPath("data.popularity.routeResponse[].isTransit").type(JsonFieldType.BOOLEAN).description("대중교통 경로 제공 여부 (false인 경우 자가용)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].isMe").type(JsonFieldType.BOOLEAN).description("경로 주인이 요청자 본인(guestId 또는 userId 일치)인지 여부"),
+                                                        fieldWithPath("data.popularity.routeResponse[].id").type(JsonFieldType.STRING).description("출발지 ID"),
+                                                        fieldWithPath("data.popularity.routeResponse[].userId").type(JsonFieldType.NUMBER).description("출발지 설정한 회원 ID (비회원인 경우 null)").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].guestId").type(JsonFieldType.STRING).description("출발지 설정한 비회원 ID (회원인 경우 null)").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
+                                                        fieldWithPath("data.popularity.routeResponse[].profileImage").type(JsonFieldType.STRING).description("프로필 이미지 URL").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].startName").type(JsonFieldType.STRING).description("출발지 이름"),
+                                                        fieldWithPath("data.popularity.routeResponse[].startLongitude").type(JsonFieldType.NUMBER).description("출발지 경도"),
+                                                        fieldWithPath("data.popularity.routeResponse[].startLatitude").type(JsonFieldType.NUMBER).description("출발지 위도"),
+                                                        fieldWithPath("data.popularity.routeResponse[].totalTime").type(JsonFieldType.NUMBER).description("총 소요 시간 (분)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute").type(JsonFieldType.ARRAY).description("대중교통 경로 상세 정보 (isTransit=true일 때만 제공)").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].trafficType").type(JsonFieldType.STRING).description("교통 수단 ('SUBWAY', 'BUS', 'WALKING)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].startExitNo").type(JsonFieldType.STRING).description("출발 정거장의 출구 번호").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].endExitNo").type(JsonFieldType.STRING).description("도착 정거장의 출구 번호").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].distance").type(JsonFieldType.NUMBER).description("이동 거리 (m)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].laneName").type(JsonFieldType.STRING).description("노선 이름"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].startBoardName").type(JsonFieldType.STRING).description("승차 정거장 이름"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].endBoardName").type(JsonFieldType.STRING).description("하차 정거장 이름"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].stationCount").type(JsonFieldType.NUMBER).description("이동 정거장 수"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].passStopList").type(JsonFieldType.OBJECT).description("경유 정류장/역 목록").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].passStopList.stations").type(JsonFieldType.ARRAY).description("경유 정류장/역 상세 목록").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].passStopList.stations[].index").type(JsonFieldType.NUMBER).description("인덱스"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].passStopList.stations[].stationName").type(JsonFieldType.STRING).description("역/정류장 이름"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].passStopList.stations[].x").type(JsonFieldType.STRING).description("경도"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].passStopList.stations[].y").type(JsonFieldType.STRING).description("위도"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].sectionTime").type(JsonFieldType.NUMBER).description("해당 구간 소요 시간 (분)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingInfo").type(JsonFieldType.OBJECT).description("자가용 경로 요약 정보 (isTransit=false일 때만 제공)").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingInfo.taxi").type(JsonFieldType.NUMBER).description("예상 택시 요금 (원)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingInfo.toll").type(JsonFieldType.NUMBER).description("예상 통행료 (원)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingInfo.duration").type(JsonFieldType.NUMBER).description("총 소요 시간 (초)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingInfo.distance").type(JsonFieldType.NUMBER).description("총 거리 (m)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingRoute").type(JsonFieldType.ARRAY).description("자가용 경로 상세 정보 (isTransit=false일 때만 제공)").optional(),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingRoute[].name").type(JsonFieldType.STRING).description("도로명"),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingRoute[].coordinates").type(JsonFieldType.ARRAY).description("경로 좌표 목록"),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingRoute[].coordinates[].x").type(JsonFieldType.STRING).description("경도"),
+                                                        fieldWithPath("data.popularity.routeResponse[].drivingRoute[].coordinates[].y").type(JsonFieldType.STRING).description("위도"),
+                                                        fieldWithPath("data.popularity.parkingLot").type(JsonFieldType.OBJECT).description("중간 지점 근처 주차장 정보"),
+                                                        fieldWithPath("data.popularity.parkingLot.name").type(JsonFieldType.STRING).description("주차장 이름"),
+                                                        fieldWithPath("data.popularity.parkingLot.longitude").type(JsonFieldType.NUMBER).description("주차장 경도"),
+                                                        fieldWithPath("data.popularity.parkingLot.latitude").type(JsonFieldType.NUMBER).description("주차장 위도"),
+                                                        fieldWithPath("data.popularity.parkingLot.distance").type(JsonFieldType.NUMBER).description("중간 지점으로부터의 거리 (m)"),
 
                                                         fieldWithPath("error").type(JsonFieldType.OBJECT).description("API 호출 에러").optional(),
                                                         fieldWithPath("error.code").type(JsonFieldType.STRING).description("에러 코드").optional(),

--- a/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
+++ b/src/test/java/com/meetup/server/event/presentation/EventControllerTest.java
@@ -287,6 +287,8 @@ class EventControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data.coordinate.parkingLot.longitude").value(127.0201132))
                 .andExpect(jsonPath("$.data.coordinate.parkingLot.latitude").value(37.5156578))
                 .andExpect(jsonPath("$.data.coordinate.parkingLot.distance").value(517.33672526))
+                .andExpect(jsonPath("$.data.popularity.subwayId").value(300))
+                .andExpect(jsonPath("$.data.popularity.meetingPoint.endStationName").value("홍대입구"))
                 .andDo(
                         MockMvcRestDocumentationWrapper.document("event/get-meeting-point-routes",
                                 preprocessRequest(prettyPrint()),
@@ -336,7 +338,7 @@ class EventControllerTest extends ControllerTestSupport {
                                                         fieldWithPath("data.coordinate.routeResponse[].startLatitude").type(JsonFieldType.NUMBER).description("출발지 위도"),
                                                         fieldWithPath("data.coordinate.routeResponse[].totalTime").type(JsonFieldType.NUMBER).description("총 소요 시간 (분)"),
                                                         fieldWithPath("data.coordinate.routeResponse[].transitRoute").type(JsonFieldType.ARRAY).description("대중교통 경로 상세 정보 (isTransit=true일 때만 제공)").optional(),
-                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].trafficType").type(JsonFieldType.STRING).description("교통 수단 ('SUBWAY', 'BUS', 'WALKING)"),
+                                                        fieldWithPath("data.coordinate.routeResponse[].transitRoute[].trafficType").type(JsonFieldType.STRING).description("교통 수단 ('SUBWAY', 'BUS', 'WALKING')"),
                                                         fieldWithPath("data.coordinate.routeResponse[].transitRoute[].startExitNo").type(JsonFieldType.STRING).description("출발 정거장의 출구 번호").optional(),
                                                         fieldWithPath("data.coordinate.routeResponse[].transitRoute[].endExitNo").type(JsonFieldType.STRING).description("도착 정거장의 출구 번호").optional(),
                                                         fieldWithPath("data.coordinate.routeResponse[].transitRoute[].distance").type(JsonFieldType.NUMBER).description("이동 거리 (m)"),
@@ -387,7 +389,7 @@ class EventControllerTest extends ControllerTestSupport {
                                                         fieldWithPath("data.popularity.routeResponse[].startLatitude").type(JsonFieldType.NUMBER).description("출발지 위도"),
                                                         fieldWithPath("data.popularity.routeResponse[].totalTime").type(JsonFieldType.NUMBER).description("총 소요 시간 (분)"),
                                                         fieldWithPath("data.popularity.routeResponse[].transitRoute").type(JsonFieldType.ARRAY).description("대중교통 경로 상세 정보 (isTransit=true일 때만 제공)").optional(),
-                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].trafficType").type(JsonFieldType.STRING).description("교통 수단 ('SUBWAY', 'BUS', 'WALKING)"),
+                                                        fieldWithPath("data.popularity.routeResponse[].transitRoute[].trafficType").type(JsonFieldType.STRING).description("교통 수단 ('SUBWAY', 'BUS', 'WALKING')"),
                                                         fieldWithPath("data.popularity.routeResponse[].transitRoute[].startExitNo").type(JsonFieldType.STRING).description("출발 정거장의 출구 번호").optional(),
                                                         fieldWithPath("data.popularity.routeResponse[].transitRoute[].endExitNo").type(JsonFieldType.STRING).description("도착 정거장의 출구 번호").optional(),
                                                         fieldWithPath("data.popularity.routeResponse[].transitRoute[].distance").type(JsonFieldType.NUMBER).description("이동 거리 (m)"),

--- a/src/test/java/com/meetup/server/fixture/EventFixture.java
+++ b/src/test/java/com/meetup/server/fixture/EventFixture.java
@@ -67,8 +67,30 @@ public class EventFixture {
 
     public static MeetingPointRouteGroups getMeetingPointRouteGroups() {
         MeetingPointRouteGroup coordinateGroup = getMeetingPointRouteGroup();
-        MeetingPointRouteGroup popularityGroup = getMeetingPointRouteGroup();
+        MeetingPointRouteGroup popularityGroup = getPopularityMeetingPointRouteGroup();
         return new MeetingPointRouteGroups(coordinateGroup, popularityGroup);
+    }
+
+    public static MeetingPointRouteGroup getPopularityMeetingPointRouteGroup() {
+        List<TransitRouteResponse> transitRoutes = List.of(RouteFixture.getTransitRoute());
+        DrivingInfoResponse drivingInfo = RouteFixture.getDrivingInfo();
+        List<DrivingRouteResponse> drivingRoutes = List.of(RouteFixture.getDrivingRoute());
+
+        List<RouteResponse> routeResponses = List.of(
+                new RouteResponse(true, false, UUID.fromString("0198c64a-5a06-7095-a692-3c5e1a2c294f"),
+                        null, UUID.fromString("0198c64a-5a06-7095-a693-c3f8ebde622c"), "김아무개",
+                        null, "강남구 삼성동", 127.043999, 37.510297, transitRoutes, null, null, 15),
+                new RouteResponse(false, false, UUID.fromString("0198c64b-086a-796d-a4d3-105c89ee529e"),
+                        null, UUID.fromString("0198c64b-086a-796d-a4d4-8d44881d2ad7"), "안연아바보",
+                        null, "강남구 삼성동", 127.043999, 37.510297, null, drivingInfo, drivingRoutes, 0)
+        );
+
+        return new MeetingPointRouteGroup(
+                300, 0,
+                new MeetingPoint("홍대입구", 126.923915, 37.557140),
+                routeResponses,
+                new ParkingLotResponse("홍대주차장", 126.922000, 37.556000, 300.0)
+        );
     }
 
     public static MeetingPointRouteGroup getMeetingPointRouteGroup() {

--- a/src/test/java/com/meetup/server/fixture/EventFixture.java
+++ b/src/test/java/com/meetup/server/fixture/EventFixture.java
@@ -66,6 +66,12 @@ public class EventFixture {
     }
 
     public static MeetingPointRouteGroups getMeetingPointRouteGroups() {
+        MeetingPointRouteGroup coordinateGroup = getMeetingPointRouteGroup();
+        MeetingPointRouteGroup popularityGroup = getMeetingPointRouteGroup();
+        return new MeetingPointRouteGroups(coordinateGroup, popularityGroup);
+    }
+
+    public static MeetingPointRouteGroup getMeetingPointRouteGroup() {
         List<TransitRouteResponse> transitRoutes = List.of(RouteFixture.getTransitRoute());
         DrivingInfoResponse drivingInfo = RouteFixture.getDrivingInfo();
         List<DrivingRouteResponse> drivingRoutes = List.of(RouteFixture.getDrivingRoute());
@@ -82,27 +88,11 @@ public class EventFixture {
                         null, "동작구 상도동", 126.95781764313084, 37.4963172817574, null, drivingInfo, drivingRoutes, 0)
         );
 
-        List<MeetingPointRouteGroup> groups = List.of(
-                new MeetingPointRouteGroup(
-                        240, 0,
-                        new MeetingPoint("논현", 127.021385, 37.511108),
-                        routeResponses,
-                        new ParkingLotResponse("강남대로150길(구)", 127.0201132, 37.5156578, 517.33672526)
-                ),
-                new MeetingPointRouteGroup(
-                        80, 0,
-                        new MeetingPoint("신사", 127.020247, 37.516438),
-                        routeResponses,
-                        new ParkingLotResponse("강남대로150길(구)", 127.020586, 37.515837, 73.1268062)
-                ),
-                new MeetingPointRouteGroup(
-                        32, 0,
-                        new MeetingPoint("교대", 127.014631, 37.493957),
-                        routeResponses,
-                        new ParkingLotResponse("파미에(반포천) 주차장(시)", 127.007933, 37.504517, 1313.17667989)
-                )
+        return new MeetingPointRouteGroup(
+                240, 0,
+                new MeetingPoint("논현", 127.021385, 37.511108),
+                routeResponses,
+                new ParkingLotResponse("강남대로150길(구)", 127.0201132, 37.5156578, 517.33672526)
         );
-
-        return new MeetingPointRouteGroups(groups);
     }
 }


### PR DESCRIPTION
## 🚀 Why - 해결하려는 문제가 무엇인가요?

- 단순 좌표 기반뿐만 아니라 인기 장소(핫플) 기반의 중간 지점을 함께 제공
- 경로 조회를 못한 참여자가 평균 소요 시간 계산에 포함되어 데이터가 왜곡되는 문제를 해결

## ✅ What - 무엇이 변경됐나요?

- 좌표 기반(coordinate) 및 인기 장소 기반(popularity) 중간 지점을 모두 반환하도록 DTO 및 서비스 로직 수정
- 경로 조회 불가 시 평균 시간 계산에서 제외하는 방어 로직 추가
- 프론트엔드 URL 경로 수정 (mapview -> mapView)
- 자료구조 사용헌 변수명 제거

## 🛠️ How - 어떻게 해결했나요?

- MeetingPointRoutesResponse에서 좌표 기반과 인기 장소 기반의 경로를 나눠 제공
- 참여자 중 일부의 경로 파싱이 실패하더라도 전체 조회가 실패하지 않도록 하고, 유효한 데이터로만 평균 이동 시간을 산출하도록 개선

## 🖼️ Attachment

## 💬 기타 코멘트



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 좌표 기반과 인기도 기반의 별도 만남 장소 추천 결과 제공
  * 서울 지하철 승객 통계 기반 인기도 점수화 및 랭킹 도입
  * 서울 지하철 공공API 연동 및 일별 승객 통계 수집 배치 작업 추가

* **개선 사항**
  * 경로 그룹화·우선순위 처리 및 평균 소요시간 계산 방식 개선
  * 거리 계산 및 날짜 포맷 유틸 추가로 정밀도 향상
  * 관리자 이벤트 링크 경로 일부 수정 (URL 대소문자 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->